### PR TITLE
Remove font-family-sans

### DIFF
--- a/toolkits/nature/packages/nature-context/HISTORY.md
+++ b/toolkits/nature/packages/nature-context/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 0.18.0 (2019-11-05)
+	* Remove $font-family-sans as we can now take this value from global
+	* Update to global-context@7.0.0
+
 ## 0.17.0 (2019-11-04)
 	* Add favicon images and example HTML
 

--- a/toolkits/nature/packages/nature-context/package.json
+++ b/toolkits/nature/packages/nature-context/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@springernature/nature-context",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "license": "MIT",
   "description": "Boostrapping for all Nature components and products",
   "keywords": [],
   "author": "Springer Nature",
-  "extendsPackage": "global-context@5.1.0"
+  "extendsPackage": "global-context@7.0.0"
 }

--- a/toolkits/nature/packages/nature-context/scss/10-settings/typography-nature.scss
+++ b/toolkits/nature/packages/nature-context/scss/10-settings/typography-nature.scss
@@ -6,13 +6,6 @@
 $is-flagship-journal: false !default;
 $primary-font: if($is-flagship-journal, Harding, Lora);
 $font-family-serif: $primary-font, Palatino, Times, 'Times New Roman', serif;
-@if ($is-flagship-journal) {
-	$font-family-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-}
-@else {
-	$font-family-sans: "Source Sans Pro", helvetica, arial, sans-serif;
-}
-
 
 // Define your base size in EMs
 // http://stackoverflow.com/questions/20099844/chrome-not-respecting-rem-font-size-on-body-tag


### PR DESCRIPTION
Removing variable `font-family-sans` from nature-context as we will now get it from `global-context/scss/10-settings/typography.scss`