### PR TITLE
nature-context v0.18.1

### DIFF
--- a/toolkits/nature/packages/nature-context/HISTORY.md
+++ b/toolkits/nature/packages/nature-context/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 0.18.1 (2019-11-05)
+	* Fix bug where package didn't extend on publication
+
 ## 0.18.0 (2019-11-05)
 	* Remove $font-family-sans as we can now take this value from global
 	* Update to global-context@7.0.0

--- a/toolkits/nature/packages/nature-context/package.json
+++ b/toolkits/nature/packages/nature-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/nature-context",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "license": "MIT",
   "description": "Boostrapping for all Nature components and products",
   "keywords": [],


### PR DESCRIPTION
Last published version did not extend properly and only published the nature files _without_ the global files. Hopefully, by re-pushing this with a bug fix it should publish correctly.