### PR TITLE
Bumps peer dependency springer-context to 12.2.2 on outdated packages

### DIFF
--- a/toolkits/springer/packages/springer-author-list/HISTORY.md
+++ b/toolkits/springer/packages/springer-author-list/HISTORY.md
@@ -1,2 +1,5 @@
+## 1.0.0 (2019-11-13)
+    * Bumps peer dependency springer-context to 12.2.2
+
 ## 0.1.0 (2019-11-04)
     * Adds author list component

--- a/toolkits/springer/packages/springer-author-list/HISTORY.md
+++ b/toolkits/springer/packages/springer-author-list/HISTORY.md
@@ -1,4 +1,4 @@
-## 1.0.0 (2019-11-13)
+## 0.2.0 (2019-11-13)
     * Bumps peer dependency springer-context to 12.2.2
 
 ## 0.1.0 (2019-11-04)

--- a/toolkits/springer/packages/springer-author-list/package.json
+++ b/toolkits/springer/packages/springer-author-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-author-list",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "license": "MIT",
   "description": "Springer branded extension of the global author-list",
   "keywords": [
@@ -9,6 +9,6 @@
   "author": "Springer Nature",
   "extendsPackage": "global-author-list@1.0.0",
   "peerDependencies": {
-    "@springernature/springer-context": "11.0.0"
+    "@springernature/springer-context": "12.2.2"
   }
 }

--- a/toolkits/springer/packages/springer-author-list/package.json
+++ b/toolkits/springer/packages/springer-author-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-author-list",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "license": "MIT",
   "description": "Springer branded extension of the global author-list",
   "keywords": [

--- a/toolkits/springer/packages/springer-box/HISTORY.md
+++ b/toolkits/springer/packages/springer-box/HISTORY.md
@@ -1,11 +1,11 @@
+## 3.0.0 (2019-11-13)
+    * Bumps peer dependency springer-context to 12.2.2
+    
 ## 2.0.0 (2019-09-12)
-
     * Rename package `springer-card` -> `springer-box`
 
 ## 1.0.0 (2019-09-05)
-
     * Design update
 
 ## 0.1.0 (2019-07-4)
-
     * Adds card component along with  README

--- a/toolkits/springer/packages/springer-box/HISTORY.md
+++ b/toolkits/springer/packages/springer-box/HISTORY.md
@@ -1,4 +1,4 @@
-## 3.0.0 (2019-11-13)
+## 2.1.0 (2019-11-13)
     * Bumps peer dependency springer-context to 12.2.2
     
 ## 2.0.0 (2019-09-12)

--- a/toolkits/springer/packages/springer-box/package.json
+++ b/toolkits/springer/packages/springer-box/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-box",
-  "version": "3.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "description": "Springer box component",
   "keywords": [],

--- a/toolkits/springer/packages/springer-box/package.json
+++ b/toolkits/springer/packages/springer-box/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@springernature/springer-box",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "license": "MIT",
   "description": "Springer box component",
   "keywords": [],
   "author": "Springer Nature",
   "peerDependencies": {
-    "@springernature/springer-context": "3.0.3"
+    "@springernature/springer-context": "12.2.2"
   }
 }

--- a/toolkits/springer/packages/springer-lists/HISTORY.md
+++ b/toolkits/springer/packages/springer-lists/HISTORY.md
@@ -1,3 +1,6 @@
+## 4.0.0 (2019-11-13)
+    * Bumps peer dependency springer-context to 12.2.2
+
 ## 3.0.0 (2019-10-07)
 	* Breaking: Adds bottom margin to terms and paragraphs within the component
 

--- a/toolkits/springer/packages/springer-lists/HISTORY.md
+++ b/toolkits/springer/packages/springer-lists/HISTORY.md
@@ -1,4 +1,4 @@
-## 4.0.0 (2019-11-13)
+## 3.1.0 (2019-11-13)
     * Bumps peer dependency springer-context to 12.2.2
 
 ## 3.0.0 (2019-10-07)

--- a/toolkits/springer/packages/springer-lists/package.json
+++ b/toolkits/springer/packages/springer-lists/package.json
@@ -1,11 +1,11 @@
 {
-    "name": "@springernature/springer-lists",
-    "version": "3.0.0",
-    "license": "MIT",
-    "description": "Springer lists components",
-    "keywords": [],
-    "author": "Springer Nature",
-    "peerDependencies": {
-      "@springernature/springer-context": "5.0.0"
-    }
+  "name": "@springernature/springer-lists",
+  "version": "4.0.0",
+  "license": "MIT",
+  "description": "Springer lists components",
+  "keywords": [],
+  "author": "Springer Nature",
+  "peerDependencies": {
+    "@springernature/springer-context": "12.2.2"
   }
+}

--- a/toolkits/springer/packages/springer-lists/package.json
+++ b/toolkits/springer/packages/springer-lists/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-lists",
-  "version": "4.0.0",
+  "version": "3.1.0",
   "license": "MIT",
   "description": "Springer lists components",
   "keywords": [],


### PR DESCRIPTION
- updated in springer-author-list, springer-box, springer-lists
- updated major version of each package
- some formatting change to be consistent