### PR TITLE
Bumps global-context extends version to 9.2.0 in springer-context

### DIFF
--- a/toolkits/springer/packages/springer-author-list/HISTORY.md
+++ b/toolkits/springer/packages/springer-author-list/HISTORY.md
@@ -1,3 +1,8 @@
+# History
+
+## 0.3.0 (2019-11-20)
+    * Bumps peer dependency springer-context to 12.3.0
+    
 ## 0.2.0 (2019-11-13)
     * Bumps peer dependency springer-context to 12.2.2
 

--- a/toolkits/springer/packages/springer-author-list/package.json
+++ b/toolkits/springer/packages/springer-author-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-author-list",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "description": "Springer branded extension of the global author-list",
   "keywords": [
@@ -9,6 +9,6 @@
   "author": "Springer Nature",
   "extendsPackage": "global-author-list@1.0.0",
   "peerDependencies": {
-    "@springernature/springer-context": "12.2.2"
+    "@springernature/springer-context": "12.3.0"
   }
 }

--- a/toolkits/springer/packages/springer-box/HISTORY.md
+++ b/toolkits/springer/packages/springer-box/HISTORY.md
@@ -1,3 +1,8 @@
+# History
+
+## 2.2.0 (2019-11-20)
+    * Bumps peer dependency springer-context to 12.3.0
+    
 ## 2.1.0 (2019-11-13)
     * Bumps peer dependency springer-context to 12.2.2
     

--- a/toolkits/springer/packages/springer-box/package.json
+++ b/toolkits/springer/packages/springer-box/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@springernature/springer-box",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": "MIT",
   "description": "Springer box component",
   "keywords": [],
   "author": "Springer Nature",
   "peerDependencies": {
-    "@springernature/springer-context": "12.2.2"
+    "@springernature/springer-context": "12.3.0"
   }
 }

--- a/toolkits/springer/packages/springer-context/HISTORY.md
+++ b/toolkits/springer/packages/springer-context/HISTORY.md
@@ -1,3 +1,8 @@
+# History
+
+## 12.3.0 (2019-11-20)
+    * Bumps global-context extends version to 9.2.0
+
 ## 12.2.2 (2019-11-12)
     * Bumps global-context extends version to 9.1.2
     * Bumps version of springer-context package

--- a/toolkits/springer/packages/springer-context/package.json
+++ b/toolkits/springer/packages/springer-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-context",
-  "version": "12.2.2",
+  "version": "12.3.0",
   "license": "MIT",
   "description": "Bootstrapping for all Springer components and products",
   "keywords": [
@@ -12,7 +12,7 @@
     "js"
   ],
   "author": "Springer Nature",
-  "extendsPackage": "global-context@9.1.2",
+  "extendsPackage": "global-context@9.2.0",
   "peerDependencies": {
     "rfs": "^8.0.4"
   }

--- a/toolkits/springer/packages/springer-lists/HISTORY.md
+++ b/toolkits/springer/packages/springer-lists/HISTORY.md
@@ -1,3 +1,8 @@
+# History
+
+## 3.2.0 (2019-11-20)
+    * Bumps peer dependency springer-context to 12.3.0
+    
 ## 3.1.0 (2019-11-13)
     * Bumps peer dependency springer-context to 12.2.2
 

--- a/toolkits/springer/packages/springer-lists/package.json
+++ b/toolkits/springer/packages/springer-lists/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@springernature/springer-lists",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "license": "MIT",
   "description": "Springer lists components",
   "keywords": [],
   "author": "Springer Nature",
   "peerDependencies": {
-    "@springernature/springer-context": "12.2.2"
+    "@springernature/springer-context": "12.3.0"
   }
 }


### PR DESCRIPTION
also bumps peer dependency springer-context to 12.3.0 in several packages