### PR TITLE
bump springer-card to 2.0.0

### DIFF
--- a/toolkits/springer/packages/springer-card/HISTORY.md
+++ b/toolkits/springer/packages/springer-card/HISTORY.md
@@ -1,4 +1,7 @@
 # History
+
+## 2.0.0 (2019-11-27)
+    * `springer-card` already existed in repo but appears unused. Bumping to next major version from version 1.0.0 to take over.  
     
 ## 0.1.0 (2019-11-26)
     * Settings for card on Springer brand

--- a/toolkits/springer/packages/springer-card/package.json
+++ b/toolkits/springer/packages/springer-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-card",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "license": "MIT",
   "description": "",
   "keywords": [],


### PR DESCRIPTION
`springer-card` already existed in repo but appears unused. Bumping to next major version from version 1.0.0 to take over.