### PR TITLE
global-article: revert linting changes that break IE10

### DIFF
--- a/toolkits/global/packages/global-article/HISTORY.md
+++ b/toolkits/global/packages/global-article/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 9.0.1 (2020-01-06)
+	* BUG: Javascript errors in IE10 after linting fixes
+		* Revert use of `append`, `includes`, `remove`
+
 ## 9.0.0 (2020-01-06)
 	* Refactor for new linting rules
 

--- a/toolkits/global/packages/global-article/js/authors.js
+++ b/toolkits/global/packages/global-article/js/authors.js
@@ -33,7 +33,8 @@ window.Component.AuthorList = (function ($) {
 			var numberAuthors = $children.length;
 
 			var exceedsLimit = function (limit) {
-				return numberAuthors > limit && !(numberAuthors === limit + 1 && $children.get(limit).className.includes('author-group'));
+				// eslint-disable-next-line unicorn/prefer-includes
+				return numberAuthors > limit && !(numberAuthors === limit + 1 && $children.get(limit).className.indexOf('author-group') !== -1);
 			};
 
 			var articleTitle = function () {
@@ -112,7 +113,8 @@ window.Component.AuthorList = (function ($) {
 						affiliations.push(affiliationAddress.textContent);
 					}
 
-					if (presentID !== null && presentID.includes('n')) {
+					// eslint-disable-next-line unicorn/prefer-includes
+					if (presentID !== null && presentID.indexOf('n') > -1) {
 						var presentAddress = authorInfo.querySelector('.js-present-address');
 						// eslint-disable-next-line no-negated-condition
 						if (presentAddress !== null) {

--- a/toolkits/global/packages/global-article/js/disqus.js
+++ b/toolkits/global/packages/global-article/js/disqus.js
@@ -41,7 +41,8 @@ function LoadDisqus() {
 
 		dsq.src = '//' + window.disqus_shortname + '.disqus.com/embed.js';
 
-		(document.querySelectorAll('head')[0] || document.querySelectorAll('body')[0]).append(dsq);
+		// eslint-disable-next-line unicorn/prefer-node-append
+		(document.querySelectorAll('head')[0] || document.querySelectorAll('body')[0]).appendChild(dsq);
 		disqusLoaded = true;
 	};
 

--- a/toolkits/global/packages/global-article/js/popup.js
+++ b/toolkits/global/packages/global-article/js/popup.js
@@ -62,7 +62,8 @@ window.Component.Popup = (function (win, document_) {
 				this.content.classList.add(HIDE_PRINT_CLASS);
 			}
 
-			document_.body.append(this.content);
+			// eslint-disable-next-line unicorn/prefer-node-append
+			document_.body.appendChild(this.content);
 		},
 		bindEvents: function () {
 			var self = this;

--- a/toolkits/global/packages/global-article/js/reading-companion.js
+++ b/toolkits/global/packages/global-article/js/reading-companion.js
@@ -86,8 +86,8 @@ window.Component.ReadingCompanion = (function (win, document_) {
 		placeholderFor: function (node) {
 			var source = node.getAttribute('data-supp-info-image') || node.src;
 			var alt = node.alt || '';
-			// eslint-disable-next-line no-negated-condition
-			var separator = !source.includes('?') ? '?' : '&';
+			// eslint-disable-next-line unicorn/prefer-includes
+			var separator = source.indexOf('?') === -1 ? '?' : '&';
 			return [
 				'<picture>',
 				'<source type="image/webp" ' + DATA_SRCSET_ATTR + '="' + source + separator + 'as=webp">',
@@ -249,16 +249,20 @@ window.Component.ReadingCompanion = (function (win, document_) {
 	function insertReturnButton(reference, source) {
 		var button = reference.querySelector('.' + READING_COMPANION_CLASS + '__return');
 		if (button) {
-			button.remove();
+			// eslint-disable-next-line unicorn/prefer-node-remove
+			button.parentNode.removeChild(button);
 		}
 		button = document_.createElement('a');
 		button.href = '#' + source.id;
-		button.append(document_.createTextNode('Return to ref ' + source.textContent + ' in article'));
+		// eslint-disable-next-line unicorn/prefer-node-append
+		button.appendChild(document_.createTextNode('Return to ref ' + source.textContent + ' in article'));
 		button.className = READING_COMPANION_CLASS + '__return';
 		button.addEventListener('click', function () {
-			button.remove();
+			// eslint-disable-next-line unicorn/prefer-node-remove
+			button.parentNode.removeChild(button);
 		});
-		reference.append(button);
+		// eslint-disable-next-line unicorn/prefer-node-append
+		reference.appendChild(button);
 	}
 
 	function scrollIntoView(element, parent) {
@@ -444,7 +448,8 @@ window.Component.ReadingCompanion = (function (win, document_) {
 				container.setAttribute('aria-labelledby', 'tab-' + name);
 				insert(container, '<div class="' + READING_COMPANION_CLASS + '__scroll-pane">' + html + '</div>');
 			} else if (container) {
-				container.remove();
+				// eslint-disable-next-line unicorn/prefer-node-remove
+				container.parentNode.removeChild(container);
 			}
 
 			return (html && container) ? tab : false;

--- a/toolkits/global/packages/global-article/package.json
+++ b/toolkits/global/packages/global-article/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-article",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Frontend package for article display",
   "license": "MIT",
   "peerDependencies": {


### PR DESCRIPTION
Some changes made to `global-article` based on new linting rules broke the JS in IE10.
This PR reverts the use of `append`, `includes`, and `remove` and instead disables the linting rules for those lines.