### PR TITLE
Fix open access color

### DIFF
--- a/toolkits/global/packages/global-context/HISTORY.md
+++ b/toolkits/global/packages/global-context/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 10.0.0 (2020-01-16)
+    * Renamed u-open-access-color to u-color-open-access
+    
 ## 9.2.1 (2019-11-21)
     * Use for-of instead of for loop in makeArray 
 

--- a/toolkits/global/packages/global-context/package.json
+++ b/toolkits/global/packages/global-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-context",
-  "version": "9.2.1",
+  "version": "10.0.0",
   "license": "MIT",
   "description": "Template for providing bootstrapping for all components and products",
   "keywords": [],

--- a/toolkits/global/packages/global-context/scss/60-utilities/colors.scss
+++ b/toolkits/global/packages/global-context/scss/60-utilities/colors.scss
@@ -1,3 +1,3 @@
-.u-open-access-color {
+.u-color-open-access {
 	color: $open-access-color;
 }

--- a/toolkits/springer/packages/springer-context/HISTORY.md
+++ b/toolkits/springer/packages/springer-context/HISTORY.md
@@ -2,7 +2,7 @@
 
 ## 13.0.0 (2020-01-16)
     * Removed springer-floats
-    * Removed colors from springer-context utilities
+    * Rename color to springer-color to avoid clashing with global version 
     * Bumps global-context extends version to 10.0.0
 
 ## 12.5.0 (2020-01-14)

--- a/toolkits/springer/packages/springer-context/HISTORY.md
+++ b/toolkits/springer/packages/springer-context/HISTORY.md
@@ -1,5 +1,10 @@
 # History
 
+## 13.0.0 (2020-01-16)
+    * Removed springer-floats
+    * Removed colors from springer-context utilities
+    * Bumps global-context extends version to 10.0.0
+
 ## 12.5.0 (2020-01-14)
     * Added favicons
 

--- a/toolkits/springer/packages/springer-context/package.json
+++ b/toolkits/springer/packages/springer-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-context",
-  "version": "12.5.0",
+  "version": "13.0.0",
   "license": "MIT",
   "description": "Bootstrapping for all Springer components and products",
   "keywords": [
@@ -12,7 +12,7 @@
     "js"
   ],
   "author": "Springer Nature",
-  "extendsPackage": "global-context@9.2.0",
+  "extendsPackage": "global-context@10.0.0",
   "peerDependencies": {
     "rfs": "^8.0.4"
   }

--- a/toolkits/springer/packages/springer-context/package.json
+++ b/toolkits/springer/packages/springer-context/package.json
@@ -12,7 +12,7 @@
     "js"
   ],
   "author": "Springer Nature",
-  "extendsPackage": "global-context@10.0.0",
+  "extendsPackage": "global-context@9.2.1",
   "peerDependencies": {
     "rfs": "^8.0.4"
   }

--- a/toolkits/springer/packages/springer-context/scss/60-utilities/colors.scss
+++ b/toolkits/springer/packages/springer-context/scss/60-utilities/colors.scss
@@ -1,3 +1,0 @@
-.u-color-success {
-	color: color('success');
-}

--- a/toolkits/springer/packages/springer-context/scss/60-utilities/springer-colors.scss
+++ b/toolkits/springer/packages/springer-context/scss/60-utilities/springer-colors.scss
@@ -1,0 +1,3 @@
+.u-color-success {
+	color: color('success');
+}

--- a/toolkits/springer/packages/springer-context/scss/60-utilities/springer-float.scss
+++ b/toolkits/springer/packages/springer-context/scss/60-utilities/springer-float.scss
@@ -1,7 +1,0 @@
-@include class-stack('u-float-right') {
-	float: right;
-}
-
-@include class-stack('u-float-left') {
-	float: left;
-}


### PR DESCRIPTION
`color.scss` in global-context got overriden because `color.scss` was added for springer-context. Renamed to springer-color to avoid clashing with global version.

Make color utility class name consistent and removed springer-floats (unused in sites-springer).
