### PR TITLE
Adds springer-nature-modal

### DIFF
--- a/toolkits/nature/packages/nature-article/README.md
+++ b/toolkits/nature/packages/nature-article/README.md
@@ -1,0 +1,9 @@
+# Nature Article
+
+Set the context for Nature branded articles rendered via the shared article renderer.
+
+- [Global Article](#global-article)
+
+## Global Article
+
+The Nature article package inherits from the [global-article package](https://github.com/springernature/frontend-toolkits/tree/master/toolkits/global/packages/global-article), anything that then needs to be either overridden from global or added specifically for nature can be added within this package. This README will detail anything that is added for this specific brand.

--- a/toolkits/springernature/packages/springer-nature-modal/HISTORY.md
+++ b/toolkits/springernature/packages/springer-nature-modal/HISTORY.md
@@ -1,0 +1,2 @@
+## 1.0.0 (2020-01-27)
+	* Adds modal component

--- a/toolkits/springernature/packages/springer-nature-modal/README.md
+++ b/toolkits/springernature/packages/springer-nature-modal/README.md
@@ -12,7 +12,7 @@ Display a modal (pop-up) window
         <div class="c-modal--body">
             <p>This is the modal! It has a <a data-component-modal-close class="close-modal-link btn-close" href="">link</a> that can also close it.</p>
         </div>
-        <button data-component="modal-close" class="c-modal--close btn-close link-like">&times;</button>
+        <button data-component-modal-close class="c-modal--close btn-close link-like">&times;</button>
     </div>
 </div>
 ```

--- a/toolkits/springernature/packages/springer-nature-modal/README.md
+++ b/toolkits/springernature/packages/springer-nature-modal/README.md
@@ -1,0 +1,36 @@
+# Springer Nature Modal
+
+Display a modal (pop-up) window
+
+## Usage
+
+```html
+<button data-modal-for="example-modal">Click this button to open the modal</button>
+<div data-component-modal id="example-modal" class="c-modal js-hide" tabindex="0">
+    <div class="c-modal--content">
+        <h4 class="c-modal--title u-mb20">Modal Title</h4>
+        <div class="c-modal--body">
+            <p>This is the modal! It has a <a data-component-modal-close class="close-modal-link btn-close" href="">link</a> that can also close it.</p>
+        </div>
+        <button data-component="modal-close" class="c-modal--close btn-close link-like">&times;</button>
+    </div>
+</div>
+```
+
+```javascript
+import Modal from '@springernature/springer-nature-modal';
+
+const modalElement = document.querySelector('#example-modal'); //For multiple modals, prefer `document.querySelectorAll('[data-component-modal]');` and initilise on each instance
+const exampleModal = new Modal(modalElement);
+
+exampleModal.show(); // Programmatically opens the modal.
+```
+
+
+#### Required markup and attributes
+
+| Element Attribute | Element | Description | Required? |
+|---|---|---|---|
+| `id`     | Modal element  | The modal element must have an id attribute that is unique | Yes |
+| `data-modal-for` | Trigger link or button | If there is a modal trigger (eg. button), it must have this attrubute matching the id of the modal it is intending to open avoiding the need to write custom event listeners to open modal. This element should sit outside of the modal's element. | No |
+| `data-component-modal-close`  | Close button element | Should be added to an element which closes the modal. Note this element must be nested inside the modal which it intends to close | No |

--- a/toolkits/springernature/packages/springer-nature-modal/__tests__/unit/modal.spec.js
+++ b/toolkits/springernature/packages/springer-nature-modal/__tests__/unit/modal.spec.js
@@ -76,7 +76,7 @@ describe('Modal', () => {
 			let closeBtn;
 
 			beforeEach(() => {
-				closeBtn = document.querySelector('.c-modal--close');
+				closeBtn = document.querySelectorAll('[data-component-modal-close]')[0];
 
 				closeBtn.click();
 			});
@@ -86,11 +86,11 @@ describe('Modal', () => {
 			});
 		});
 
-		describe('When a link with the close modal class is clicked', () => {
+		describe('When a link with the close modal data attribute is clicked', () => {
 			let closeModalLink;
 
 			beforeEach(() => {
-				closeModalLink = document.querySelector('[data-component-modal-close]');
+				closeModalLink = document.querySelectorAll('[data-component-modal-close]')[1];
 
 				closeModalLink.click();
 			});

--- a/toolkits/springernature/packages/springer-nature-modal/__tests__/unit/modal.spec.js
+++ b/toolkits/springernature/packages/springer-nature-modal/__tests__/unit/modal.spec.js
@@ -58,7 +58,7 @@ describe('Modal', () => {
 			expect(modalEl).toBe(lastBodyEl);
 		});
 
-		test('should hidden after it\'s trigger has been clicked again', () => {
+		test('should be hidden after it\'s trigger has been clicked again', () => {
 			trigger1.click();
 
 			expect(modalEl.classList.contains('js-hide')).toBe(true);

--- a/toolkits/springernature/packages/springer-nature-modal/__tests__/unit/modal.spec.js
+++ b/toolkits/springernature/packages/springer-nature-modal/__tests__/unit/modal.spec.js
@@ -1,0 +1,175 @@
+import Modal from '../../js/modal';
+
+describe('Modal', () => {
+	const html = `<a class="modal1-trigger" data-modal-for="modal1" href="#">Modal trigger link</a>
+		<div data-component-modal id="modal1" class="c-modal js-hide" tabindex="0">
+			<div class="c-modal--content">
+				<h4 class="c-modal--title u-mb20">Modal Title</h4>
+				<div class="c-modal--body">
+					<p>This is the modal! It has a <a data-component-modal-close class="close-modal-link btn-close" href="">link</a> that can also close it.</p>
+				</div>
+				<button data-component-modal-close class="c-modal--close btn-close link-like">&times;</button>
+			</div>
+		</div>`;
+
+	beforeEach(() => {
+		document.body.innerHTML = html;
+
+		const modalElements = document.querySelectorAll('[data-component-modal]');
+		modalElements.forEach(modal => {
+			new Modal(modal);
+		});
+	});
+
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	test('should be log an error to console ', () => {
+		const modalEl = document.querySelector('.c-modal');
+
+		expect(modalEl.classList.contains('js-hide')).toBe(true);
+	});
+
+	test('should be hidden initially', () => {
+		const modalEl = document.querySelector('.c-modal');
+
+		expect(modalEl.classList.contains('js-hide')).toBe(true);
+	});
+
+	describe('When it\'s trigger is clicked', () => {
+		let modalEl;
+		let trigger;
+
+		beforeEach(() => {
+			modalEl = document.querySelector('.c-modal');
+			trigger = document.querySelector('.modal1-trigger');
+
+			trigger.click();
+		});
+
+		test('should be shown and focus given to the first focusable element', () => {
+			expect(modalEl.classList.contains('js-hide')).toBe(false);
+			expect(modalEl.getAttribute('aria-hidden')).toBe('false');
+			expect(document.activeElement).toBe(modalEl.querySelector('a'));
+		});
+
+		test('should have it\'s element moved to the bottom', () => {
+			let bodyElChildren = document.body.children;
+			let bodyChildrenCount = document.body.children.length;
+			let lastBodyEl = bodyElChildren[bodyChildrenCount - 1];
+			expect(modalEl).toBe(lastBodyEl);
+		});
+
+		test('should hidden after it\'s trigger has been clicked again', () => {
+			trigger.click();
+
+			expect(modalEl.classList.contains('js-hide')).toBe(true);
+			expect(modalEl.getAttribute('aria-hidden')).toBe('true');
+		});
+
+		describe('When the modal\'s close button is clicked', () => {
+			let closeBtn;
+
+			beforeEach(() => {
+				closeBtn = document.querySelector('.c-modal--close');
+
+				closeBtn.click();
+			});
+
+			test('should dismiss the opened modal', () => {
+				expect(modalEl.classList.contains('js-hide')).toBe(true);
+			});
+		});
+
+		describe('When a link with the close modal class is clicked', () => {
+			let closeModalLink;
+
+			beforeEach(() => {
+				closeModalLink = document.querySelector('.close-modal-link');
+
+				closeModalLink.click();
+			});
+
+			test('should dismiss the opened modal', () => {
+				expect(modalEl.classList.contains('js-hide')).toBe(true);
+			});
+		});
+
+	});
+
+	xdescribe('When the ESC key is pressed', () => {
+		let modalEl;
+		let trigger;
+
+		const ESCAPE_KEY_CODE = 27;
+
+		// const event = new KeyboardEvent('keydown', {'keyCode': ESCAPE_KEY_CODE});
+
+		const event = document.createEvent('KeyboardEvent');
+		const initMethod = typeof event.initKeyboardEvent !== 'undefined' ? 'initKeyboardEvent' : 'initKeyEvent';
+		event[initMethod](
+			'keydown', // event type : keydown, keyup, keypress
+			true, // bubbles
+			true, // cancelable
+			window, // viewArg: should be window
+			false, // ctrlKeyArg
+			false, // altKeyArg
+			false, // shiftKeyArg
+			false, // metaKeyArg
+			ESCAPE_KEY_CODE, // keyCodeArg : unsigned long the virtual key code, else 0
+			0 // charCodeArgs : unsigned long the Unicode character associated with the depressed key, else 0
+		);
+
+		beforeEach(() => {
+			modalEl = document.querySelector('.c-modal');
+			trigger = document.querySelector('.modal1-trigger');
+			trigger.click(); // Ensure modal is open
+
+			// modalEl.dispatchEvent(event);
+		});
+
+		test('and the modal is already open, it should hide the modal', () => {
+			modalEl.dispatchEvent(event); // Trigger the pressing of the escape key
+
+			expect(modalEl.classList.contains('js-hide')).toBe(true);
+		});
+	});
+
+	xdescribe('When the Tab key is pressed in a way that would take focus away from the modal', () => {
+		let modalEl;
+		let trigger;
+
+		const TAB_KEY_CODE = 9;
+
+		// const event = new KeyboardEvent('keydown', {'keyCode': ESCAPE_KEY_CODE});
+
+		const event = document.createEvent('KeyboardEvent');
+		const initMethod = typeof event.initKeyboardEvent !== 'undefined' ? 'initKeyboardEvent' : 'initKeyEvent';
+		event[initMethod](
+			'keydown', // event type : keydown, keyup, keypress
+			true, // bubbles
+			true, // cancelable
+			window, // viewArg: should be window
+			false, // ctrlKeyArg
+			false, // altKeyArg
+			false, // shiftKeyArg
+			false, // metaKeyArg
+			TAB_KEY_CODE, // keyCodeArg : unsigned long the virtual key code, else 0
+			0 // charCodeArgs : unsigned long the Unicode character associated with the depressed key, else 0
+		);
+
+		beforeEach(() => {
+			modalEl = document.querySelector('.c-modal');
+			trigger = document.querySelector('.modal1-trigger');
+			trigger.click(); // Ensure modal is open
+			modalEl.querySelector('[data-component="modal-close"]').focus(); // Ensure the last focusable element is focused
+		});
+
+		test('should retain focus inside the modal', () => {
+			modalEl.dispatchEvent(event); // Trigger the pressing of the escape key
+
+			expect(document.activeElement).toBe(modalEl);
+		});
+	});
+});

--- a/toolkits/springernature/packages/springer-nature-modal/__tests__/unit/modal.spec.js
+++ b/toolkits/springernature/packages/springer-nature-modal/__tests__/unit/modal.spec.js
@@ -90,7 +90,7 @@ describe('Modal', () => {
 			let closeModalLink;
 
 			beforeEach(() => {
-				closeModalLink = document.querySelector('.close-modal-link');
+				closeModalLink = document.querySelector('[data-component-modal-close]');
 
 				closeModalLink.click();
 			});

--- a/toolkits/springernature/packages/springer-nature-modal/__tests__/unit/modal.spec.js
+++ b/toolkits/springernature/packages/springer-nature-modal/__tests__/unit/modal.spec.js
@@ -2,6 +2,7 @@ import Modal from '../../js/modal';
 
 describe('Modal', () => {
 	const html = `<a class="modal1-trigger" data-modal-for="modal1" href="#">Modal trigger link</a>
+	<a class="modal1-trigger2" data-modal-for="modal1" href="#">Another trigger link</a>
 		<div data-component-modal id="modal1" class="c-modal js-hide" tabindex="0">
 			<div class="c-modal--content">
 				<h4 class="c-modal--title u-mb20">Modal Title</h4>
@@ -33,13 +34,15 @@ describe('Modal', () => {
 
 	describe('When it\'s trigger is clicked', () => {
 		let modalEl;
-		let trigger;
+		let trigger1;
+		let trigger2;
 
 		beforeEach(() => {
 			modalEl = document.querySelector('.c-modal');
-			trigger = document.querySelector('.modal1-trigger');
+			trigger1 = document.querySelector('.modal1-trigger');
+			trigger2 = document.querySelector('.modal1-trigger2');
 
-			trigger.click();
+			trigger1.click();
 		});
 
 		test('should be shown and focus given to the first focusable element', () => {
@@ -56,7 +59,14 @@ describe('Modal', () => {
 		});
 
 		test('should hidden after it\'s trigger has been clicked again', () => {
-			trigger.click();
+			trigger1.click();
+
+			expect(modalEl.classList.contains('js-hide')).toBe(true);
+			expect(modalEl.getAttribute('aria-hidden')).toBe('true');
+		});
+
+		test('should also be hidden if the second trigger was clicked', () => {
+			trigger2.click();
 
 			expect(modalEl.classList.contains('js-hide')).toBe(true);
 			expect(modalEl.getAttribute('aria-hidden')).toBe('true');

--- a/toolkits/springernature/packages/springer-nature-modal/__tests__/unit/modal.spec.js
+++ b/toolkits/springernature/packages/springer-nature-modal/__tests__/unit/modal.spec.js
@@ -25,12 +25,6 @@ describe('Modal', () => {
 		document.body.innerHTML = '';
 	});
 
-	test('should be log an error to console ', () => {
-		const modalEl = document.querySelector('.c-modal');
-
-		expect(modalEl.classList.contains('js-hide')).toBe(true);
-	});
-
 	test('should be hidden initially', () => {
 		const modalEl = document.querySelector('.c-modal');
 
@@ -96,80 +90,5 @@ describe('Modal', () => {
 			});
 		});
 
-	});
-
-	xdescribe('When the ESC key is pressed', () => {
-		let modalEl;
-		let trigger;
-
-		const ESCAPE_KEY_CODE = 27;
-
-		// const event = new KeyboardEvent('keydown', {'keyCode': ESCAPE_KEY_CODE});
-
-		const event = document.createEvent('KeyboardEvent');
-		const initMethod = typeof event.initKeyboardEvent !== 'undefined' ? 'initKeyboardEvent' : 'initKeyEvent';
-		event[initMethod](
-			'keydown', // event type : keydown, keyup, keypress
-			true, // bubbles
-			true, // cancelable
-			window, // viewArg: should be window
-			false, // ctrlKeyArg
-			false, // altKeyArg
-			false, // shiftKeyArg
-			false, // metaKeyArg
-			ESCAPE_KEY_CODE, // keyCodeArg : unsigned long the virtual key code, else 0
-			0 // charCodeArgs : unsigned long the Unicode character associated with the depressed key, else 0
-		);
-
-		beforeEach(() => {
-			modalEl = document.querySelector('.c-modal');
-			trigger = document.querySelector('.modal1-trigger');
-			trigger.click(); // Ensure modal is open
-
-			// modalEl.dispatchEvent(event);
-		});
-
-		test('and the modal is already open, it should hide the modal', () => {
-			modalEl.dispatchEvent(event); // Trigger the pressing of the escape key
-
-			expect(modalEl.classList.contains('js-hide')).toBe(true);
-		});
-	});
-
-	xdescribe('When the Tab key is pressed in a way that would take focus away from the modal', () => {
-		let modalEl;
-		let trigger;
-
-		const TAB_KEY_CODE = 9;
-
-		// const event = new KeyboardEvent('keydown', {'keyCode': ESCAPE_KEY_CODE});
-
-		const event = document.createEvent('KeyboardEvent');
-		const initMethod = typeof event.initKeyboardEvent !== 'undefined' ? 'initKeyboardEvent' : 'initKeyEvent';
-		event[initMethod](
-			'keydown', // event type : keydown, keyup, keypress
-			true, // bubbles
-			true, // cancelable
-			window, // viewArg: should be window
-			false, // ctrlKeyArg
-			false, // altKeyArg
-			false, // shiftKeyArg
-			false, // metaKeyArg
-			TAB_KEY_CODE, // keyCodeArg : unsigned long the virtual key code, else 0
-			0 // charCodeArgs : unsigned long the Unicode character associated with the depressed key, else 0
-		);
-
-		beforeEach(() => {
-			modalEl = document.querySelector('.c-modal');
-			trigger = document.querySelector('.modal1-trigger');
-			trigger.click(); // Ensure modal is open
-			modalEl.querySelector('[data-component="modal-close"]').focus(); // Ensure the last focusable element is focused
-		});
-
-		test('should retain focus inside the modal', () => {
-			modalEl.dispatchEvent(event); // Trigger the pressing of the escape key
-
-			expect(document.activeElement).toBe(modalEl);
-		});
 	});
 });

--- a/toolkits/springernature/packages/springer-nature-modal/js/modal.js
+++ b/toolkits/springernature/packages/springer-nature-modal/js/modal.js
@@ -6,7 +6,7 @@ class Modal {
 		}
 		this.modal = modalElement;
 		this.modalId = this.modal.getAttribute('id');
-		this.trigger = document.querySelector(`[data-modal-for='${this.modalId}']`);
+		this.triggers = Array.from(document.querySelectorAll(`[data-modal-for='${this.modalId}']`));
 		this.closeButtons = document.querySelectorAll(`#${this.modalId} [data-component-modal-close]`);
 		this.isMouseMove = false;
 		this.preModalFocussedElement = null;
@@ -17,10 +17,12 @@ class Modal {
 	}
 
 	_registerEvents() {
-		if (this.trigger) {
-			this.trigger.addEventListener('click', event => {
-				event.preventDefault();
-				this.toggleModal();
+		if (this.triggers.length > 0) {
+			this.triggers.forEach(trigger => {
+				trigger.addEventListener('click', event => {
+					event.preventDefault();
+					this.toggleModal();
+				});
 			});
 		}
 		if (this.closeButtons.length > 0) {

--- a/toolkits/springernature/packages/springer-nature-modal/js/modal.js
+++ b/toolkits/springernature/packages/springer-nature-modal/js/modal.js
@@ -1,0 +1,113 @@
+class Modal {
+	constructor(modalElement) {
+		if (!modalElement || !modalElement.hasAttribute('id')) {
+			console.error('Modal must be a valid DOM node with an ID.');
+			return;
+		}
+		this.modal = modalElement;
+		this.modalId = this.modal.getAttribute('id');
+		this.trigger = document.querySelector(`[data-modal-for='${this.modalId}']`);
+		this.closeButtons = document.querySelectorAll(`#${this.modalId} [data-component-modal-close]`);
+		this.isMouseMove = false;
+		this.preModalFocussedElement = null;
+		this.focusableEls = Array.from(this.modal.querySelectorAll('a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]'));
+		this.firstFocusableEl = this.focusableEls[0];
+		this.lastFocusableEl = this.focusableEls[this.focusableEls.length - 1];
+		this._registerEvents();
+	}
+
+	_registerEvents() {
+		if (this.trigger) {
+			this.trigger.addEventListener('click', event => {
+				event.preventDefault();
+				this.toggleModal();
+			});
+		}
+		if (this.closeButtons.length > 0) {
+			Array.from(this.closeButtons).forEach(button => {
+				button.addEventListener('click', this.toggleModal.bind(this));
+			});
+			window.addEventListener('click', this._windowOnClick.bind(this));
+			window.addEventListener('mousemove', () => {
+				this.isMouseMove = true;
+			});
+			window.addEventListener('mousedown', () => {
+				this.isMouseMove = false;
+			});
+			window.addEventListener('mouseup', () => this._windowOnClick.bind(this));
+		}
+
+		this.modal.addEventListener('keydown', event => {
+			event.stopImmediatePropagation();
+			switch (event.code) {
+				case 'Escape':
+					this.toggleModal();
+					this._restoreFocus();
+					break;
+				case 'Tab':
+					if (event.shiftKey) {
+						this._handleBackwardTab(event);
+					} else {
+						this._handleForwardTab(event);
+					}
+					break;
+				default:
+					break;
+			}
+		});
+	}
+
+	open() {
+		this.preModalFocussedElement = document.activeElement;
+		document.querySelector('html').classList.add('has-modal');
+		document.body.append(this.modal);
+		this.modal.classList.remove('js-hide');
+		this.modal.setAttribute('aria-hidden', false);
+		this.firstFocusableEl.focus();
+	}
+
+	close() {
+		document.querySelector('html').classList.remove('has-modal');
+		this.modal.classList.add('js-hide');
+		this.modal.setAttribute('aria-hidden', true);
+		this._restoreFocus();
+	}
+
+	toggleModal() {
+		if (this.modal.classList.contains('js-hide')) {
+			this.open();
+		} else {
+			this.close();
+		}
+	}
+
+	_windowOnClick(event) {
+		if (event.target === this.modal) {
+			if (!this.isMouseMove) {
+				this.toggleModal();
+			}
+		}
+	}
+
+	_restoreFocus() {
+		if (this.preModalFocussedElement) {
+			this.preModalFocussedElement.focus();
+		}
+	}
+
+	_handleBackwardTab(event) {
+		if (document.activeElement === this.firstFocusableEl) {
+			event.preventDefault();
+			this.lastFocusableEl.focus();
+		}
+	}
+
+	_handleForwardTab(event) {
+		if (document.activeElement === this.lastFocusableEl) {
+			event.preventDefault();
+			this.firstFocusableEl.focus();
+		}
+	}
+}
+
+export default Modal;

--- a/toolkits/springernature/packages/springer-nature-modal/package.json
+++ b/toolkits/springernature/packages/springer-nature-modal/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@springernature/springer-nature-modal",
+  "version": "1.0.0",
+  "license": "MIT",
+  "description": "Springer Nature branded modal pop-up window",
+  "keywords": ["modal", "pop-up"],
+  "author": "Springer Nature",
+  "extendsPackage": "global-context@1.1.0"
+}

--- a/toolkits/springernature/packages/springer-nature-modal/scss/50-components/springer-nature-modal.scss
+++ b/toolkits/springernature/packages/springer-nature-modal/scss/50-components/springer-nature-modal.scss
@@ -1,0 +1,83 @@
+.js .c-modal {
+	align-items: center;
+	background-color: rgba(0, 0, 0, 0.4);
+	content: '';
+	display: flex;
+	justify-content: center;
+	height: 100%;
+	left: 0;
+	position: fixed;
+	top: 0;
+	width: 100%;
+
+	&--content {
+		background-color: #fff;
+		overflow-y: auto;
+		border-top: 3px solid #007e99;
+		box-shadow: 0 4px 6px 3px rgba(0, 0, 0, 0.25);
+		border-radius: 3px;
+		height: auto;
+		margin: 30px;
+		max-height: 95%;
+		max-width: 620px;
+		overflow-y: scroll;
+		position: relative;
+		padding: 30px;
+		transition: height 0.2s ease-out;
+		width: 100%;
+	}
+
+	&--title {
+		font-size: 18px;
+		font-weight: 600;
+		line-height: 1.48;
+	}
+
+	&--close {
+		color: #666;
+		font-size: 32px;
+		position: absolute;
+		top: 15px;
+		right: 15px;
+
+		&:hover {
+			text-decoration: none;
+		}
+	}
+
+	.hidden-within-modal {
+		display: none;
+	}
+
+	.unstyle-within-modal {
+		background-color: transparent;
+		border: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	.shown-only-within-modal {
+		display: inline-block;
+	}
+
+	.copy-button-modal {
+		font-size: 12px;
+		left: 150px;
+		position: absolute;
+		top: 35px;
+	}
+}
+
+.shown-only-within-modal {
+	display: none;
+}
+
+html.has-modal {
+	overflow: hidden;
+
+	.c-header,
+	main,
+	.c-footer {
+		filter: blur(1px);
+	}
+}


### PR DESCRIPTION
# Springer Nature Modal

![modal-animation](https://user-images.githubusercontent.com/722302/73253732-ffd09580-41b4-11ea-9ae6-8fbd79fab2bc.gif)

Display a modal (pop-up) window

## Usage

```html
<button data-modal-for="example-modal">Click this button to open the modal</button>
<div data-component-modal id="example-modal" class="c-modal js-hide" tabindex="0">
    <div class="c-modal--content">
        <h4 class="c-modal--title u-mb20">Modal Title</h4>
        <div class="c-modal--body">
            <p>This is the modal! It has a <a data-component-modal-close class="close-modal-link btn-close" href="">link</a> that can also close it.</p>
        </div>
        <button data-component="modal-close" class="c-modal--close btn-close link-like">&times;</button>
    </div>
</div>
```

```javascript
import Modal from '@springernature/springer-nature-modal';

const modalElement = document.querySelector('#example-modal'); //For multiple modals, prefer `document.querySelectorAll('[data-component-modal]');` and initilise on each instance
const exampleModal = new Modal(modalElement);

exampleModal.show(); // Programmatically opens the modal.
```


#### Required markup and attributes

| Element Attribute | Element | Description | Required? |
|---|---|---|---|
| `id`     | Modal element  | The modal element must have an id attribute that is unique | Yes |
| `data-modal-for` | Trigger link or button | If there is a modal trigger (eg. button), it must have this attrubute matching the id of the modal it is intending to open avoiding the need to write custom event listeners to open modal. This element should sit outside of the modal's element. | No |
| `data-component-modal-close`  | Close button element | Should be added to an element which closes the modal. Note this element must be nested inside the modal which it intends to close | No |
