### PR TITLE
global-context: breaking - renames link utility / adds link utilities

### DIFF
--- a/toolkits/global/packages/global-context/HISTORY.md
+++ b/toolkits/global/packages/global-context/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 11.0.0 (2020-02-12)
+    * BREAKING: Renames link utility to be consistent with other utilities
+    * Adds mixins and utilities for u-link-inherit and u-link-underline
+
 ## 10.0.0 (2020-01-16)
     * Renamed u-open-access-color to u-color-open-access
     

--- a/toolkits/global/packages/global-context/package.json
+++ b/toolkits/global/packages/global-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-context",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "license": "MIT",
   "description": "Template for providing bootstrapping for all components and products",
   "keywords": [],

--- a/toolkits/global/packages/global-context/package.json
+++ b/toolkits/global/packages/global-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-context",
-  "version": "10.1.0",
+  "version": "11.0.0",
   "license": "MIT",
   "description": "Template for providing bootstrapping for all components and products",
   "keywords": [],

--- a/toolkits/global/packages/global-context/scss/30-mixins/links.scss
+++ b/toolkits/global/packages/global-context/scss/30-mixins/links.scss
@@ -1,4 +1,27 @@
-@mixin u-faux-block-link {
+@mixin u-link-inherit() {
+	color: inherit;
+
+	&.visited,
+	&:visited {
+		color: inherit;
+	}
+
+	&.hover,
+	&:hover {
+		color: inherit;
+	}
+}
+
+@mixin u-link-underline() {
+	text-decoration: underline;
+
+	&.hover,
+	&:hover {
+		text-decoration: none;
+	}
+}
+
+@mixin u-link-faux-block() {
 	&::before {
 		content: '';
 		position: absolute;

--- a/toolkits/global/packages/global-context/scss/60-utilities/links.scss
+++ b/toolkits/global/packages/global-context/scss/60-utilities/links.scss
@@ -1,3 +1,11 @@
-.u-faux-block-link {
-	@include u-faux-block-link;
+.u-link-inherit {
+	@include u-link-inherit();
+}
+
+.u-link-underline {
+	@include u-link-underline();
+}
+
+.u-link-faux-block {
+	@include u-link-faux-block();
 }


### PR DESCRIPTION
- Renames u-x-link to u-link-x for consistency with other utilities
- Adds u-link-inherit and u-link-underline