### PR TITLE
Makes all label elements sans-serif font to fix those on springer bra…

### DIFF
--- a/toolkits/springer/packages/springer-context/HISTORY.md
+++ b/toolkits/springer/packages/springer-context/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 14.0.3 (2020-02-12)
+    * Makes all label elements sans-serif font to fix those on springer branded pages that incorrectly had serif
+
 ## 14.0.2 (2020-02-11)
     * BUG: Set base context font size up to 1.8em
 

--- a/toolkits/springer/packages/springer-context/package.json
+++ b/toolkits/springer/packages/springer-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-context",
-  "version": "14.0.2",
+  "version": "14.0.3",
   "license": "MIT",
   "description": "Bootstrapping for all Springer components and products",
   "keywords": [

--- a/toolkits/springer/packages/springer-context/scss/40-base/forms.scss
+++ b/toolkits/springer/packages/springer-context/scss/40-base/forms.scss
@@ -23,3 +23,7 @@ textarea:disabled {
 		outline: none;
 	}
 }
+
+label {
+	font-family: $font-family-sans;
+}


### PR DESCRIPTION
…nded pages that incorrectly had serif

Patch version because:
- fixes an issue with site
- does not change layout (would have made it major)
- does not require testing by qa (would have made it major or minor)
- does not affect accessibility (would have made it major or minor)
- does not create a significant stylistic change (would have made it minor)