### PR TITLE
nature/springer context: update to latest global context

### DIFF
--- a/toolkits/nature/packages/nature-context/HISTORY.md
+++ b/toolkits/nature/packages/nature-context/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 0.24.0 (2020-02-12)
+	* Update to global-context@11.0.0
+	* @import links from global
+
 ## 0.23.0 (2020-02-04)
     * Correct path to colors/default in core
 

--- a/toolkits/nature/packages/nature-context/package.json
+++ b/toolkits/nature/packages/nature-context/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@springernature/nature-context",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "license": "MIT",
   "description": "Boostrapping for all Nature components and products",
   "keywords": [],
   "author": "Springer Nature",
-  "extendsPackage": "global-context@9.1.0"
+  "extendsPackage": "global-context@11.0.0"
 }

--- a/toolkits/nature/packages/nature-context/scss/enhanced.scss
+++ b/toolkits/nature/packages/nature-context/scss/enhanced.scss
@@ -23,6 +23,7 @@
 @import '30-mixins/hiding';
 @import '30-mixins/icons';
 @import '30-mixins/keyframes';
+@import '30-mixins/links';
 @import '30-mixins/lists';
 @import '30-mixins/style';
 @import '30-mixins/typography';

--- a/toolkits/springer/packages/springer-context/HISTORY.md
+++ b/toolkits/springer/packages/springer-context/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 15.0.0 (2020-02-12)
+	* Update to global-context@11.0.0
+	* Remove inherited link mixin as comes @from global
+
 ## 14.0.3 (2020-02-12)
     * Makes all label elements sans-serif font to fix those on springer branded pages that incorrectly had serif
 

--- a/toolkits/springer/packages/springer-context/package.json
+++ b/toolkits/springer/packages/springer-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-context",
-  "version": "14.0.3",
+  "version": "15.0.0",
   "license": "MIT",
   "description": "Bootstrapping for all Springer components and products",
   "keywords": [
@@ -12,7 +12,7 @@
     "js"
   ],
   "author": "Springer Nature",
-  "extendsPackage": "global-context@10.0.0",
+  "extendsPackage": "global-context@11.0.0",
   "peerDependencies": {
     "rfs": "^8.0.4"
   }

--- a/toolkits/springer/packages/springer-context/scss/30-mixins/springer-links.scss
+++ b/toolkits/springer/packages/springer-context/scss/30-mixins/springer-links.scss
@@ -96,25 +96,6 @@
 }
 
 /**
- * Inherited
- *
- */
-
-@mixin inherited-link {
-	color: inherit;
-
-	&.visited,
-	&:visited {
-		color: inherit;
-	}
-
-	&.hover,
-	&:hover {
-		color: inherit;
-	}
-}
-
-/**
  * Link like
  * Style non-links to look like links
  * Remember to add aria


### PR DESCRIPTION
Note: breaking change in Springer because of the use of majors already. In Nature, there's never been a major release so breaking changes can be included in the minor (until v1 is released).

Springer already imported links from global.