### PR TITLE
Increase the base font size

### DIFF
--- a/toolkits/global/packages/global-context/HISTORY.md
+++ b/toolkits/global/packages/global-context/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 12.0.0 (2020-02-12)
+    * Update the $context--font-size-base to align it with our imprints
+
 ## 11.0.0 (2020-02-12)
     * BREAKING: Renames link utility to be consistent with other utilities
     * Adds mixins and utilities for u-link-inherit and u-link-underline

--- a/toolkits/global/packages/global-context/package.json
+++ b/toolkits/global/packages/global-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-context",
-  "version": "11.0.0",
+  "version": "12.0.0",
   "license": "MIT",
   "description": "Template for providing bootstrapping for all components and products",
   "keywords": [],

--- a/toolkits/global/packages/global-context/scss/10-settings/typography.scss
+++ b/toolkits/global/packages/global-context/scss/10-settings/typography.scss
@@ -8,7 +8,7 @@ $font-family-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen
 
 // Define your base size in EMs
 // http://stackoverflow.com/questions/20099844/chrome-not-respecting-rem-font-size-on-body-tag
-$context--font-size-base: 1em;
+$context--font-size-base: 1.8em;
 
 // Headings
 $context--font-size-h1: 3rem;


### PR DESCRIPTION
so we can remove the overrides from the brand level, they all use 1.8em as there base size. If any want to vary in the future they can add this back at a brand level.