### PR TITLE
Remove base font size

### DIFF
--- a/toolkits/nature/packages/nature-context/HISTORY.md
+++ b/toolkits/nature/packages/nature-context/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 0.25.0 (2020-02-12)
+	* Update to global-context@12.0.0
+	* Remove brand override of global $context--font-size-base variable
+
 ## 0.24.0 (2020-02-12)
 	* Update to global-context@11.0.0
 	* @import links from global

--- a/toolkits/nature/packages/nature-context/package.json
+++ b/toolkits/nature/packages/nature-context/package.json
@@ -5,5 +5,5 @@
   "description": "Boostrapping for all Nature components and products",
   "keywords": [],
   "author": "Springer Nature",
-  "extendsPackage": "global-context@11.0.0"
+  "extendsPackage": "global-context@12.0.0"
 }

--- a/toolkits/nature/packages/nature-context/scss/10-settings/typography-nature.scss
+++ b/toolkits/nature/packages/nature-context/scss/10-settings/typography-nature.scss
@@ -6,7 +6,3 @@
 $is-flagship-journal: false !default;
 $primary-font: if($is-flagship-journal, Harding, Lora);
 $font-family-serif: $primary-font, Palatino, Times, 'Times New Roman', serif;
-
-// Define your base size in EMs
-// http://stackoverflow.com/questions/20099844/chrome-not-respecting-rem-font-size-on-body-tag
-$context--font-size-base: 1.8em;


### PR DESCRIPTION
and bump the global-context version on extends-package, so we get the base font size from that.