### PR TITLE
global-banner: sets underline on links

### DIFF
--- a/toolkits/global/packages/global-banner/HISTORY.md
+++ b/toolkits/global/packages/global-banner/HISTORY.md
@@ -1,7 +1,7 @@
 # History
 
-## 2.0.0 (2020-02-12)
-    * BREAKING: Bumnp global-context dependency
+## 2.0.0 (2020-02-13)
+    * BREAKING: Bump global-context dependency
     * Sets underline on links
 
 ## 1.0.1 (2020-02-05)

--- a/toolkits/global/packages/global-banner/HISTORY.md
+++ b/toolkits/global/packages/global-banner/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 2.0.0 (2020-02-12)
+    * BREAKING: Bumnp global-context dependency
+    * Sets underline on links
+
 ## 1.0.1 (2020-02-05)
     * Align text center
 

--- a/toolkits/global/packages/global-banner/package.json
+++ b/toolkits/global/packages/global-banner/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@springernature/global-banner",
-  "version": "1.0.1",
+  "version": "2.0.1",
   "license": "MIT",
   "description": "Full width banner used for displaying informational messages",
   "keywords": [],
   "author": "Springer Nature",
   "peerDependencies": {
-    "@springernature/global-context": "^10.0.0"
+    "@springernature/global-context": "^11.0.0"
   }
 }

--- a/toolkits/global/packages/global-banner/package.json
+++ b/toolkits/global/packages/global-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-banner",
-  "version": "2.0.1",
+  "version": "2.0.0",
   "license": "MIT",
   "description": "Full width banner used for displaying informational messages",
   "keywords": [],

--- a/toolkits/global/packages/global-banner/package.json
+++ b/toolkits/global/packages/global-banner/package.json
@@ -6,6 +6,6 @@
   "keywords": [],
   "author": "Springer Nature",
   "peerDependencies": {
-    "@springernature/global-context": "^11.0.0"
+    "@springernature/global-context": "^13.0.0"
   }
 }

--- a/toolkits/global/packages/global-banner/scss/50-components/_banner.scss
+++ b/toolkits/global/packages/global-banner/scss/50-components/_banner.scss
@@ -79,13 +79,3 @@
 		color: $banner--link-color;
 	}
 }
-
-.c-banner__link--underline {
-	text-decoration: underline;
-
-	&:active,
-	&:focus,
-	&:hover {
-		text-decoration: none;
-	}
-}

--- a/toolkits/global/packages/global-banner/scss/50-components/_banner.scss
+++ b/toolkits/global/packages/global-banner/scss/50-components/_banner.scss
@@ -71,6 +71,7 @@
 }
 
 .c-banner__link {
+	@include u-link-underline();
 	color: $banner--link-color;
 
 	&:visited,


### PR DESCRIPTION
Banner links should always have underlines, regardless of the brand.
This is because the banner is intended to be a combination of a text and links (normally in a sentence).

Bumps global-context peer dep.