### PR TITLE
global-context: breaking - flex utility names

### DIFF
--- a/toolkits/global/packages/global-context/HISTORY.md
+++ b/toolkits/global/packages/global-context/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 14.0.0 (2020-02-18)
+    * BREAKING: Renames flex utility classes to match the property they set
+
 ## 13.1.2 (2020-02-17)
     * Sets width of display flex utility to 100% to fix IE bug with nested flex
 

--- a/toolkits/global/packages/global-context/package.json
+++ b/toolkits/global/packages/global-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-context",
-  "version": "13.1.2",
+  "version": "14.0.0",
   "license": "MIT",
   "description": "Template for providing bootstrapping for all components and products",
   "keywords": [],

--- a/toolkits/global/packages/global-context/scss/60-utilities/display.scss
+++ b/toolkits/global/packages/global-context/scss/60-utilities/display.scss
@@ -15,6 +15,10 @@
 	width: 100%; // Caters for an ie bug with nested flex when child is a column
 }
 
+.u-display-inline-flex {
+	display: inline-flex;
+}
+
 .u-display-grid {
 	display: grid;
 }

--- a/toolkits/global/packages/global-context/scss/60-utilities/flex.scss
+++ b/toolkits/global/packages/global-context/scss/60-utilities/flex.scss
@@ -1,38 +1,38 @@
-.u-flex-align-center {
-	align-items: center;
+// Applied to flex element
+
+.u-flex-direction-row {
+	flex-direction: row;
 }
 
-.u-flex-align-baseline {
-	align-items: baseline;
-}
-
-.u-flex-justify-space-between {
-	justify-content: space-between;
-}
-
-.u-flex-justify-center {
-	justify-content: center;
-}
-
-.u-flex-justify-left {
-	justify-content: left;
+.u-flex-direction-column {
+	flex-direction: column;
 }
 
 .u-flex-wrap {
 	flex-wrap: wrap;
 }
 
-.u-flex-inline {
-	display: inline-flex;
+.u-align-items-center {
+	align-items: center;
 }
 
-.u-flex-row {
-	flex-direction: row;
+.u-align-items-baseline {
+	align-items: baseline;
 }
 
-.u-flex-column {
-	flex-direction: column;
+.u-justify-content-space-between {
+	justify-content: space-between;
 }
+
+.u-justify-content-center {
+	justify-content: center;
+}
+
+.u-justify-content-left {
+	justify-content: left;
+}
+
+// Applied to flex child elements
 
 .u-flex-grow {
 	flex: 1 0 auto;
@@ -48,4 +48,16 @@
 
 .u-flex-static {
 	flex: 0 0 auto;
+}
+
+.u-align-self-center {
+	align-self: center;
+}
+
+.u-align-self-start {
+	align-self: flex-start;
+}
+
+.u-align-self-end {
+	align-self: flex-end;
 }


### PR DESCRIPTION
I'm making these consistent for now.
Whether this is the approach in the long term is still up for debate.