### PR TITLE
nature-context: nature headings

### DIFF
--- a/toolkits/nature/packages/nature-context/HISTORY.md
+++ b/toolkits/nature/packages/nature-context/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 0.31.0 (2020-02-24)
+	* Adds heading utility mixins and classes
+	* Heading styles dependent upon $is-flagship-journal to avoid breaking changes to mosaic
+
 ## 0.30.2 (2020-02-19)
 	* Fix import order in enhanced.scss
 	* Remove redundant functions folder

--- a/toolkits/nature/packages/nature-context/HISTORY.md
+++ b/toolkits/nature/packages/nature-context/HISTORY.md
@@ -3,6 +3,7 @@
 ## 0.31.0 (2020-02-24)
 	* Adds heading utility mixins and classes
 	* Heading styles dependent upon $is-flagship-journal to avoid breaking changes to mosaic
+	* Removes rem units from basic
 
 ## 0.30.2 (2020-02-19)
 	* Fix import order in enhanced.scss

--- a/toolkits/nature/packages/nature-context/package.json
+++ b/toolkits/nature/packages/nature-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/nature-context",
-  "version": "0.30.2",
+  "version": "0.31.0",
   "license": "MIT",
   "description": "Boostrapping for all Nature components and products",
   "keywords": [],

--- a/toolkits/nature/packages/nature-context/scss/10-settings/typography-nature.scss
+++ b/toolkits/nature/packages/nature-context/scss/10-settings/typography-nature.scss
@@ -6,3 +6,11 @@
 $is-flagship-journal: false !default;
 $primary-font: if($is-flagship-journal, Harding, Lora);
 $font-family-serif: $primary-font, Palatino, Times, 'Times New Roman', serif;
+
+$context--heading-font-weight: if($is-flagship-journal, bold, normal);
+$context--heading-line-height: 1.3;
+
+$context--font-size-h1: if($is-flagship-journal, 3.2rem, 3rem);
+$context--font-size-h2: 2.4rem;
+$context--font-size-h3: if($is-flagship-journal, 1.9rem, 1.7rem);
+$context--font-size-h4: if($is-flagship-journal, 1.7rem, 1.4rem);

--- a/toolkits/nature/packages/nature-context/scss/30-mixins/typography-nature.scss
+++ b/toolkits/nature/packages/nature-context/scss/30-mixins/typography-nature.scss
@@ -1,0 +1,46 @@
+@mixin u-font-smoothing() {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+
+// Headings
+
+@mixin _heading-base() {
+	font-weight: $context--heading-font-weight;
+	@if $is-flagship-journal {
+		@include u-font-smoothing();
+		line-height: $context--heading-line-height;
+	}
+}
+
+@mixin u-h1() {
+	@include _heading-base();
+	font-size: $context--font-size-h1;
+	margin-bottom: spacing(24);
+	font-family: $font-family-serif;
+	font-weight: $context--heading-font-weight;
+}
+
+@mixin u-h2() {
+	@include _heading-base();
+	font-size: $context--font-size-h2;
+	margin-bottom: spacing(24);
+	font-family: $font-family-serif;
+	font-weight: $context--heading-font-weight;
+}
+
+@mixin u-h3() {
+	@include _heading-base();
+	font-size: $context--font-size-h3;
+	margin-bottom: spacing(16);
+	font-family: $font-family-serif;
+	font-weight: $context--heading-font-weight;
+}
+
+@mixin u-h4() {
+	@include _heading-base();
+	font-size: $context--font-size-h4;
+	margin-bottom: spacing(16);
+	font-family: $font-family-sans;
+	font-weight: $context--heading-font-weight;
+}

--- a/toolkits/nature/packages/nature-context/scss/40-base/typography-nature.scss
+++ b/toolkits/nature/packages/nature-context/scss/40-base/typography-nature.scss
@@ -18,22 +18,30 @@ ol {
 
 /*
  * Headings
- * classes used to maintain the semantically appropriate heading levels
- * NOT for use on non-headings
- * if additional headings are needed they should be created via
- * additional classes, never via location dependant styling
  */
 
-h5 {
-	font-size: 1.2rem;
+h1 {
+	@include u-h1();
 }
 
-h1,
-h2,
-h3,
+h2 {
+	@include u-h2();
+}
+
+h3 {
+	@include u-h3();
+}
+
+h4 {
+	@include u-h4();
+}
+
 h5 {
-	font-family: $font-family-serif;
-	font-weight: normal;
+	@include u-h4();
+}
+
+h6 {
+	@include u-h4();
 }
 
 p:empty {

--- a/toolkits/nature/packages/nature-context/scss/60-utilities/typography-nature.scss
+++ b/toolkits/nature/packages/nature-context/scss/60-utilities/typography-nature.scss
@@ -1,0 +1,20 @@
+/**
+ * Classes used to maintain the semantically appropriate heading levels
+ * NOT for use on non-headings
+ */
+
+.u-h1 {
+	@include u-h1();
+}
+
+.u-h2 {
+	@include u-h2();
+}
+
+.u-h3 {
+	@include u-h3();
+}
+
+.u-h4 {
+	@include u-h4();
+}


### PR DESCRIPTION
Heading styles applied via mixins.
`h4` is the final level. `h5` and `h6` are presentationally the same as `h4`.

Note: I could find anything that uses the `h5` tag in the html for Nature so it felt safe to remove.