### PR TITLE
Allow input rows to shrink as well as grow

### DIFF
--- a/toolkits/global/packages/global-forms/HISTORY.md
+++ b/toolkits/global/packages/global-forms/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 0.0.3 (2020-03-04)
+    * BUG: allow row items to shrink as well as grow
+
 ## 0.0.2 (2019-07-11)
     * a reminder about secure markup
 

--- a/toolkits/global/packages/global-forms/package.json
+++ b/toolkits/global/packages/global-forms/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@springernature/global-forms",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"license": "MIT",
 	"description": "form component",
 	"keywords": [

--- a/toolkits/global/packages/global-forms/scss/50-components/_global-forms.scss
+++ b/toolkits/global/packages/global-forms/scss/50-components/_global-forms.scss
@@ -13,7 +13,7 @@
 
 .c-input-row__item {
 	align-self: stretch;
-	flex: 1 0 auto;
+	flex: 1 1 auto;
 	padding-right: $global-form--grid-gutter-width / 2;
 	padding-left:  $global-form--grid-gutter-width / 2;
 }
@@ -42,7 +42,7 @@
 }
 
 .c-input-group__control {
-	@include global-form-input
+	@include global-form-input;
 
 	&--check {
 		width: auto;


### PR DESCRIPTION
Input row items were set to have the ability to grow but not shrink `flex: 1 0 auto`. This meant that on small screens the input boxes would exceed the width of the page. This updates row items to be able to shrink as well as grow `flex: 1 1 auto`.

## Before

![before](https://user-images.githubusercontent.com/853933/75875498-bb679380-5e0b-11ea-813c-e912548c783d.png)

## After

![after](https://user-images.githubusercontent.com/853933/75875511-c1f60b00-5e0b-11ea-9a87-909b601c8948.png)
