### PR TITLE
global-expander: Keyboard interaction fixes

### DIFF
--- a/toolkits/global/packages/global-expander/HISTORY.md
+++ b/toolkits/global/packages/global-expander/HISTORY.md
@@ -1,17 +1,18 @@
 # History
 
-## 0.3.0 (2020-01-06)
+## 0.3.1 (2020-03-06)
+    * Bug Fix: this._tabbableItems is null
+    * Bug Fix: Set focus back on trigger after tabbing out of the target
+    * Adds tests for keyboard interactions
 
+## 0.3.0 (2020-01-06)
     * Refactor for linting changes
 
 ## 0.2.0 (2019-12-04)
-
     * Add autofocus option
 
 ## 0.1.1 (2019-11-27)
-
     * Sets focus on first tabbable child of target when open
 
 ## 0.1.0 (2019-11-20)
-
     * Initial version

--- a/toolkits/global/packages/global-expander/js/expander.js
+++ b/toolkits/global/packages/global-expander/js/expander.js
@@ -18,6 +18,9 @@ const Expander = class {
 		this._triggerEl = trigger;
 		this._targetEl = target;
 		this._originalTriggerText = trigger.textContent;
+		this._targetTabbableItems = makeArray(target.querySelectorAll(
+			'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+		));
 
 		this._isOpen = false;
 
@@ -63,6 +66,7 @@ const Expander = class {
 			window.requestAnimationFrame(() => {
 				if (!this._targetTabbableItems.includes(document.activeElement)) {
 					this._close();
+					this._triggerEl.focus();
 				}
 			});
 		}
@@ -135,12 +139,8 @@ const Expander = class {
 		}
 
 		if (this._options.AUTOFOCUS) {
-			const tabbableItems = makeArray(this._targetEl.querySelectorAll(
-				'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-			));
-
-			if (tabbableItems.length > 0) {
-				const firstTabbableItem = tabbableItems[0];
+			if (this._targetTabbableItems.length > 0) {
+				const firstTabbableItem = this._targetTabbableItems[0];
 				firstTabbableItem.focus();
 
 				if (firstTabbableItem.setSelectionRange) {

--- a/toolkits/global/packages/global-expander/package.json
+++ b/toolkits/global/packages/global-expander/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-expander",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Frontend package for expanding a target when clicking a toggle",
   "license": "MIT",
   "peerDependencies": {


### PR DESCRIPTION
* Bug Fix: this._tabbableItems is null
* Bug Fix: Set focus back on trigger after tabbing out of the target
* Adds tests for keyboard interactions