### PR TITLE
Dropdown component accept array of classnames as option

### DIFF
--- a/toolkits/springer/packages/springer-dropdown/HISTORY.md
+++ b/toolkits/springer/packages/springer-dropdown/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 4.0.0 (2020-03-11)
+	* BREAKING: DROPDOWN_CLASS option now called DROPDOWN_CLASSES and can take multiple classnmes in an array
+
 ## 3.0.1 (2020-02-18)
 	* Use appendChild instead of append for IE support
 

--- a/toolkits/springer/packages/springer-dropdown/__tests__/unit/dropdown.spec.js
+++ b/toolkits/springer/packages/springer-dropdown/__tests__/unit/dropdown.spec.js
@@ -15,7 +15,7 @@ const selector = {
 const defaultOptions = {
 	BUTTON_CLASS: '',
 	CLICK_OUTSIDE: true,
-	DROPDOWN_CLASS: '',
+	DROPDOWN_CLASSES: [''],
 	HIDE_CLASS: 'u-hide',
 	HIDE_INITIALLY: true,
 	MENU_POSITION: 'left'
@@ -307,9 +307,9 @@ describe('springer-dropdown', () => {
 
 	describe('configuration options', () => {
 		describe('via function parameter', () => {
-			test('DROPDOWN_CLASS: Should add additional className to dropdown', () => {
+			test('DROPDOWN_CLASSES: Should add additional className to dropdown', () => {
 				// When
-				dropdown({DROPDOWN_CLASS: 'additional-dropdown-class'});
+				dropdown({DROPDOWN_CLASSES: ['additional-dropdown-class']});
 
 				// Then
 				expect(element.DROPDOWN.classList.contains('additional-dropdown-class')).toBe(true);
@@ -356,7 +356,7 @@ describe('springer-dropdown', () => {
 		});
 
 		describe('via data-* attributes', () => {
-			test('DROPDOWN_CLASS: Should add additional className to dropdown', () => {
+			test('DROPDOWN_CLASSES: Should add additional className to dropdown', () => {
 				// Given
 				element.BUTTON.setAttribute('data-dropdown-dropdown-class', 'additional-dropdown-class');
 

--- a/toolkits/springer/packages/springer-dropdown/__tests__/unit/dropdown.spec.js
+++ b/toolkits/springer/packages/springer-dropdown/__tests__/unit/dropdown.spec.js
@@ -1,6 +1,7 @@
 import {dropdown} from '../../js';
 import {Dropdown} from '../../js/dropdown';
 import {constants} from '../../js/constants';
+import classPrivateFieldLooseBase from "@babel/runtime/helpers/esm/classPrivateFieldLooseBase";
 
 /**
  * Local Constants
@@ -315,6 +316,15 @@ describe('springer-dropdown', () => {
 				expect(element.DROPDOWN.classList.contains('additional-dropdown-class')).toBe(true);
 			});
 
+			test('DROPDOWN_CLASSES: Should add additional classNames to dropdown if there are multiple', () => {
+				// When
+				dropdown({DROPDOWN_CLASSES: ['additional-dropdown-class', 'another-class']});
+
+				// Then
+				expect(element.DROPDOWN.classList.contains('additional-dropdown-class')).toBe(true);
+				expect(element.DROPDOWN.classList.contains('another-class')).toBe(true);
+			});
+
 			test('HIDE_INITIALLY: Should not initially add HIDE_CLASS className to menu when set to false', () => {
 				// When
 				dropdown({HIDE_INITIALLY: false});
@@ -365,6 +375,18 @@ describe('springer-dropdown', () => {
 
 				// Then
 				expect(element.DROPDOWN.classList.contains('additional-dropdown-class')).toBe(true);
+			});
+
+			test('DROPDOWN_CLASSES: Should add additional classNames to dropdown if there are multiple', () => {
+				// Given
+				element.BUTTON.setAttribute('data-dropdown-dropdown-class', 'additional-dropdown-class another-class');
+
+				// When
+				dropdown();
+
+				// Then
+				expect(element.DROPDOWN.classList.contains('additional-dropdown-class')).toBe(true);
+				expect(element.DROPDOWN.classList.contains('another-class')).toBe(true);
 			});
 
 			test('HIDE_INITIALLY: Should initially add HIDE_CLASS className to menu', () => {

--- a/toolkits/springer/packages/springer-dropdown/__tests__/unit/dropdown.spec.js
+++ b/toolkits/springer/packages/springer-dropdown/__tests__/unit/dropdown.spec.js
@@ -1,7 +1,6 @@
 import {dropdown} from '../../js';
 import {Dropdown} from '../../js/dropdown';
 import {constants} from '../../js/constants';
-import classPrivateFieldLooseBase from "@babel/runtime/helpers/esm/classPrivateFieldLooseBase";
 
 /**
  * Local Constants

--- a/toolkits/springer/packages/springer-dropdown/js/dropdown.js
+++ b/toolkits/springer/packages/springer-dropdown/js/dropdown.js
@@ -172,11 +172,13 @@ const Dropdown = class {
 		}
 
 		if (this._options.DROPDOWN_CLASSES.length > 0) {
-			this._options.DROPDOWN_CLASSES.forEach(classname => {
-				if (classname.length > 0) {
-					this._dropdownEl.classList.add(classname);
+			// for each classname passed in
+			for (let i = 0; i < this._options.DROPDOWN_CLASSES.length; i++) {
+				// if the classname is not blank
+				if (this._options.DROPDOWN_CLASSES[i].length > 0) {
+					this._dropdownEl.classList.add(this._options.DROPDOWN_CLASSES[i]);
 				}
-			});
+			}
 		}
 
 		if (this._options.MENU_POSITION === 'right') {

--- a/toolkits/springer/packages/springer-dropdown/js/dropdown.js
+++ b/toolkits/springer/packages/springer-dropdown/js/dropdown.js
@@ -11,7 +11,7 @@ const selector = {
 const defaultOptions = {
 	BUTTON_CLASS: '',
 	CLICK_OUTSIDE: true,
-	DROPDOWN_CLASS: '',
+	DROPDOWN_CLASSES: [''],
 	HIDE_CLASS: 'u-hide',
 	HIDE_INITIALLY: true,
 	MENU_POSITION: 'left'
@@ -171,8 +171,12 @@ const Dropdown = class {
 			this._menuEl.classList.add(this._options.HIDE_CLASS);
 		}
 
-		if (this._options.DROPDOWN_CLASS.length > 0) {
-			this._dropdownEl.classList.add(this._options.DROPDOWN_CLASS);
+		if (this._options.DROPDOWN_CLASSES.length > 0) {
+			this._options.DROPDOWN_CLASSES.forEach((classname) => {
+				if (classname.length > 0) {
+					this._dropdownEl.classList.add(classname);
+				}
+			})
 		}
 
 		if (this._options.MENU_POSITION === 'right') {

--- a/toolkits/springer/packages/springer-dropdown/js/dropdown.js
+++ b/toolkits/springer/packages/springer-dropdown/js/dropdown.js
@@ -172,11 +172,11 @@ const Dropdown = class {
 		}
 
 		if (this._options.DROPDOWN_CLASSES.length > 0) {
-			this._options.DROPDOWN_CLASSES.forEach((classname) => {
+			this._options.DROPDOWN_CLASSES.forEach(classname => {
 				if (classname.length > 0) {
 					this._dropdownEl.classList.add(classname);
 				}
-			})
+			});
 		}
 
 		if (this._options.MENU_POSITION === 'right') {

--- a/toolkits/springer/packages/springer-dropdown/js/index.js
+++ b/toolkits/springer/packages/springer-dropdown/js/index.js
@@ -6,7 +6,7 @@ import {Dropdown} from './dropdown';
  * Data Attribute API
  */
 const attributes = {
-	DROPDOWN_CLASSES: [constants.DATA_COMPONENT + '-dropdown-class'],
+	DROPDOWN_CLASSES: constants.DATA_COMPONENT + '-dropdown-class',
 	HIDE_CLASS: constants.DATA_COMPONENT + '-hide-class',
 	HIDE_INITIALLY: constants.DATA_COMPONENT + '-hide-initially',
 	CLICK_OUTSIDE: constants.DATA_COMPONENT + '-click-outside'
@@ -20,6 +20,9 @@ const dropdown = (options = {}) => {
 
 	makeArray(buttons).forEach(button => {
 		const dataOptions = getDataOptions(button, attributes);
+		if (dataOptions.DROPDOWN_CLASSES) {
+			dataOptions.DROPDOWN_CLASSES = dataOptions.DROPDOWN_CLASSES.split(' ') || [dataOptions.DROPDOWN_CLASSES];
+		}
 		const dropdown = new Dropdown(button, Object.assign({}, options, dataOptions));
 		dropdown.init();
 	});

--- a/toolkits/springer/packages/springer-dropdown/js/index.js
+++ b/toolkits/springer/packages/springer-dropdown/js/index.js
@@ -6,7 +6,7 @@ import {Dropdown} from './dropdown';
  * Data Attribute API
  */
 const attributes = {
-	DROPDOWN_CLASS: constants.DATA_COMPONENT + '-dropdown-class',
+	DROPDOWN_CLASSES: [constants.DATA_COMPONENT + '-dropdown-class'],
 	HIDE_CLASS: constants.DATA_COMPONENT + '-hide-class',
 	HIDE_INITIALLY: constants.DATA_COMPONENT + '-hide-initially',
 	CLICK_OUTSIDE: constants.DATA_COMPONENT + '-click-outside'

--- a/toolkits/springer/packages/springer-dropdown/package.json
+++ b/toolkits/springer/packages/springer-dropdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-dropdown",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "license": "MIT",
   "description": "Display a contextual list of links controlled by a toggle",
   "keywords": [],


### PR DESCRIPTION
Rather than limiting the dropdown component to only allow one classname to be added when passing in options, you can now pass in an array of classnames should you need.

This is needed in Springer where I will be making multiple dropdowns and they require 2 classnames each.