### PR TITLE
nature-context: Changes to nature headings

### DIFF
--- a/toolkits/nature/packages/nature-context/HISTORY.md
+++ b/toolkits/nature/packages/nature-context/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 0.32.3 (2020-03-18)
+    * Increase font sizes and reduce margins on headings in accordance with brand
+
 ## 0.32.2 (2020-03-11)
     * Update open access color to improve contrast
     * Bump global-context to 14.2.1

--- a/toolkits/nature/packages/nature-context/package.json
+++ b/toolkits/nature/packages/nature-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/nature-context",
-  "version": "0.32.2",
+  "version": "0.32.3",
   "license": "MIT",
   "description": "Boostrapping for all Nature components and products",
   "keywords": [],

--- a/toolkits/nature/packages/nature-context/scss/10-settings/typography-nature.scss
+++ b/toolkits/nature/packages/nature-context/scss/10-settings/typography-nature.scss
@@ -12,5 +12,5 @@ $context--heading-line-height: 1.3;
 
 $context--font-size-h1: if($is-flagship-journal, 3.2rem, 3rem);
 $context--font-size-h2: 2.4rem;
-$context--font-size-h3: if($is-flagship-journal, 1.9rem, 1.7rem);
-$context--font-size-h4: if($is-flagship-journal, 1.7rem, 1.4rem);
+$context--font-size-h3: if($is-flagship-journal, 2rem, 1.7rem);
+$context--font-size-h4: if($is-flagship-journal, 1.8rem, 1.4rem);

--- a/toolkits/nature/packages/nature-context/scss/30-mixins/typography-nature.scss
+++ b/toolkits/nature/packages/nature-context/scss/30-mixins/typography-nature.scss
@@ -24,7 +24,7 @@
 @mixin u-h2() {
 	@include _heading-base();
 	font-size: $context--font-size-h2;
-	margin-bottom: spacing(24);
+	margin-bottom: spacing(8);
 	font-family: $font-family-serif;
 	font-weight: $context--heading-font-weight;
 }
@@ -32,7 +32,7 @@
 @mixin u-h3() {
 	@include _heading-base();
 	font-size: $context--font-size-h3;
-	margin-bottom: spacing(16);
+	margin-bottom: spacing(8);
 	font-family: $font-family-serif;
 	font-weight: $context--heading-font-weight;
 }
@@ -40,7 +40,7 @@
 @mixin u-h4() {
 	@include _heading-base();
 	font-size: $context--font-size-h4;
-	margin-bottom: spacing(16);
+	margin-bottom: spacing(8);
 	font-family: $font-family-sans;
 	font-weight: $context--heading-font-weight;
 }


### PR DESCRIPTION
For _reasons_ the margins need to be much smaller for headings.
Sizes for smaller headings are bumped a bit.