### PR TITLE
convert reading companion to use module.exports and add tests and export

### DIFF
--- a/toolkits/global/packages/global-article/HISTORY.md
+++ b/toolkits/global/packages/global-article/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 15.0.0 (2019-03-20)
+	* Convert `ReadingCompanion` to use `module.exports` and add unit tests for it
+
 ## 14.0.0 (2019-03-17)
 	* Remove `TabGroup` and associated styles, it's no longer used
 

--- a/toolkits/global/packages/global-article/__tests__/reading-companion.js
+++ b/toolkits/global/packages/global-article/__tests__/reading-companion.js
@@ -187,7 +187,7 @@ describe('Reading Companion', () => {
 		expect(tabs.children.length).toBe(3);
 	});
 
-	test('Should set sections as default active tab', () => {
+	test('Should set sections as the default active tab', () => {
 		includeMockFigures();
 		includeMockReferences();
 		initReadingCompanion();
@@ -197,7 +197,7 @@ describe('Reading Companion', () => {
 		expect(tabs.querySelector('[data-tab-target="sections"]').getAttribute('aria-selected')).toBe('true');
 	});
 
-	test('Should create list of items which contains a anchor element to the existing abstract section', () => {
+	test('Should create a list of items which contains an anchor element to the existing abstract section', () => {
 		initReadingCompanion();
 		const sections = readingCompanionContainer.querySelector('.c-reading-companion__sections-list');
 
@@ -205,7 +205,7 @@ describe('Reading Companion', () => {
 		expect(document.querySelector('.c-reading-companion__sections-list').firstElementChild.textContent).toBe('Abstract');
 	});
 
-	test('Should create list of items with existent figures', () => {
+	test('Should create a list of items with existent figures', () => {
 		includeMockFigures();
 		initReadingCompanion();
 
@@ -256,7 +256,7 @@ describe('Reading Companion', () => {
 		expect(figures.firstElementChild.querySelector('.c-reading-companion__figure-full-link').textContent).toBe('Full size image');
 	});
 
-	test('Should create list of items with existent references and its corresponding related info when references exist', () => {
+	test('Should create a list of items with existent references and its corresponding related info', () => {
 		includeMockReferences();
 		initReadingCompanion();
 
@@ -267,7 +267,7 @@ describe('Reading Companion', () => {
 		expect(references.firstElementChild.querySelector('.c-reading-companion__reference-links')).not.toBeNull();
 	});
 
-	test('Should move the active tab to the last when keydown is 37', () => {
+	test('Should move the active tab to the last when typing on the left arrow key', () => {
 		includeMockReferences();
 		includeMockFigures();
 		initReadingCompanion();
@@ -282,7 +282,7 @@ describe('Reading Companion', () => {
 		expect(lastTab.classList.contains('c-reading-companion__tab--active')).toBeTruthy();
 	});
 
-	test('Should move the active tab to the previous element sibling if there is an active element', () => {
+	test('Should move the active tab to the previous sibling element if there is an active element', () => {
 		includeMockReferences();
 		includeMockFigures();
 		initReadingCompanion();		
@@ -300,7 +300,7 @@ describe('Reading Companion', () => {
 		expect(tabs.querySelector('[data-tab-target="figures"]').getAttribute('aria-selected')).toBe('true');
 	});
 	
-	test('Should move the active tab to the first when keydown is 39', () => {
+	test('Should move the active tab to the first when typing on the right arrow key', () => {
 		includeMockReferences();
 		includeMockFigures();
 		initReadingCompanion();
@@ -315,7 +315,7 @@ describe('Reading Companion', () => {
 		expect(firstTab.classList.contains('c-reading-companion__tab--active')).toBeTruthy();
 	});
 
-	test('Should move the active tab to the next element sibling if there is an active element', () => {
+	test('Should move the active tab to the next sibling element if there is an active element', () => {
 		includeMockReferences();
 		includeMockFigures();
 		initReadingCompanion();		
@@ -357,7 +357,7 @@ describe('Reading Companion', () => {
 		expect(document.querySelector('#rc-sec-Sec1').classList.contains('c-reading-companion__section-item--active')).toBeTruthy();
 	});
 
-	test('Should switch to figure tab and focus on the selected figure when clicking on a figure link', () => {
+	test('Should switch to the figure tab and focus on the selected figure when clicking on a figure link', () => {
 		includeMockFigures();
 		addFigLinkSection();
 		initReadingCompanion();
@@ -377,7 +377,7 @@ describe('Reading Companion', () => {
 		expect(selectedFigure.scrollIntoView).toHaveBeenCalledWith({block: 'start'});
 	});
 
-	test('Should switch to reference tab and focus on the selected reference when clicking on a reference link', () => {
+	test('Should switch to the references tab and focus on the selected reference when clicking on a reference link', () => {
 		// TODO: add more tests for insertReturnButton function
 		includeMockReferences();
 		initReadingCompanion();

--- a/toolkits/global/packages/global-article/__tests__/reading-companion.js
+++ b/toolkits/global/packages/global-article/__tests__/reading-companion.js
@@ -79,13 +79,8 @@ describe('Reading Companion', () => {
 			writable: true,
 			value: jest.fn().mockImplementation(query => ({
 			  matches: false,
-			  media: query,
-			  onchange: null,
 			  addListener: jest.fn(),
-			  removeListener: jest.fn(),
-			  addEventListener: jest.fn(),
-			  removeEventListener: jest.fn(),
-			  dispatchEvent: jest.fn(),
+			  removeListener: jest.fn()
 			})),
 		  });
 	}
@@ -383,6 +378,7 @@ describe('Reading Companion', () => {
 	});
 
 	test('Should switch to reference tab and focus on the selected reference when clicking on a reference link', () => {
+		// TODO: add more tests for insertReturnButton function
 		includeMockReferences();
 		initReadingCompanion();
 
@@ -394,6 +390,5 @@ describe('Reading Companion', () => {
 		emitter.emit('nav.reference', 'ref-CR1', null);
 
 		expect(referencesTab.getAttribute('aria-selected')).toBe('true');
-
 	});
 });

--- a/toolkits/global/packages/global-article/__tests__/reading-companion.js
+++ b/toolkits/global/packages/global-article/__tests__/reading-companion.js
@@ -19,61 +19,6 @@ describe('Reading Companion', () => {
 		readingCompanion.init(config, scheduler, emitter);
 	}
 
-	function includeMockFigures() {
-		// figure in the content
-		const figureHTML = `<section>
-			<div class="c-article-section__figure js-c-reading-companion-figures-item">
-				<figure>
-					<figcaption>
-						<b id="Fig2" class="c-article-section__figure-caption">Fig 2</b>
-					</figcaption>
-					<div>
-						<div class="c-article-section__figure-item">
-							<a class="c-article-section__figure-link" href="/fig2">
-								<picture>
-									<source type="image/webp" srcset="//media.springernature.com/41586_2020_2068_Fig2_HTML.png">
-									<img src="//media.springernature.com/41586_2020_2068_Fig2_HTML.png" alt="figure2">
-								</picture>
-							</a>
-						</div>
-					</div>
-					<a class="c-article__pill-button" href="/articles/s41586-020-2068-4/figures/1">Full size image</a>
-			</div>
-		</section>`;
-
-		document.querySelector('section').insertAdjacentHTML('afterend', figureHTML);
-	}
-
-	function includeMockReferences() {
-		const referencesHTML = `<section>
-			<div class="c-article-section__references">
-				<ol class="c-article-references">
-					<li class="c-article-references__item js-c-reading-companion-references-item">
-						<span class="c-article-references__counter">1.</span>
-						<a href="#ref-CR1" class="c-article-references__text" id="ref-CR1">Link</a>
-						<ul class="c-article-references__links u-hide-print">
-							<li><a href="http://link">ADS</a></li>
-							<li><a href="http://link">PubMed</a></li>
-							<li><a href="http://link">Google Scholar</a></li>
-						</ul>
-					</li>
-				</ol>
-			</div>
-		</section>`;
-
-		document.querySelector('section').insertAdjacentHTML('afterend', referencesHTML);
-	}
-
-	function includeExtendedFiguresWithSupplementary() {
-		const supplementaryHTML = `<div class="c-article-supplementary__item js-c-reading-companion-figures-item" id="Fig4">
-			<h3 class="c-article-supplementary__title u-h3">
-				<a href="/articles/s41586-020-2087-1/figures/4" data-supp-info-image="41586_2020_2087_Fig4_ESM.jpg">Extended Data Fig. 1</a>
-			</h3>
-		</div>`;
-
-		document.querySelector('section').insertAdjacentHTML('afterend', supplementaryHTML);
-	}
-
 	function mockWindow() {
 		Object.defineProperty(window, 'matchMedia', {
 			writable: true,
@@ -85,43 +30,24 @@ describe('Reading Companion', () => {
 		  });
 	}
 
-	function overrideHeadingToNotAllowCharacters() {
-		document.querySelector('.c-article-section__title').textContent = '%Ab_s!tract';
-	}
-
-	function addBackgroundSection() {
-		const backgroundSection = `<section>
-			<div class="c-article-section" id="Sec1-section">
-				<h2 class="c-article-section__title u-h2 js-section-title js-c-reading-companion-sections-item" id="Sec1" tabindex="-1">Background</h2>
-				<div class="c-article-section__content" id="Sec1-content">
-					<p>This is the content.</p>
-				</div>
-			</div>
-		</section>`;
-
-		document.querySelector('[data-component="article-container"] section').insertAdjacentHTML('afterend', backgroundSection);
-	}
-
-	function addFigLinkSection() {
-		const figLinkSection = `<section>
-			<h2 class="js-section-title" id="method">Method</h2>
-			<p>Method <a href="#Fig2" id="fig-link2">2</a></p>
-		</section>`;
-
-		document.querySelector('[data-component="article-container"] section').insertAdjacentHTML('afterend', figLinkSection);
-	}
-
 	beforeEach(() => {
-		document.documentElement.innerHTML = `
-			<head></head>
+		document.body.innerHTML = `
 			<body>
 				<div data-component="article-container">
-					<section aria-labelledby="Abs1">
+					<section>
+						<h2 class="js-section-title">Method</h2>
+						<p>Method <a href="#Fig2" id="fig-link2">2</a></p>
+					</section>
+					<section>
 						<div class="c-article-section" id="Abs1-section">
 							<h2 class="c-article-section__title u-h2 js-section-title js-c-reading-companion-sections-item" id="Abs1">Abstract</h2>
 						</div>
 					</section>
-
+					<section>
+						<div class="c-article-section" id="Sec1-section">
+							<h2 class="c-article-section__title u-h2 js-section-title js-c-reading-companion-sections-item" id="Sec1">Background</h2>
+						</div>
+					</section>
 					<div class="c-reading-companion">
 						<div class="c-reading-companion__sticky" data-component="reading-companion-sticky">
 							<div class="c-reading-companion__panel c-reading-companion__sections c-reading-companion__panel--active" id="tabpanel-sections">
@@ -151,244 +77,304 @@ describe('Reading Companion', () => {
 		document.body.innerHTML = null;
 	});
 
-	test('Should be able to initiate the reading companion', () => {
-		initReadingCompanion();
-		expect(readingCompanion.init).toBeDefined();
-	});
-	
-	test('Should set and define the content container for the sections tab', () => {
-		initReadingCompanion();
+	describe('When no existing figures or references', () => {
+		function overrideHeadingToNotAllowCharacters() {
+			document.querySelector('.c-article-section__title').textContent = '%Ab_s!tract';
+		}
+
+		test('Should be able to initiate the reading companion', () => {
+			initReadingCompanion();
+			expect(readingCompanion.init).toBeDefined();
+		});
 		
-		expect(readingCompanionContainer.querySelector('.c-reading-companion__scroll-pane')).toBeDefined();
-		expect(readingCompanionContainer.querySelector('.c-reading-companion__sections').getAttribute('aria-labelledby')).toBeDefined();
-		expect(readingCompanionContainer.querySelector('.c-reading-companion__sections').getAttribute('aria-labelledby')).toBe('tab-sections');
-	});
-	test('Should remove non text and numbers from the heading before adding the data-track-label', () => {
-		overrideHeadingToNotAllowCharacters();
-		initReadingCompanion();
+		test('Should set and define the content container for the sections tab', () => {
+			initReadingCompanion();
+			
+			expect(readingCompanionContainer.querySelector('.c-reading-companion__scroll-pane')).toBeDefined();
 
-		const firstSection = document.querySelector('.c-reading-companion__sections-list').firstElementChild;
-		expect(firstSection.querySelector('a').getAttribute('data-track-label')).toBe('link:Abstract');
-	});
+			const ariaLabelledbyAttribute = readingCompanionContainer.querySelector('.c-reading-companion__sections').getAttribute('aria-labelledby');
+			
+			expect(ariaLabelledbyAttribute).not.toBeNull();
+			expect(ariaLabelledbyAttribute).toBe('tab-sections');
+		});
 
-	test('Should create only a heading Section when nor figures nor references', () => {
-		initReadingCompanion();
-		expect(document.querySelector('.c-reading-companion__heading')).toBeDefined();
-		expect(document.querySelector('.c-reading-companion__tabs')).toBeNull();
-	});
-
-	test('Should create a set of tabs for each section when they exist', () => {
-		includeMockFigures();
-		includeMockReferences();
-		initReadingCompanion();
-
-		const tabs = readingCompanionContainer.querySelector('.c-reading-companion__tabs');
-		expect(tabs).not.toBeNull();
-		expect(tabs.children.length).toBe(3);
-	});
-
-	test('Should set sections as the default active tab', () => {
-		includeMockFigures();
-		includeMockReferences();
-		initReadingCompanion();
-
-		const tabs = readingCompanionContainer.querySelector('.c-reading-companion__tabs');
-
-		expect(tabs.querySelector('[data-tab-target="sections"]').getAttribute('aria-selected')).toBe('true');
-	});
-
-	test('Should create a list of items which contains an anchor element to the existing abstract section', () => {
-		initReadingCompanion();
-		const sections = readingCompanionContainer.querySelector('.c-reading-companion__sections-list');
-
-		expect(sections).not.toBeNull();
-		expect(document.querySelector('.c-reading-companion__sections-list').firstElementChild.textContent).toBe('Abstract');
-	});
-
-	test('Should create a list of items with existent figures', () => {
-		includeMockFigures();
-		initReadingCompanion();
-
-		const figures = readingCompanionContainer.querySelector('.c-reading-companion__figures-list');
-
-		expect(figures).not.toBeNull();
-		expect(document.querySelector('.c-reading-companion__figures-list').children.length).toBe(1);
-	});
-
-	test('Should generate a figure element and its corresponding related info when figures exist', () => {
-		includeMockFigures();
-		initReadingCompanion();
-
-		const figures = readingCompanionContainer.querySelector('.c-reading-companion__figures-list');
-		expect(figures.firstElementChild.querySelector('figure')).not.toBeNull();
-		expect(figures.firstElementChild.querySelector('figcaption')).not.toBeNull();
-		expect(figures.firstElementChild.querySelector('picture')).not.toBeNull();
-		expect(figures.firstElementChild.querySelector('.c-reading-companion__figure-links')).not.toBeNull();
-	});
-
-	test('Should add a supplementary info when available ', () => {
-		includeExtendedFiguresWithSupplementary();
-		initReadingCompanion();
-		const figureTitle = document.querySelector('.c-reading-companion__figure-title');
-		const figures = readingCompanionContainer.querySelector('.c-reading-companion__figures-list');
-
-		expect(figureTitle.textContent.length > 0).toBeTruthy();
-		expect(figureTitle.getAttribute('id')).not.toBeNull();
-		expect(figures.firstElementChild.querySelector('a')).not.toBeNull();
-		expect(figures.firstElementChild.querySelector('picture')).not.toBeNull();
-		expect(figures.firstElementChild.querySelector('picture > img')).not.toBeNull();
-	});
-
-	test('Should add a link to the full width version in a supplementary info ', () => {
-		includeExtendedFiguresWithSupplementary();
-		initReadingCompanion({access: true});
-		const figures = readingCompanionContainer.querySelector('.c-reading-companion__figures-list');
-
-		expect(figures.firstElementChild.querySelector('.c-reading-companion__figure-full-link')).not.toBeNull();
-	});
-
-	test('Should generate a full size image link on the figure content when has access ', () => {
-		includeMockFigures();
-		initReadingCompanion({ access: true });
-
-		const figures = readingCompanionContainer.querySelector('.c-reading-companion__figures-list');
-		expect(figures.firstElementChild.querySelector('.c-reading-companion__figure-full-link')).not.toBeNull();
-		expect(figures.firstElementChild.querySelector('.c-reading-companion__figure-full-link').textContent).toBe('Full size image');
-	});
-
-	test('Should create a list of items with existent references and its corresponding related info', () => {
-		includeMockReferences();
-		initReadingCompanion();
-
-		const references = readingCompanionContainer.querySelector('.c-reading-companion__references-list');
-
-		expect(references).not.toBeNull();
-		expect(references.children.length).toBe(1);
-		expect(references.firstElementChild.querySelector('.c-reading-companion__reference-links')).not.toBeNull();
-	});
-
-	test('Should move the active tab to the last when typing on the left arrow key', () => {
-		includeMockReferences();
-		includeMockFigures();
-		initReadingCompanion();
-
-		const tabs = document.querySelector('.c-reading-companion__tabs');
-		const lastTab = tabs.querySelector('.c-reading-companion__tabs > li:last-child button');
-		const event = new KeyboardEvent('keydown', {'keyCode': 37});
-
-		tabs.dispatchEvent(event);
-
-		expect(lastTab.getAttribute('aria-selected')).toBe('true');
-		expect(lastTab.classList.contains('c-reading-companion__tab--active')).toBeTruthy();
-	});
-
-	test('Should move the active tab to the previous sibling element if there is an active element', () => {
-		includeMockReferences();
-		includeMockFigures();
-		initReadingCompanion();		
-
-		const tabs = document.querySelector('.c-reading-companion__tabs');
-		const lastTab = tabs.querySelector('.c-reading-companion__tabs > li:last-child button');
-		const event = new KeyboardEvent('keydown', {'keyCode': 37});
-
-		tabs.dispatchEvent(event);
-
-		expect(lastTab.getAttribute('aria-selected')).toBe('true');
-
-		tabs.dispatchEvent(event);
-
-		expect(tabs.querySelector('[data-tab-target="figures"]').getAttribute('aria-selected')).toBe('true');
-	});
+		test('Should remove non text and numbers from the heading before adding the data-track-label', () => {
+			overrideHeadingToNotAllowCharacters();
+			initReadingCompanion();
 	
-	test('Should move the active tab to the first when typing on the right arrow key', () => {
-		includeMockReferences();
-		includeMockFigures();
-		initReadingCompanion();
+			const firstSection = readingCompanionContainer.querySelector('.c-reading-companion__sections-list').firstElementChild;
 
-		const tabs = document.querySelector('.c-reading-companion__tabs');
-		const firstTab = tabs.querySelector('.c-reading-companion__tabs > li:first-child button');
-		const event = new KeyboardEvent('keydown', {'keyCode': 39});
+			expect(firstSection.querySelector('a').getAttribute('data-track-label')).toBe('link:Abstract');
+		});
+	
+		test('Should create only a heading Section', () => {
+			initReadingCompanion();
 
-		tabs.dispatchEvent(event);
+			expect(document.querySelector('.c-reading-companion__heading')).not.toBeNull();
+			expect(document.querySelector('.c-reading-companion__tabs')).toBeNull();
+		});
+	
+		test('Should create a list of items which contains an anchor element to the existing abstract section', () => {
+			initReadingCompanion();
 
-		expect(firstTab.getAttribute('aria-selected')).toBe('true');
-		expect(firstTab.classList.contains('c-reading-companion__tab--active')).toBeTruthy();
+			const sections = readingCompanionContainer.querySelector('.c-reading-companion__sections-list');
+	
+			expect(sections).not.toBeNull();
+			expect(sections.firstElementChild.textContent).toBe('Abstract');
+		});
 	});
 
-	test('Should move the active tab to the next sibling element if there is an active element', () => {
-		includeMockReferences();
-		includeMockFigures();
-		initReadingCompanion();		
+	describe('When existing figures and references', () => {
+		let tabs = null;
+		let firstTab = null;
+		let lastTab = null;
+		let event = null;
 
-		const tabs = document.querySelector('.c-reading-companion__tabs');
-		const firstTab = tabs.querySelector('.c-reading-companion__tabs > li:first-child button');
-		const event = new KeyboardEvent('keydown', {'keyCode': 39});
+		function includeMockFigures() {
+			// figure in the content
+			const figureHTML = `<section>
+				<div class="c-article-section__figure js-c-reading-companion-figures-item">
+					<figure>
+						<figcaption>
+							<b id="Fig2" class="c-article-section__figure-caption">Fig 2</b>
+						</figcaption>
+						<div>
+							<div class="c-article-section__figure-item">
+								<a class="c-article-section__figure-link" href="/fig2">
+									<picture>
+										<source type="image/webp" srcset="//media.springernature.com/41586_2020_2068_Fig2_HTML.png">
+										<img src="//media.springernature.com/41586_2020_2068_Fig2_HTML.png" alt="figure2">
+									</picture>
+								</a>
+							</div>
+						</div>
+						<a class="c-article__pill-button" href="/articles/s41586-020-2068-4/figures/1">Full size image</a>
+				</div>
+			</section>`;
+	
+			document.querySelector('section').insertAdjacentHTML('afterend', figureHTML);
+		}
+	
+		function includeMockReferences() {
+			const referencesHTML = `<section>
+				<div class="c-article-section__references">
+					<ol class="c-article-references">
+						<li class="c-article-references__item js-c-reading-companion-references-item">
+							<span class="c-article-references__counter">1.</span>
+							<a href="#ref-CR1" class="c-article-references__text" id="ref-CR1">Link</a>
+							<ul class="c-article-references__links u-hide-print">
+								<li><a href="http://link">ADS</a></li>
+								<li><a href="http://link">PubMed</a></li>
+								<li><a href="http://link">Google Scholar</a></li>
+							</ul>
+						</li>
+					</ol>
+				</div>
+			</section>`;
+	
+			document.querySelector('section').insertAdjacentHTML('afterend', referencesHTML);
+		}
 
-		tabs.dispatchEvent(event);
+		function includeExtendedFiguresWithSupplementary() {
+			const supplementaryHTML = `<div class="c-article-supplementary__item js-c-reading-companion-figures-item" id="Fig4">
+				<h3 class="c-article-supplementary__title u-h3">
+					<a href="/articles/s41586-020-2087-1/figures/4" data-supp-info-image="41586_2020_2087_Fig4_ESM.jpg">Extended Data Fig. 1</a>
+				</h3>
+			</div>`;
 
-		expect(firstTab.getAttribute('aria-selected')).toBe('true');
+			document.querySelector('section').insertAdjacentHTML('afterend', supplementaryHTML);
+		}
 
-		tabs.dispatchEvent(event);
+		function setUpInteractionTabs(key) {
+			tabs = document.querySelector('.c-reading-companion__tabs');
+			firstTab = tabs.querySelector('.c-reading-companion__tabs > li:first-child button');
+			lastTab = tabs.querySelector('.c-reading-companion__tabs > li:last-child button');
+			event = new KeyboardEvent('keydown', {'keyCode': key});
+	
+			tabs.dispatchEvent(event);
+		}
 
-		expect(tabs.querySelector('[data-tab-target="figures"]').getAttribute('aria-selected')).toBe('true');
-	});
+		beforeEach(() => {
+			includeMockFigures();
+			includeMockReferences();
+		});
 
-	test('Should move the active tab to the one is clicked on', () => {
-		includeMockReferences();
-		includeMockFigures();
-		initReadingCompanion();
+		afterEach(() => {
+			tabs = null;
+			firstTab = null;
+			lastTab = null;
+			event = null;
+		})
+	
+		test('Should create a set of tabs for each section of the sections', () => {
+			initReadingCompanion();
 
-		const referencesTab = document.querySelector('[data-tab-target="references"]');
+			const tabs = readingCompanionContainer.querySelector('.c-reading-companion__tabs');
 
-		referencesTab.click();
-		expect(referencesTab.getAttribute('aria-selected')).toBe("true");
-	});
+			expect(tabs).not.toBeNull();
+			expect(tabs.children.length).toBe(3);
+		});
+	
+		test('Should set sections as the default active tab', () => {
+			initReadingCompanion();
 
-	test('Should update the active section on a new selection', () => {
-		addBackgroundSection();
-		initReadingCompanion();
-		emitter.emit('nav.section', 'Abs1', null);
+			const tabs = readingCompanionContainer.querySelector('.c-reading-companion__tabs');
+	
+			expect(tabs.querySelector('[data-tab-target="sections"]').getAttribute('aria-selected')).toBe('true');
+		});
 
-		expect(document.querySelector('#rc-sec-Abs1').classList.contains('c-reading-companion__section-item--active')).toBeTruthy();
+		test('Should create a list of items with existent figures', () => {
+			initReadingCompanion();
+
+			const figures = readingCompanionContainer.querySelector('.c-reading-companion__figures-list');
+	
+			expect(figures).not.toBeNull();
+			expect(figures.children.length).toBe(1);
+		});
+	
+		test('Should generate a figure element and its corresponding related info', () => {
+			initReadingCompanion();
+
+			const figures = readingCompanionContainer.querySelector('.c-reading-companion__figures-list');
+
+			expect(figures.firstElementChild.querySelector('figure')).not.toBeNull();
+			expect(figures.firstElementChild.querySelector('figcaption')).not.toBeNull();
+			expect(figures.firstElementChild.querySelector('picture')).not.toBeNull();
+			expect(figures.firstElementChild.querySelector('.c-reading-companion__figure-links')).not.toBeNull();
+		});
+
+		test('Should generate a full size image link on the figure content when has access ', () => {
+			initReadingCompanion({ access: true });
+	
+			const figures = readingCompanionContainer.querySelector('.c-reading-companion__figures-list');
+	
+			expect(figures.firstElementChild.querySelector('.c-reading-companion__figure-full-link')).not.toBeNull();
+			expect(figures.firstElementChild.querySelector('.c-reading-companion__figure-full-link').textContent).toBe('Full size image');
+		});
+	
+		test('Should create a list of items with existent references and its corresponding related info', () => {
+			initReadingCompanion();
+	
+			const references = readingCompanionContainer.querySelector('.c-reading-companion__references-list');
+	
+			expect(references).not.toBeNull();
+			expect(references.children.length).toBe(1);
+			expect(references.firstElementChild.querySelector('.c-reading-companion__reference-links')).not.toBeNull();
+		});
+	
+		test('Should add a supplementary info when available ', () => {
+			includeExtendedFiguresWithSupplementary();
+			initReadingCompanion();
+	
+			const figureTitle = document.querySelector('.c-reading-companion__figure-title');
+			const figures = readingCompanionContainer.querySelector('.c-reading-companion__figures-list');
+	
+			expect(figureTitle.textContent.length > 0).toBeTruthy();
+			expect(figureTitle.getAttribute('id')).not.toBeNull();
+			expect(figures.firstElementChild.querySelector('a')).not.toBeNull();
+			expect(figures.firstElementChild.querySelector('picture')).not.toBeNull();
+			expect(figures.firstElementChild.querySelector('picture > img')).not.toBeNull();
+		});
+	
+		test('Should add a link to the full width version in a supplementary info ', () => {
+			includeExtendedFiguresWithSupplementary();
+			initReadingCompanion({access: true});
+	
+			const figures = readingCompanionContainer.querySelector('.c-reading-companion__figures-list');
+	
+			expect(figures.firstElementChild.querySelector('.c-reading-companion__figure-full-link')).not.toBeNull();
+		});
+	
+		test('Should move the active tab to the last when typing on the left arrow key', () => {
+			initReadingCompanion();
+			setUpInteractionTabs(37);
+	
+			expect(lastTab.getAttribute('aria-selected')).toBe('true');
+			expect(lastTab.classList.contains('c-reading-companion__tab--active')).toBeTruthy();
+		});
+	
+		test('Should move the active tab to the previous sibling element if there is an active element', () => {
+			initReadingCompanion();
+			setUpInteractionTabs(37);
+
+			expect(lastTab.getAttribute('aria-selected')).toBe('true');
+	
+			tabs.dispatchEvent(event);
+	
+			expect(tabs.querySelector('[data-tab-target="figures"]').getAttribute('aria-selected')).toBe('true');
+		});
 		
-		emitter.emit('nav.section', 'Sec1', 'Abs1');
+		test('Should move the active tab to the first when typing on the right arrow key', () => {
+			initReadingCompanion();
+			setUpInteractionTabs(39);
+	
+			expect(firstTab.getAttribute('aria-selected')).toBe('true');
+			expect(firstTab.classList.contains('c-reading-companion__tab--active')).toBeTruthy();
+		});
+	
+		test('Should move the active tab to the next sibling element if there is an active element', () => {
+			initReadingCompanion();		
+			setUpInteractionTabs(39);
+	
+			expect(firstTab.getAttribute('aria-selected')).toBe('true');
+	
+			tabs.dispatchEvent(event);
+	
+			expect(tabs.querySelector('[data-tab-target="figures"]').getAttribute('aria-selected')).toBe('true');
+		});
+	
+		test('Should move the active tab to the one is clicked on', () => {
+			initReadingCompanion();
+	
+			const referencesTab = document.querySelector('[data-tab-target="references"]');
+	
+			referencesTab.click();
+			expect(referencesTab.getAttribute('aria-selected')).toBe("true");
+		});
+	
+		test('Should update the active section on a new selection', () => {
+			initReadingCompanion();
+	
+			emitter.emit('nav.section', 'Abs1', null);
+	
+			expect(document.querySelector('#rc-sec-Abs1').classList.contains('c-reading-companion__section-item--active')).toBeTruthy();
+			
+			emitter.emit('nav.section', 'Sec1', 'Abs1');
+	
+			expect(document.querySelector('#rc-sec-Abs1').classList.contains('c-reading-companion__section-item--active')).toBeFalsy();
+			expect(document.querySelector('#rc-sec-Sec1').classList.contains('c-reading-companion__section-item--active')).toBeTruthy();
+		});
+	
+		test('Should switch to the figure tab and focus on the selected figure when clicking on a figure link', () => {
+			initReadingCompanion();
 
-		expect(document.querySelector('#rc-sec-Abs1').classList.contains('c-reading-companion__section-item--active')).toBeFalsy();
-		expect(document.querySelector('#rc-sec-Sec1').classList.contains('c-reading-companion__section-item--active')).toBeTruthy();
-	});
+			const figureTab = document.querySelector('#tab-figures');
+			const selectedFigure = document.querySelector('#rc-Fig2');
+	
+			selectedFigure.scrollIntoView = jest.fn();
+			selectedFigure.addEventListener = jest.fn();
+			emitter.emit('nav.figure', 'Fig2', null);
+	
+			expect(figureTab.getAttribute('aria-selected')).toBe('true');
+			expect(figureTab.classList.contains('c-reading-companion__tab--active')).toBeTruthy();
+			expect(selectedFigure.getAttribute('tabindex')).toBe('-1');
+			expect(selectedFigure.classList.contains('c-reading-companion--highlighted')).toBeTruthy();
+			expect(selectedFigure.addEventListener).toHaveBeenCalled();
+			expect(selectedFigure.scrollIntoView).toHaveBeenCalledWith({block: 'start'});
+		});
 
-	test('Should switch to the figure tab and focus on the selected figure when clicking on a figure link', () => {
-		includeMockFigures();
-		addFigLinkSection();
-		initReadingCompanion();
-
-		const figureTab = document.querySelector('#tab-figures');
-		const selectedFigure = document.querySelector('#rc-Fig2');
-
-		selectedFigure.scrollIntoView = jest.fn();
-		selectedFigure.addEventListener = jest.fn();
-		emitter.emit('nav.figure', 'Fig2', null);
-
-		expect(figureTab.getAttribute('aria-selected')).toBe('true');
-		expect(figureTab.classList.contains('c-reading-companion__tab--active')).toBeTruthy();
-		expect(selectedFigure.getAttribute('tabindex')).toBe('-1');
-		expect(selectedFigure.classList.contains('c-reading-companion--highlighted')).toBeTruthy();
-		expect(selectedFigure.addEventListener).toHaveBeenCalled();
-		expect(selectedFigure.scrollIntoView).toHaveBeenCalledWith({block: 'start'});
-	});
-
-	test('Should switch to the references tab and focus on the selected reference when clicking on a reference link', () => {
-		// TODO: add more tests for insertReturnButton function
-		includeMockReferences();
-		initReadingCompanion();
-
-		const referencesTab = document.querySelector('#tab-references');
-		const selectedReference = document.querySelector('#rc-ref-CR1');
-
-		selectedReference.scrollIntoView = jest.fn();
-		selectedReference.addEventListener = jest.fn();
-		emitter.emit('nav.reference', 'ref-CR1', null);
-
-		expect(referencesTab.getAttribute('aria-selected')).toBe('true');
+		test('Should switch to the references tab and focus on the selected reference when clicking on a reference link', () => {
+			// TODO: add more tests for insertReturnButton function
+			initReadingCompanion();
+	
+			const referencesTab = document.querySelector('#tab-references');
+			const selectedReference = document.querySelector('#rc-ref-CR1');
+	
+			selectedReference.scrollIntoView = jest.fn();
+			selectedReference.addEventListener = jest.fn();
+			emitter.emit('nav.reference', 'ref-CR1', null);
+	
+			expect(referencesTab.getAttribute('aria-selected')).toBe('true');
+		});
 	});
 });

--- a/toolkits/global/packages/global-article/__tests__/reading-companion.js
+++ b/toolkits/global/packages/global-article/__tests__/reading-companion.js
@@ -30,6 +30,10 @@ describe('Reading Companion', () => {
 		  });
 	}
 
+	function overrideHeadingToNotAllowCharacters() {
+		document.querySelector('.c-article-section__title').textContent = '%Ab_s!tract';
+	}
+
 	beforeEach(() => {
 		document.body.innerHTML = `
 			<body>
@@ -75,10 +79,6 @@ describe('Reading Companion', () => {
 
 		document.body.innerHTML = null;
 	});
-
-	function overrideHeadingToNotAllowCharacters() {
-		document.querySelector('.c-article-section__title').textContent = '%Ab_s!tract';
-	}
 
 	test('Should be able to initiate the reading companion', () => {
 		initReadingCompanion();

--- a/toolkits/global/packages/global-article/__tests__/reading-companion.js
+++ b/toolkits/global/packages/global-article/__tests__/reading-companion.js
@@ -65,7 +65,6 @@ describe('Reading Companion', () => {
 		readingCompanionContainer = document.querySelector('.c-reading-companion');
 	});
 
-
 	beforeAll(() => {
 		mockWindow();
 	});
@@ -77,50 +76,50 @@ describe('Reading Companion', () => {
 		document.body.innerHTML = null;
 	});
 
-	describe('When no existing figures or references', () => {
-		function overrideHeadingToNotAllowCharacters() {
-			document.querySelector('.c-article-section__title').textContent = '%Ab_s!tract';
-		}
+	function overrideHeadingToNotAllowCharacters() {
+		document.querySelector('.c-article-section__title').textContent = '%Ab_s!tract';
+	}
 
-		test('Should be able to initiate the reading companion', () => {
-			initReadingCompanion();
-			expect(readingCompanion.init).toBeDefined();
-		});
+	test('Should be able to initiate the reading companion', () => {
+		initReadingCompanion();
+		expect(readingCompanion.init).toBeDefined();
+	});
+	
+	test('Should set and define the content container for the sections tab', () => {
+		initReadingCompanion();
 		
-		test('Should set and define the content container for the sections tab', () => {
-			initReadingCompanion();
-			
-			expect(readingCompanionContainer.querySelector('.c-reading-companion__scroll-pane')).toBeDefined();
+		expect(readingCompanionContainer.querySelector('.c-reading-companion__scroll-pane')).toBeDefined();
 
-			const ariaLabelledbyAttribute = readingCompanionContainer.querySelector('.c-reading-companion__sections').getAttribute('aria-labelledby');
-			
-			expect(ariaLabelledbyAttribute).not.toBeNull();
-			expect(ariaLabelledbyAttribute).toBe('tab-sections');
-		});
+		const ariaLabelledbyAttribute = readingCompanionContainer.querySelector('.c-reading-companion__sections').getAttribute('aria-labelledby');
+		
+		expect(ariaLabelledbyAttribute).not.toBeNull();
+		expect(ariaLabelledbyAttribute).toBe('tab-sections');
+	});
 
-		test('Should remove non text and numbers from the heading before adding the data-track-label', () => {
-			overrideHeadingToNotAllowCharacters();
-			initReadingCompanion();
-	
-			const firstSection = readingCompanionContainer.querySelector('.c-reading-companion__sections-list').firstElementChild;
+	test('Should remove non text and numbers from the heading before adding the data-track-label', () => {
+		overrideHeadingToNotAllowCharacters();
+		initReadingCompanion();
 
-			expect(firstSection.querySelector('a').getAttribute('data-track-label')).toBe('link:Abstract');
-		});
-	
+		const firstSection = readingCompanionContainer.querySelector('.c-reading-companion__sections-list').firstElementChild;
+
+		expect(firstSection.querySelector('a').getAttribute('data-track-label')).toBe('link:Abstract');
+	});
+
+	test('Should create a list of items which contains an anchor element to the existing abstract section', () => {
+		initReadingCompanion();
+
+		const sections = readingCompanionContainer.querySelector('.c-reading-companion__sections-list');
+
+		expect(sections).not.toBeNull();
+		expect(sections.firstElementChild.textContent).toBe('Abstract');
+	});
+
+	describe('When no existing figures or references', () => {
 		test('Should create only a heading Section', () => {
 			initReadingCompanion();
 
 			expect(document.querySelector('.c-reading-companion__heading')).not.toBeNull();
 			expect(document.querySelector('.c-reading-companion__tabs')).toBeNull();
-		});
-	
-		test('Should create a list of items which contains an anchor element to the existing abstract section', () => {
-			initReadingCompanion();
-
-			const sections = readingCompanionContainer.querySelector('.c-reading-companion__sections-list');
-	
-			expect(sections).not.toBeNull();
-			expect(sections.firstElementChild.textContent).toBe('Abstract');
 		});
 	});
 

--- a/toolkits/global/packages/global-article/__tests__/reading-companion.js
+++ b/toolkits/global/packages/global-article/__tests__/reading-companion.js
@@ -1,0 +1,399 @@
+const ReadingCompanion = require('../js/reading-companion');
+const EventEmitter = require('../js/event-emitter');
+
+const scheduler = {
+	on: jest.fn().mockImplementation((event, callback) => {
+		callback();
+	}),
+	off: jest.fn()
+};
+
+describe('Reading Companion', () => {
+	let readingCompanion = null;
+	let emitter = null;
+	let readingCompanionContainer = null;
+
+	function initReadingCompanion(config = {}) {
+		emitter = new EventEmitter();
+		readingCompanion = ReadingCompanion();
+		readingCompanion.init(config, scheduler, emitter);
+	}
+
+	function includeMockFigures() {
+		// figure in the content
+		const figureHTML = `<section>
+			<div class="c-article-section__figure js-c-reading-companion-figures-item">
+				<figure>
+					<figcaption>
+						<b id="Fig2" class="c-article-section__figure-caption">Fig 2</b>
+					</figcaption>
+					<div>
+						<div class="c-article-section__figure-item">
+							<a class="c-article-section__figure-link" href="/fig2">
+								<picture>
+									<source type="image/webp" srcset="//media.springernature.com/41586_2020_2068_Fig2_HTML.png">
+									<img src="//media.springernature.com/41586_2020_2068_Fig2_HTML.png" alt="figure2">
+								</picture>
+							</a>
+						</div>
+					</div>
+					<a class="c-article__pill-button" href="/articles/s41586-020-2068-4/figures/1">Full size image</a>
+			</div>
+		</section>`;
+
+		document.querySelector('section').insertAdjacentHTML('afterend', figureHTML);
+	}
+
+	function includeMockReferences() {
+		const referencesHTML = `<section>
+			<div class="c-article-section__references">
+				<ol class="c-article-references">
+					<li class="c-article-references__item js-c-reading-companion-references-item">
+						<span class="c-article-references__counter">1.</span>
+						<a href="#ref-CR1" class="c-article-references__text" id="ref-CR1">Link</a>
+						<ul class="c-article-references__links u-hide-print">
+							<li><a href="http://link">ADS</a></li>
+							<li><a href="http://link">PubMed</a></li>
+							<li><a href="http://link">Google Scholar</a></li>
+						</ul>
+					</li>
+				</ol>
+			</div>
+		</section>`;
+
+		document.querySelector('section').insertAdjacentHTML('afterend', referencesHTML);
+	}
+
+	function includeExtendedFiguresWithSupplementary() {
+		const supplementaryHTML = `<div class="c-article-supplementary__item js-c-reading-companion-figures-item" id="Fig4">
+			<h3 class="c-article-supplementary__title u-h3">
+				<a href="/articles/s41586-020-2087-1/figures/4" data-supp-info-image="41586_2020_2087_Fig4_ESM.jpg">Extended Data Fig. 1</a>
+			</h3>
+		</div>`;
+
+		document.querySelector('section').insertAdjacentHTML('afterend', supplementaryHTML);
+	}
+
+	function mockWindow() {
+		Object.defineProperty(window, 'matchMedia', {
+			writable: true,
+			value: jest.fn().mockImplementation(query => ({
+			  matches: false,
+			  media: query,
+			  onchange: null,
+			  addListener: jest.fn(),
+			  removeListener: jest.fn(),
+			  addEventListener: jest.fn(),
+			  removeEventListener: jest.fn(),
+			  dispatchEvent: jest.fn(),
+			})),
+		  });
+	}
+
+	function overrideHeadingToNotAllowCharacters() {
+		document.querySelector('.c-article-section__title').textContent = '%Ab_s!tract';
+	}
+
+	function addBackgroundSection() {
+		const backgroundSection = `<section>
+			<div class="c-article-section" id="Sec1-section">
+				<h2 class="c-article-section__title u-h2 js-section-title js-c-reading-companion-sections-item" id="Sec1" tabindex="-1">Background</h2>
+				<div class="c-article-section__content" id="Sec1-content">
+					<p>This is the content.</p>
+				</div>
+			</div>
+		</section>`;
+
+		document.querySelector('[data-component="article-container"] section').insertAdjacentHTML('afterend', backgroundSection);
+	}
+
+	function addFigLinkSection() {
+		const figLinkSection = `<section>
+			<h2 class="js-section-title" id="method">Method</h2>
+			<p>Method <a href="#Fig2" id="fig-link2">2</a></p>
+		</section>`;
+
+		document.querySelector('[data-component="article-container"] section').insertAdjacentHTML('afterend', figLinkSection);
+	}
+
+	beforeEach(() => {
+		document.documentElement.innerHTML = `
+			<head></head>
+			<body>
+				<div data-component="article-container">
+					<section aria-labelledby="Abs1">
+						<div class="c-article-section" id="Abs1-section">
+							<h2 class="c-article-section__title u-h2 js-section-title js-c-reading-companion-sections-item" id="Abs1">Abstract</h2>
+						</div>
+					</section>
+
+					<div class="c-reading-companion">
+						<div class="c-reading-companion__sticky" data-component="reading-companion-sticky">
+							<div class="c-reading-companion__panel c-reading-companion__sections c-reading-companion__panel--active" id="tabpanel-sections">
+							</div>
+							<div class="c-reading-companion__panel c-reading-companion__figures" id="tabpanel-figures">
+							</div>
+							<div class="c-reading-companion__panel c-reading-companion__references" id="tabpanel-references">
+							</div>
+						</div>
+					</div>
+				</div>
+			</body>
+		`;
+
+		readingCompanionContainer = document.querySelector('.c-reading-companion');
+	});
+
+
+	beforeAll(() => {
+		mockWindow();
+	});
+
+	afterEach(() => {
+		readingCompanion = null;
+		emitter = null;
+
+		document.body.innerHTML = null;
+	});
+
+	test('Should be able to initiate the reading companion', () => {
+		initReadingCompanion();
+		expect(readingCompanion.init).toBeDefined();
+	});
+	
+	test('Should set and define the content container for the sections tab', () => {
+		initReadingCompanion();
+		
+		expect(readingCompanionContainer.querySelector('.c-reading-companion__scroll-pane')).toBeDefined();
+		expect(readingCompanionContainer.querySelector('.c-reading-companion__sections').getAttribute('aria-labelledby')).toBeDefined();
+		expect(readingCompanionContainer.querySelector('.c-reading-companion__sections').getAttribute('aria-labelledby')).toBe('tab-sections');
+	});
+	test('Should remove non text and numbers from the heading before adding the data-track-label', () => {
+		overrideHeadingToNotAllowCharacters();
+		initReadingCompanion();
+
+		const firstSection = document.querySelector('.c-reading-companion__sections-list').firstElementChild;
+		expect(firstSection.querySelector('a').getAttribute('data-track-label')).toBe('link:Abstract');
+	});
+
+	test('Should create only a heading Section when nor figures nor references', () => {
+		initReadingCompanion();
+		expect(document.querySelector('.c-reading-companion__heading')).toBeDefined();
+		expect(document.querySelector('.c-reading-companion__tabs')).toBeNull();
+	});
+
+	test('Should create a set of tabs for each section when they exist', () => {
+		includeMockFigures();
+		includeMockReferences();
+		initReadingCompanion();
+
+		const tabs = readingCompanionContainer.querySelector('.c-reading-companion__tabs');
+		expect(tabs).not.toBeNull();
+		expect(tabs.children.length).toBe(3);
+	});
+
+	test('Should set sections as default active tab', () => {
+		includeMockFigures();
+		includeMockReferences();
+		initReadingCompanion();
+
+		const tabs = readingCompanionContainer.querySelector('.c-reading-companion__tabs');
+
+		expect(tabs.querySelector('[data-tab-target="sections"]').getAttribute('aria-selected')).toBe('true');
+	});
+
+	test('Should create list of items which contains a anchor element to the existing abstract section', () => {
+		initReadingCompanion();
+		const sections = readingCompanionContainer.querySelector('.c-reading-companion__sections-list');
+
+		expect(sections).not.toBeNull();
+		expect(document.querySelector('.c-reading-companion__sections-list').firstElementChild.textContent).toBe('Abstract');
+	});
+
+	test('Should create list of items with existent figures', () => {
+		includeMockFigures();
+		initReadingCompanion();
+
+		const figures = readingCompanionContainer.querySelector('.c-reading-companion__figures-list');
+
+		expect(figures).not.toBeNull();
+		expect(document.querySelector('.c-reading-companion__figures-list').children.length).toBe(1);
+	});
+
+	test('Should generate a figure element and its corresponding related info when figures exist', () => {
+		includeMockFigures();
+		initReadingCompanion();
+
+		const figures = readingCompanionContainer.querySelector('.c-reading-companion__figures-list');
+		expect(figures.firstElementChild.querySelector('figure')).not.toBeNull();
+		expect(figures.firstElementChild.querySelector('figcaption')).not.toBeNull();
+		expect(figures.firstElementChild.querySelector('picture')).not.toBeNull();
+		expect(figures.firstElementChild.querySelector('.c-reading-companion__figure-links')).not.toBeNull();
+	});
+
+	test('Should add a supplementary info when available ', () => {
+		includeExtendedFiguresWithSupplementary();
+		initReadingCompanion();
+		const figureTitle = document.querySelector('.c-reading-companion__figure-title');
+		const figures = readingCompanionContainer.querySelector('.c-reading-companion__figures-list');
+
+		expect(figureTitle.textContent.length > 0).toBeTruthy();
+		expect(figureTitle.getAttribute('id')).not.toBeNull();
+		expect(figures.firstElementChild.querySelector('a')).not.toBeNull();
+		expect(figures.firstElementChild.querySelector('picture')).not.toBeNull();
+		expect(figures.firstElementChild.querySelector('picture > img')).not.toBeNull();
+	});
+
+	test('Should add a link to the full width version in a supplementary info ', () => {
+		includeExtendedFiguresWithSupplementary();
+		initReadingCompanion({access: true});
+		const figures = readingCompanionContainer.querySelector('.c-reading-companion__figures-list');
+
+		expect(figures.firstElementChild.querySelector('.c-reading-companion__figure-full-link')).not.toBeNull();
+	});
+
+	test('Should generate a full size image link on the figure content when has access ', () => {
+		includeMockFigures();
+		initReadingCompanion({ access: true });
+
+		const figures = readingCompanionContainer.querySelector('.c-reading-companion__figures-list');
+		expect(figures.firstElementChild.querySelector('.c-reading-companion__figure-full-link')).not.toBeNull();
+		expect(figures.firstElementChild.querySelector('.c-reading-companion__figure-full-link').textContent).toBe('Full size image');
+	});
+
+	test('Should create list of items with existent references and its corresponding related info when references exist', () => {
+		includeMockReferences();
+		initReadingCompanion();
+
+		const references = readingCompanionContainer.querySelector('.c-reading-companion__references-list');
+
+		expect(references).not.toBeNull();
+		expect(references.children.length).toBe(1);
+		expect(references.firstElementChild.querySelector('.c-reading-companion__reference-links')).not.toBeNull();
+	});
+
+	test('Should move the active tab to the last when keydown is 37', () => {
+		includeMockReferences();
+		includeMockFigures();
+		initReadingCompanion();
+
+		const tabs = document.querySelector('.c-reading-companion__tabs');
+		const lastTab = tabs.querySelector('.c-reading-companion__tabs > li:last-child button');
+		const event = new KeyboardEvent('keydown', {'keyCode': 37});
+
+		tabs.dispatchEvent(event);
+
+		expect(lastTab.getAttribute('aria-selected')).toBe('true');
+		expect(lastTab.classList.contains('c-reading-companion__tab--active')).toBeTruthy();
+	});
+
+	test('Should move the active tab to the previous element sibling if there is an active element', () => {
+		includeMockReferences();
+		includeMockFigures();
+		initReadingCompanion();		
+
+		const tabs = document.querySelector('.c-reading-companion__tabs');
+		const lastTab = tabs.querySelector('.c-reading-companion__tabs > li:last-child button');
+		const event = new KeyboardEvent('keydown', {'keyCode': 37});
+
+		tabs.dispatchEvent(event);
+
+		expect(lastTab.getAttribute('aria-selected')).toBe('true');
+
+		tabs.dispatchEvent(event);
+
+		expect(tabs.querySelector('[data-tab-target="figures"]').getAttribute('aria-selected')).toBe('true');
+	});
+	
+	test('Should move the active tab to the first when keydown is 39', () => {
+		includeMockReferences();
+		includeMockFigures();
+		initReadingCompanion();
+
+		const tabs = document.querySelector('.c-reading-companion__tabs');
+		const firstTab = tabs.querySelector('.c-reading-companion__tabs > li:first-child button');
+		const event = new KeyboardEvent('keydown', {'keyCode': 39});
+
+		tabs.dispatchEvent(event);
+
+		expect(firstTab.getAttribute('aria-selected')).toBe('true');
+		expect(firstTab.classList.contains('c-reading-companion__tab--active')).toBeTruthy();
+	});
+
+	test('Should move the active tab to the next element sibling if there is an active element', () => {
+		includeMockReferences();
+		includeMockFigures();
+		initReadingCompanion();		
+
+		const tabs = document.querySelector('.c-reading-companion__tabs');
+		const firstTab = tabs.querySelector('.c-reading-companion__tabs > li:first-child button');
+		const event = new KeyboardEvent('keydown', {'keyCode': 39});
+
+		tabs.dispatchEvent(event);
+
+		expect(firstTab.getAttribute('aria-selected')).toBe('true');
+
+		tabs.dispatchEvent(event);
+
+		expect(tabs.querySelector('[data-tab-target="figures"]').getAttribute('aria-selected')).toBe('true');
+	});
+
+	test('Should move the active tab to the one is clicked on', () => {
+		includeMockReferences();
+		includeMockFigures();
+		initReadingCompanion();
+
+		const referencesTab = document.querySelector('[data-tab-target="references"]');
+
+		referencesTab.click();
+		expect(referencesTab.getAttribute('aria-selected')).toBe("true");
+	});
+
+	test('Should update the active section on a new selection', () => {
+		addBackgroundSection();
+		initReadingCompanion();
+		emitter.emit('nav.section', 'Abs1', null);
+
+		expect(document.querySelector('#rc-sec-Abs1').classList.contains('c-reading-companion__section-item--active')).toBeTruthy();
+		
+		emitter.emit('nav.section', 'Sec1', 'Abs1');
+
+		expect(document.querySelector('#rc-sec-Abs1').classList.contains('c-reading-companion__section-item--active')).toBeFalsy();
+		expect(document.querySelector('#rc-sec-Sec1').classList.contains('c-reading-companion__section-item--active')).toBeTruthy();
+	});
+
+	test('Should switch to figure tab and focus on the selected figure when clicking on a figure link', () => {
+		includeMockFigures();
+		addFigLinkSection();
+		initReadingCompanion();
+
+		const figureTab = document.querySelector('#tab-figures');
+		const selectedFigure = document.querySelector('#rc-Fig2');
+
+		selectedFigure.scrollIntoView = jest.fn();
+		selectedFigure.addEventListener = jest.fn();
+		emitter.emit('nav.figure', 'Fig2', null);
+
+		expect(figureTab.getAttribute('aria-selected')).toBe('true');
+		expect(figureTab.classList.contains('c-reading-companion__tab--active')).toBeTruthy();
+		expect(selectedFigure.getAttribute('tabindex')).toBe('-1');
+		expect(selectedFigure.classList.contains('c-reading-companion--highlighted')).toBeTruthy();
+		expect(selectedFigure.addEventListener).toHaveBeenCalled();
+		expect(selectedFigure.scrollIntoView).toHaveBeenCalledWith({block: 'start'});
+	});
+
+	test('Should switch to reference tab and focus on the selected reference when clicking on a reference link', () => {
+		includeMockReferences();
+		initReadingCompanion();
+
+		const referencesTab = document.querySelector('#tab-references');
+		const selectedReference = document.querySelector('#rc-ref-CR1');
+
+		selectedReference.scrollIntoView = jest.fn();
+		selectedReference.addEventListener = jest.fn();
+		emitter.emit('nav.reference', 'ref-CR1', null);
+
+		expect(referencesTab.getAttribute('aria-selected')).toBe('true');
+
+	});
+});

--- a/toolkits/global/packages/global-article/js/reading-companion.js
+++ b/toolkits/global/packages/global-article/js/reading-companion.js
@@ -486,7 +486,7 @@ var ReadingCompanion = (function (win, document_) {
 				var initialised = false;
 
 				var setup = function (mql) {
-					if (initialised || mql.matches) { // eslint-disable-line no-use-before-define
+					if (initialised || mql.matches) {
 						return;
 					}
 
@@ -506,7 +506,7 @@ var ReadingCompanion = (function (win, document_) {
 						switchToTab('sections');
 					}
 
-					initialised = true; // eslint-disable-line no-use-before-define
+					initialised = true;
 				};
 
 				var doSetup = function (mql) {

--- a/toolkits/global/packages/global-article/js/reading-companion.js
+++ b/toolkits/global/packages/global-article/js/reading-companion.js
@@ -519,7 +519,7 @@ var ReadingCompanion = (function (win, document_) {
 				doSetup(mq);
 			}
 		};
-	}
+	};
 })(window, document);
 
 if (typeof module !== 'undefined') {

--- a/toolkits/global/packages/global-article/js/reading-companion.js
+++ b/toolkits/global/packages/global-article/js/reading-companion.js
@@ -1,522 +1,527 @@
 
-window.Component.ReadingCompanion = (function (win, document_) {
+var ReadingCompanion = (function (win, document_) {
 	'use strict';
+	return function () {
+		var READING_COMPANION_CLASS = 'c-reading-companion';
 
-	var READING_COMPANION_CLASS = 'c-reading-companion';
+		var ACTIVE_MODIFIER = '--active';
+		var SECTION_ITEM_CLASS = READING_COMPANION_CLASS + '__section-item';
+		var ACTIVE_SECTION_CLASS = SECTION_ITEM_CLASS + ACTIVE_MODIFIER;
 
-	var ACTIVE_MODIFIER = '--active';
-	var SECTION_ITEM_CLASS = READING_COMPANION_CLASS + '__section-item';
-	var ACTIVE_SECTION_CLASS = SECTION_ITEM_CLASS + ACTIVE_MODIFIER;
+		var STICKY_MODIFIER = '--stuck';
+		var STICKY_CLASS = READING_COMPANION_CLASS + '__sticky';
 
-	var STICKY_MODIFIER = '--stuck';
-	var STICKY_CLASS = READING_COMPANION_CLASS + '__sticky';
+		var SECTION_ID_PREFIX = 'rc-sec-';
+		var FIGURE_ID_PREFIX = 'rc-';
+		var REFERENCE_ID_PREFIX = 'rc-';
 
-	var SECTION_ID_PREFIX = 'rc-sec-';
-	var FIGURE_ID_PREFIX = 'rc-';
-	var REFERENCE_ID_PREFIX = 'rc-';
+		var TAB_NAME_ATTR = 'data-tab-target';
+		var COMPONENT_ATTR = 'data-component';
+		var ARIA_SELECTED_ATTR = 'aria-selected';
+		var ARIA_CONTROLS_ATTR = 'aria-controls';
+		var TABINDEX_ATTR = 'tabindex';
 
-	var TAB_NAME_ATTR = 'data-tab-target';
-	var COMPONENT_ATTR = 'data-component';
-	var ARIA_SELECTED_ATTR = 'aria-selected';
-	var ARIA_CONTROLS_ATTR = 'aria-controls';
-	var TABINDEX_ATTR = 'tabindex';
+		var DATA_SRC_ATTR = 'data-src';
+		var DATA_SRCSET_ATTR = 'data-srcset';
 
-	var DATA_SRC_ATTR = 'data-src';
-	var DATA_SRCSET_ATTR = 'data-srcset';
+		var _isFullWidth = false;
+		var _access = false;
+		var _offset = 0;
+		var _maxTabWidth = Number.MAX_VALUE;
 
-	var _isFullWidth = false;
-	var _access = false;
-	var _offset = 0;
-	var _maxTabWidth = Number.MAX_VALUE;
+		var _container = null;
 
-	var _container = null;
-
-	// eslint-disable-next-line unicorn/consistent-function-scoping
-	function select(container, selector) {
-		return Array.prototype.slice.call(container.querySelectorAll(selector));
-	}
-
-	function cleanLinks(html) {
-		var d = document_.createElement('div');
-		d.innerHTML = html;
-		select(d, 'a').forEach(function (a) {
-			var s = document_.createElement('span');
-			s.innerHTML = a.innerHTML;
-			a.parentNode.replaceChild(s, a);
-		});
-		return d.innerHTML;
-	}
-
-	function Section(node) {
-		this.html = cleanLinks(node.innerHTML);
-		this.text = node.textContent.replace(/[^a-z0-9\s]/ig, '');
-		this.id = node.id;
-	}
-
-	Section.prototype.render = function () {
-		return '<li id="' + SECTION_ID_PREFIX + this.id + '" class="' + SECTION_ITEM_CLASS + '"><a href="#' + this.id + '" data-track="click" data-track-action="section anchor" data-track-label="link:' + this.text + '">' + this.html + '</a></li>';
-	};
-
-	function Figure(node) {
-		var suppInfoLink = node.querySelector('.c-article-supplementary__title a');
-
-		if (suppInfoLink) {
-			this.id = node.id;
-			this.caption = suppInfoLink.innerHTML;
-			this.link = suppInfoLink.href;
-			this.images = [this.placeholderFor(suppInfoLink)];
-		} else {
-			this.id = (node.querySelector('.c-article-section__figure-caption') || {id: null}).id;
-			this.caption = (node.querySelector('figcaption > b') || {innerHTML: 'Figure'}).innerHTML;
-			this.link = (node.querySelector('.c-article__pill-button') || {href: null}).href;
-			this.images = this.findImages(node);
+		// eslint-disable-next-line unicorn/consistent-function-scoping
+		function select(container, selector) {
+			return Array.prototype.slice.call(container.querySelectorAll(selector));
 		}
-	}
 
-	Figure.prototype = {
-		findImages: function (node) {
-			var images = [];
-			var self = this;
-			select(node, 'picture > img').forEach(function (element) {
-				images.push(self.placeholderFor(element));
+		function cleanLinks(html) {
+			var d = document_.createElement('div');
+			d.innerHTML = html;
+			select(d, 'a').forEach(function (a) {
+				var s = document_.createElement('span');
+				s.innerHTML = a.innerHTML;
+				a.parentNode.replaceChild(s, a);
 			});
-			return images;
-		},
+			return d.innerHTML;
+		}
 
-		placeholderFor: function (node) {
-			var source = node.getAttribute('data-supp-info-image') || node.src;
-			var alt = node.alt || '';
-			// eslint-disable-next-line unicorn/prefer-includes
-			var separator = source.indexOf('?') === -1 ? '?' : '&';
-			return [
-				'<picture>',
-				'<source type="image/webp" ' + DATA_SRCSET_ATTR + '="' + source + separator + 'as=webp">',
-				'<img ' + DATA_SRC_ATTR + '="' + source + '" alt="' + alt + '">',
-				'</picture>'
-			].join('');
-		},
+		function Section(node) {
+			this.html = cleanLinks(node.innerHTML);
+			this.text = node.textContent.replace(/[^a-z0-9\s]/ig, '');
+			this.id = node.id;
+		}
 
-		render: function () {
+		Section.prototype.render = function () {
+			return '<li id="' + SECTION_ID_PREFIX + this.id + '" class="' + SECTION_ITEM_CLASS + '"><a href="#' + this.id + '" data-track="click" data-track-action="section anchor" data-track-label="link:' + this.text + '">' + this.html + '</a></li>';
+		};
+
+		function Figure(node) {
+			var suppInfoLink = node.querySelector('.c-article-supplementary__title a');
+
+			if (suppInfoLink) {
+				this.id = node.id;
+				this.caption = suppInfoLink.innerHTML;
+				this.link = suppInfoLink.href;
+				this.images = [this.placeholderFor(suppInfoLink)];
+			} else {
+				this.id = (node.querySelector('.c-article-section__figure-caption') || {id: null}).id;
+				this.caption = (node.querySelector('figcaption > b') || {innerHTML: 'Figure'}).innerHTML;
+				this.link = (node.querySelector('.c-article__pill-button') || {href: null}).href;
+				this.images = this.findImages(node);
+			}
+		}
+
+		Figure.prototype = {
+			findImages: function (node) {
+				var images = [];
+				var self = this;
+				select(node, 'picture > img').forEach(function (element) {
+					images.push(self.placeholderFor(element));
+				});
+				return images;
+			},
+
+			placeholderFor: function (node) {
+				var source = node.getAttribute('data-supp-info-image') || node.src;
+				var alt = node.alt || '';
+				// eslint-disable-next-line unicorn/prefer-includes
+				var separator = source.indexOf('?') === -1 ? '?' : '&';
+				return [
+					'<picture>',
+					'<source type="image/webp" ' + DATA_SRCSET_ATTR + '="' + source + separator + 'as=webp">',
+					'<img ' + DATA_SRC_ATTR + '="' + source + '" alt="' + alt + '">',
+					'</picture>'
+				].join('');
+			},
+
+			render: function () {
+				return [
+					'<li class="' + READING_COMPANION_CLASS + '__figure-item">',
+					'<figure>',
+					'<figcaption><b class="' + READING_COMPANION_CLASS + '__figure-title" id="' + FIGURE_ID_PREFIX + this.id + '">' + this.caption + '</b></figcaption>',
+					this.images.join(''),
+					(this.link) ? '<p class="' + READING_COMPANION_CLASS + '__figure-links">' : '',
+					(this.link) ? '<a href="#' + this.id + '" data-track="click" data-track-action="figure anchor" data-track-label="link">View in article</a>' : '',
+					(this.link && _access) ? '<a href="' + this.link + '" class="' + READING_COMPANION_CLASS + '__figure-full-link" data-track="click" data-track-action="view figure" data-track-label="link">Full size image<svg width="16" height="16" class="u-icon"><use href="#global-icon-chevron-right"/></svg></a>' : '',
+					(this.link) ? '</p>' : '',
+					'</figure>',
+					'</li>'
+				].join('');
+			}
+		};
+
+		// eslint-disable-next-line unicorn/consistent-function-scoping
+		function Reference(node) {
+			var citation = node.querySelector('.c-article-references__text');
+			this.id = citation.id;
+			this.num = (node.querySelector('.c-article-references__counter') || {textContent: ''}).textContent;
+			this.citation = citation.innerHTML;
+			this.links = this.findLinks(node);
+		}
+
+		Reference.prototype.findLinks = function (node) {
+			var links = [];
+			select(node, '.c-article-references__links a').forEach(function (element) {
+				links.push(new ReferenceLink(element));
+			});
+			return links;
+		};
+
+		Reference.prototype.render = function () {
 			return [
-				'<li class="' + READING_COMPANION_CLASS + '__figure-item">',
-				'<figure>',
-				'<figcaption><b class="' + READING_COMPANION_CLASS + '__figure-title" id="' + FIGURE_ID_PREFIX + this.id + '">' + this.caption + '</b></figcaption>',
-				this.images.join(''),
-				(this.link) ? '<p class="' + READING_COMPANION_CLASS + '__figure-links">' : '',
-				(this.link) ? '<a href="#' + this.id + '" data-track="click" data-track-action="figure anchor" data-track-label="link">View in article</a>' : '',
-				(this.link && _access) ? '<a href="' + this.link + '" class="' + READING_COMPANION_CLASS + '__figure-full-link" data-track="click" data-track-action="view figure" data-track-label="link">Full size image<svg width="16" height="16" class="u-icon"><use href="#global-icon-chevron-right"/></svg></a>' : '',
-				(this.link) ? '</p>' : '',
-				'</figure>',
+				'<li class="' + READING_COMPANION_CLASS + '__reference-item">',
+				'<p class="' + READING_COMPANION_CLASS + '__reference-citation" id="' + REFERENCE_ID_PREFIX + this.id + '">' + this.citation + '</p>',
+				(this.links.length > 0) ? ('<ul class="' + READING_COMPANION_CLASS + '__reference-links">' + this.links.map(function (link) {
+					return link.render();
+				}).join('') + '</ul>') : '',
 				'</li>'
 			].join('');
-		}
-	};
-
-	// eslint-disable-next-line unicorn/consistent-function-scoping
-	function Reference(node) {
-		var citation = node.querySelector('.c-article-references__text');
-		this.id = citation.id;
-		this.num = (node.querySelector('.c-article-references__counter') || {textContent: ''}).textContent;
-		this.citation = citation.innerHTML;
-		this.links = this.findLinks(node);
-	}
-
-	Reference.prototype.findLinks = function (node) {
-		var links = [];
-		select(node, '.c-article-references__links a').forEach(function (element) {
-			links.push(new ReferenceLink(element));
-		});
-		return links;
-	};
-
-	Reference.prototype.render = function () {
-		return [
-			'<li class="' + READING_COMPANION_CLASS + '__reference-item">',
-			'<p class="' + READING_COMPANION_CLASS + '__reference-citation" id="' + REFERENCE_ID_PREFIX + this.id + '">' + this.citation + '</p>',
-			(this.links.length > 0) ? ('<ul class="' + READING_COMPANION_CLASS + '__reference-links">' + this.links.map(function (link) {
-				return link.render();
-			}).join('') + '</ul>') : '',
-			'</li>'
-		].join('');
-	};
-
-	// eslint-disable-next-line unicorn/consistent-function-scoping
-	function ReferenceLink(node) {
-		this.href = node.href;
-		this.text = node.textContent;
-	}
-	ReferenceLink.prototype.render = function () {
-		return '<li><a href="' + this.href + '" data-track="click" data-track-action="outbound reference" data-track-label="link">' + this.text + '</a></li>';
-	};
-
-	function sectionById(id) {
-		// eslint-disable-next-line unicorn/prefer-query-selector
-		return document_.getElementById(SECTION_ID_PREFIX + id);
-	}
-
-	function figureById(id) {
-		// eslint-disable-next-line unicorn/prefer-query-selector
-		return document_.getElementById(FIGURE_ID_PREFIX + id);
-	}
-
-	function referenceById(id) {
-		// eslint-disable-next-line unicorn/prefer-query-selector
-		return document_.getElementById(REFERENCE_ID_PREFIX + id);
-	}
-
-	function switchToTabAndScroll(name, node) {
-		var focusClass = READING_COMPANION_CLASS + '--highlighted';
-		var animationEnd = 'animationend';
-
-		if (node) {
-			switchToTab(name);
-			node.setAttribute(TABINDEX_ATTR, '-1');
-			node.focus();
-			node.classList.add(focusClass);
-			node.addEventListener(animationEnd, function cleanupAnimationEvent() {
-				node.classList.remove(focusClass);
-				node.removeEventListener(animationEnd, cleanupAnimationEvent);
-			});
-			node.scrollIntoView({block: 'start'});
-		}
-	}
-
-	function loadDeferedAssets(parent) {
-		select(parent, 'picture').forEach(function (pic) {
-			var source = pic.querySelector('source');
-			var img = pic.querySelector('img');
-			source.srcset = source.getAttribute(DATA_SRCSET_ATTR);
-			source.removeAttribute(DATA_SRCSET_ATTR);
-			img.src = img.getAttribute(DATA_SRC_ATTR);
-			img.removeAttribute(DATA_SRC_ATTR);
-		});
-	}
-
-	function switchToTab(name, options) {
-		var next = _container.querySelector('.' + READING_COMPANION_CLASS + '__' + name);
-		var previous = _container.querySelector('.' + READING_COMPANION_CLASS + '__panel' + ACTIVE_MODIFIER);
-		var defered;
-		var nextButton;
-		var previousButton;
-
-		if (!next || !previous) {
-			return;
-		}
-
-		defered = next.querySelector('img[' + DATA_SRC_ATTR + ']');
-		nextButton = _container.querySelector('button[' + ARIA_CONTROLS_ATTR + '=' + next.id + ']');
-
-		if (defered) {
-			loadDeferedAssets(next);
-		}
-
-		if (previous) {
-			previousButton = _container.querySelector('button[' + ARIA_CONTROLS_ATTR + '=' + previous.id + ']');
-			previousButton.setAttribute(ARIA_SELECTED_ATTR, 'false');
-			previousButton.setAttribute(TABINDEX_ATTR, '-1');
-			previousButton.classList.remove(READING_COMPANION_CLASS + '__tab' + ACTIVE_MODIFIER);
-			previous.classList.remove(READING_COMPANION_CLASS + '__panel' + ACTIVE_MODIFIER);
-			previous.removeAttribute(TABINDEX_ATTR);
-		}
-
-		nextButton.setAttribute(ARIA_SELECTED_ATTR, 'true');
-		nextButton.removeAttribute(TABINDEX_ATTR);
-		nextButton.classList.add(READING_COMPANION_CLASS + '__tab' + ACTIVE_MODIFIER);
-		next.classList.add(READING_COMPANION_CLASS + '__panel' + ACTIVE_MODIFIER);
-		next.setAttribute(TABINDEX_ATTR, '0');
-		if (options && options.focus) {
-			nextButton.focus();
-		}
-
-		setTabWidth();
-	}
-
-	function setTabWidth() {
-		_isFullWidth = _container.querySelector('.' + READING_COMPANION_CLASS + '__panel' + ACTIVE_MODIFIER + '.' + READING_COMPANION_CLASS + '__panel--full-width');
-		reflowWidth();
-	}
-
-	function reflowWidth() {
-		var parent = _container.parentNode;
-		var width = parent.offsetWidth;
-
-		if (width >= _maxTabWidth && _isFullWidth && _access) {
-			width = (win.innerWidth - parent.getBoundingClientRect().left - 10);
-		}
-		_container.style.width = width + 'px';
-	}
-
-	function insertReturnButton(reference, source) {
-		var button = reference.querySelector('.' + READING_COMPANION_CLASS + '__return');
-		if (button) {
-			// eslint-disable-next-line unicorn/prefer-node-remove
-			button.parentNode.removeChild(button);
-		}
-		button = document_.createElement('a');
-		button.href = '#' + source.id;
-		// eslint-disable-next-line unicorn/prefer-node-append
-		button.appendChild(document_.createTextNode('Return to ref ' + source.textContent + ' in article'));
-		button.className = READING_COMPANION_CLASS + '__return';
-		button.addEventListener('click', function () {
-			// eslint-disable-next-line unicorn/prefer-node-remove
-			button.parentNode.removeChild(button);
-		});
-		// eslint-disable-next-line unicorn/prefer-node-append
-		reference.appendChild(button);
-	}
-
-	function scrollIntoView(element, parent) {
-		var parentHeight = parent.clientHeight;
-		var parentTop = parent.scrollTop + parent.offsetTop;
-		var parentBottom = parentTop + parentHeight;
-		var offset = parentHeight / 4;
-
-		var elementTop = element.offsetTop;
-		var elementBottom = elementTop + element.clientHeight;
-
-		if (elementTop < parentTop) {
-			parent.scrollTop -= ((parentTop - elementTop) + offset);
-		} else if (elementBottom > parentBottom) {
-			parent.scrollTop += ((elementBottom - parentBottom) + offset);
-		}
-	}
-
-	function bindEvents(scheduler, emitter) {
-		var article = document_.querySelector('div[' + COMPONENT_ATTR + '=article-container]');
-		var sectionsList = _container.querySelector('.' + READING_COMPANION_CLASS + '__sections-list');
-		var advert = _container.querySelector('.js-ad');
-		var tabBar = _container.querySelector('.' + READING_COMPANION_CLASS + '__tabs');
-		var ctaLink = _container.querySelector('.' + READING_COMPANION_CLASS + '__cta a');
-		var sections = null;
-
-		if (!sectionsList) {
-			return;
-		}
-
-		sections = _container.querySelector('.' + READING_COMPANION_CLASS + '__sections-list').parentNode;
-
-		var calcOffset = function () {
-			return ((advert) ? advert.offsetHeight : 0) + _offset + ((tabBar) ? 80 : 20);
 		};
 
-		emitter.on('nav.section', function (id, previousId) {
-			var previous = previousId && sectionById(previousId);
-			var next = id && sectionById(id);
+		// eslint-disable-next-line unicorn/consistent-function-scoping
+		function ReferenceLink(node) {
+			this.href = node.href;
+			this.text = node.textContent;
+		}
+		ReferenceLink.prototype.render = function () {
+			return '<li><a href="' + this.href + '" data-track="click" data-track-action="outbound reference" data-track-label="link">' + this.text + '</a></li>';
+		};
+
+		function sectionById(id) {
+			// eslint-disable-next-line unicorn/prefer-query-selector
+			return document_.getElementById(SECTION_ID_PREFIX + id);
+		}
+
+		function figureById(id) {
+			// eslint-disable-next-line unicorn/prefer-query-selector
+			return document_.getElementById(FIGURE_ID_PREFIX + id);
+		}
+
+		function referenceById(id) {
+			// eslint-disable-next-line unicorn/prefer-query-selector
+			return document_.getElementById(REFERENCE_ID_PREFIX + id);
+		}
+
+		function switchToTabAndScroll(name, node) {
+			var focusClass = READING_COMPANION_CLASS + '--highlighted';
+			var animationEnd = 'animationend';
+
+			if (node) {
+				switchToTab(name);
+				node.setAttribute(TABINDEX_ATTR, '-1');
+				node.focus();
+				node.classList.add(focusClass);
+				node.addEventListener(animationEnd, function cleanupAnimationEvent() {
+					node.classList.remove(focusClass);
+					node.removeEventListener(animationEnd, cleanupAnimationEvent);
+				});
+				node.scrollIntoView({block: 'start'});
+			}
+		}
+
+		function loadDeferedAssets(parent) {
+			select(parent, 'picture').forEach(function (pic) {
+				var source = pic.querySelector('source');
+				var img = pic.querySelector('img');
+				source.srcset = source.getAttribute(DATA_SRCSET_ATTR);
+				source.removeAttribute(DATA_SRCSET_ATTR);
+				img.src = img.getAttribute(DATA_SRC_ATTR);
+				img.removeAttribute(DATA_SRC_ATTR);
+			});
+		}
+
+		function switchToTab(name, options) {
+			var next = _container.querySelector('.' + READING_COMPANION_CLASS + '__' + name);
+			var previous = _container.querySelector('.' + READING_COMPANION_CLASS + '__panel' + ACTIVE_MODIFIER);
+			var defered;
+			var nextButton;
+			var previousButton;
+
+			if (!next || !previous) {
+				return;
+			}
+
+			defered = next.querySelector('img[' + DATA_SRC_ATTR + ']');
+			nextButton = _container.querySelector('button[' + ARIA_CONTROLS_ATTR + '=' + next.id + ']');
+
+			if (defered) {
+				loadDeferedAssets(next);
+			}
 
 			if (previous) {
-				previous.classList.remove(ACTIVE_SECTION_CLASS);
-			}
-			if (next) {
-				next.classList.add(ACTIVE_SECTION_CLASS);
-				scrollIntoView(next, sections);
-			}
-		});
-
-		emitter.on('nav.figure', function (id) {
-			switchToTabAndScroll('figures', figureById(id));
-		});
-
-		emitter.on('nav.reference', function (id, source) {
-			var reference = referenceById(id);
-			if (source) {
-				insertReturnButton(reference, source);
-			}
-			switchToTabAndScroll('references', reference);
-		});
-
-		scheduler.on('scroll resize orientationchange', function () {
-			_maxTabWidth = _container.parentNode.parentNode.offsetWidth;
-
-			if (_container.parentNode.getBoundingClientRect().top <= _offset) {
-				_container.classList.add(STICKY_CLASS + STICKY_MODIFIER);
-			} else {
-				_container.classList.remove(STICKY_CLASS + STICKY_MODIFIER);
+				previousButton = _container.querySelector('button[' + ARIA_CONTROLS_ATTR + '=' + previous.id + ']');
+				previousButton.setAttribute(ARIA_SELECTED_ATTR, 'false');
+				previousButton.setAttribute(TABINDEX_ATTR, '-1');
+				previousButton.classList.remove(READING_COMPANION_CLASS + '__tab' + ACTIVE_MODIFIER);
+				previous.classList.remove(READING_COMPANION_CLASS + '__panel' + ACTIVE_MODIFIER);
+				previous.removeAttribute(TABINDEX_ATTR);
 			}
 
-			var height = _container.offsetHeight;
-			var intersection = article.getBoundingClientRect().bottom - document_.documentElement.clientTop - (height + _offset);
-
-			if (_container.classList.contains(STICKY_CLASS + STICKY_MODIFIER)) {
-				sections.style.maxHeight = (win.innerHeight - calcOffset()) + 'px';
+			nextButton.setAttribute(ARIA_SELECTED_ATTR, 'true');
+			nextButton.removeAttribute(TABINDEX_ATTR);
+			nextButton.classList.add(READING_COMPANION_CLASS + '__tab' + ACTIVE_MODIFIER);
+			next.classList.add(READING_COMPANION_CLASS + '__panel' + ACTIVE_MODIFIER);
+			next.setAttribute(TABINDEX_ATTR, '0');
+			if (options && options.focus) {
+				nextButton.focus();
 			}
 
-			if (intersection <= 0) {
-				_container.style.top = (intersection + _offset) + 'px';
-			} else {
-				_container.style.top = _offset + 'px';
-			}
+			setTabWidth();
+		}
 
-			if (tabBar) {
-				tabBar.style.maxWidth = _maxTabWidth + 'px';
-			}
-
-			if (ctaLink) {
-				ctaLink.style.maxWidth = _maxTabWidth + 'px';
-			}
-
+		function setTabWidth() {
+			_isFullWidth = _container.querySelector('.' + READING_COMPANION_CLASS + '__panel' + ACTIVE_MODIFIER + '.' + READING_COMPANION_CLASS + '__panel--full-width');
 			reflowWidth();
-		});
+		}
 
-		if (tabBar) {
-			tabBar.addEventListener('keydown', function (event) {
-				var active = document_.activeElement.parentNode;
-				var next;
+		function reflowWidth() {
+			var parent = _container.parentNode;
+			var width = parent.offsetWidth;
 
-				// eslint-disable-next-line unicorn/prefer-event-key
-				if (event.keyCode === 37) {
-					next = active.previousElementSibling || _container.querySelector('.' + READING_COMPANION_CLASS + '__tabs > li:last-child');
-				// eslint-disable-next-line unicorn/prefer-event-key
-				} else if (event.keyCode === 39) {
-					next = active.nextElementSibling || _container.querySelector('.' + READING_COMPANION_CLASS + '__tabs > li:first-child');
+			if (width >= _maxTabWidth && _isFullWidth && _access) {
+				width = (win.innerWidth - parent.getBoundingClientRect().left - 10);
+			}
+			_container.style.width = width + 'px';
+		}
+
+		function insertReturnButton(reference, source) {
+			var button = reference.querySelector('.' + READING_COMPANION_CLASS + '__return');
+			if (button) {
+				// eslint-disable-next-line unicorn/prefer-node-remove
+				button.parentNode.removeChild(button);
+			}
+			button = document_.createElement('a');
+			button.href = '#' + source.id;
+			// eslint-disable-next-line unicorn/prefer-node-append
+			button.appendChild(document_.createTextNode('Return to ref ' + source.textContent + ' in article'));
+			button.className = READING_COMPANION_CLASS + '__return';
+			button.addEventListener('click', function () {
+				// eslint-disable-next-line unicorn/prefer-node-remove
+				button.parentNode.removeChild(button);
+			});
+			// eslint-disable-next-line unicorn/prefer-node-append
+			reference.appendChild(button);
+		}
+
+		function scrollIntoView(element, parent) {
+			var parentHeight = parent.clientHeight;
+			var parentTop = parent.scrollTop + parent.offsetTop;
+			var parentBottom = parentTop + parentHeight;
+			var offset = parentHeight / 4;
+
+			var elementTop = element.offsetTop;
+			var elementBottom = elementTop + element.clientHeight;
+
+			if (elementTop < parentTop) {
+				parent.scrollTop -= ((parentTop - elementTop) + offset);
+			} else if (elementBottom > parentBottom) {
+				parent.scrollTop += ((elementBottom - parentBottom) + offset);
+			}
+		}
+
+		function bindEvents(scheduler, emitter) {
+			var article = document_.querySelector('div[' + COMPONENT_ATTR + '=article-container]');
+			var sectionsList = _container.querySelector('.' + READING_COMPANION_CLASS + '__sections-list');
+			var advert = _container.querySelector('.js-ad');
+			var tabBar = _container.querySelector('.' + READING_COMPANION_CLASS + '__tabs');
+			var ctaLink = _container.querySelector('.' + READING_COMPANION_CLASS + '__cta a');
+			var sections = null;
+
+			if (!sectionsList) {
+				return;
+			}
+
+			sections = _container.querySelector('.' + READING_COMPANION_CLASS + '__sections-list').parentNode;
+
+			var calcOffset = function () {
+				return ((advert) ? advert.offsetHeight : 0) + _offset + ((tabBar) ? 80 : 20);
+			};
+
+			emitter.on('nav.section', function (id, previousId) {
+				var previous = previousId && sectionById(previousId);
+				var next = id && sectionById(id);
+
+				if (previous) {
+					previous.classList.remove(ACTIVE_SECTION_CLASS);
 				}
 				if (next) {
-					switchToTab(next.querySelector('[' + TAB_NAME_ATTR + ']').getAttribute(TAB_NAME_ATTR), {focus: true});
+					next.classList.add(ACTIVE_SECTION_CLASS);
+					scrollIntoView(next, sections);
 				}
-			}, false);
-
-			select(tabBar, '.' + READING_COMPANION_CLASS + '__tab').forEach(function (element) {
-				element.addEventListener('click', function (event) {
-					switchToTab(event.target.getAttribute(TAB_NAME_ATTR), {focus: true});
-				}, false);
 			});
-		}
-	}
 
-	function htmlFor(name, data) {
-		var map = {
-			sections: function (sections) {
-				var items = [];
-				sections.forEach(function (element) {
-					items.push(new Section(element));
-				});
+			emitter.on('nav.figure', function (id) {
+				switchToTabAndScroll('figures', figureById(id));
+			});
 
-				return (items.length > 0) ? '<ul class="' + READING_COMPANION_CLASS + '__sections-list">' + items.map(function (item) {
-					return item.render();
-				}).join('') + '</ul>' : '';
-			},
-			figures: function (figures) {
-				var items = [];
-				figures.forEach(function (element) {
-					var fig = new Figure(element);
-					if (fig.id) {
-						items.push(fig);
+			emitter.on('nav.reference', function (id, source) {
+				var reference = referenceById(id);
+				if (source) {
+					insertReturnButton(reference, source);
+				}
+				switchToTabAndScroll('references', reference);
+			});
+
+			scheduler.on('scroll resize orientationchange', function () {
+				_maxTabWidth = _container.parentNode.parentNode.offsetWidth;
+
+				if (_container.parentNode.getBoundingClientRect().top <= _offset) {
+					_container.classList.add(STICKY_CLASS + STICKY_MODIFIER);
+				} else {
+					_container.classList.remove(STICKY_CLASS + STICKY_MODIFIER);
+				}
+
+				var height = _container.offsetHeight;
+				var intersection = article.getBoundingClientRect().bottom - document_.documentElement.clientTop - (height + _offset);
+
+				if (_container.classList.contains(STICKY_CLASS + STICKY_MODIFIER)) {
+					sections.style.maxHeight = (win.innerHeight - calcOffset()) + 'px';
+				}
+
+				if (intersection <= 0) {
+					_container.style.top = (intersection + _offset) + 'px';
+				} else {
+					_container.style.top = _offset + 'px';
+				}
+
+				if (tabBar) {
+					tabBar.style.maxWidth = _maxTabWidth + 'px';
+				}
+
+				if (ctaLink) {
+					ctaLink.style.maxWidth = _maxTabWidth + 'px';
+				}
+
+				reflowWidth();
+			});
+
+			if (tabBar) {
+				tabBar.addEventListener('keydown', function (event) {
+					var active = document_.activeElement.parentNode;
+					var next;
+
+					// eslint-disable-next-line unicorn/prefer-event-key
+					if (event.keyCode === 37) {
+						next = active.previousElementSibling || _container.querySelector('.' + READING_COMPANION_CLASS + '__tabs > li:last-child');
+					// eslint-disable-next-line unicorn/prefer-event-key
+					} else if (event.keyCode === 39) {
+						next = active.nextElementSibling || _container.querySelector('.' + READING_COMPANION_CLASS + '__tabs > li:first-child');
 					}
-				});
+					if (next) {
+						switchToTab(next.querySelector('[' + TAB_NAME_ATTR + ']').getAttribute(TAB_NAME_ATTR), {focus: true});
+					}
+				}, false);
 
-				if (!items.length) { // eslint-disable-line unicorn/explicit-length-check
-					return '';
+				select(tabBar, '.' + READING_COMPANION_CLASS + '__tab').forEach(function (element) {
+					element.addEventListener('click', function (event) {
+						switchToTab(event.target.getAttribute(TAB_NAME_ATTR), {focus: true});
+					}, false);
+				});
+			}
+		}
+
+		function htmlFor(name, data) {
+			var map = {
+				sections: function (sections) {
+					var items = [];
+					sections.forEach(function (element) {
+						items.push(new Section(element));
+					});
+
+					return (items.length > 0) ? '<ul class="' + READING_COMPANION_CLASS + '__sections-list">' + items.map(function (item) {
+						return item.render();
+					}).join('') + '</ul>' : '';
+				},
+				figures: function (figures) {
+					var items = [];
+					figures.forEach(function (element) {
+						var fig = new Figure(element);
+						if (fig.id) {
+							items.push(fig);
+						}
+					});
+
+					if (!items.length) { // eslint-disable-line unicorn/explicit-length-check
+						return '';
+					}
+
+					return '<ul class="' + READING_COMPANION_CLASS + '__figures-list">' + items.map(function (item) {
+						return item.render();
+					}).join('') + '</ul>';
+				},
+				references: function (references) {
+					var items = [];
+					references.forEach(function (element) {
+						items.push(new Reference(element));
+					});
+
+					if (!items.length) { // eslint-disable-line unicorn/explicit-length-check
+						return '';
+					}
+
+					return '<ol class="' + READING_COMPANION_CLASS + '__references-list' + ((items[0].num) ? ' ' + READING_COMPANION_CLASS + '__references-list--numeric' : '') + '">' + items.map(function (item) {
+						return item.render();
+					}).join('') + '</ol>';
+				}
+			};
+			return (map[name]) ? map[name](data) : '';
+		}
+
+		function htmlForTab(id, text) {
+			return '<li role="presentation"><button ' + TAB_NAME_ATTR + '="' + id + '" role="tab" id="tab-' + id + '" ' + ARIA_CONTROLS_ATTR + '="tabpanel-' + id + '" ' + ARIA_SELECTED_ATTR + '="false" ' + TABINDEX_ATTR + '="-1" class="' + READING_COMPANION_CLASS + '__tab">' + text + '</button></li>';
+		}
+
+		function buildTabBar(tabs) {
+			return '<ul class="' + READING_COMPANION_CLASS + '__tabs" role="tablist">' + tabs.join('') + '</ul>';
+		}
+
+		// eslint-disable-next-line unicorn/consistent-function-scoping
+		function insert(element, html) {
+			element.insertAdjacentHTML('afterbegin', html);
+		}
+
+		// eslint-disable-next-line unicorn/consistent-function-scoping
+		function insertBefore(element, html) {
+			element.insertAdjacentHTML('beforebegin', html);
+		}
+
+		function buildTabs() {
+			var tabs = ['sections', 'figures', 'references'].map(function (name) {
+				var container = document_.querySelector('.' + READING_COMPANION_CLASS + '__' + name);
+				var html = htmlFor(name, select(document_, '.js-' + READING_COMPANION_CLASS + '-' + name + '-item'));
+				// eslint-disable-next-line unicorn/prefer-string-slice
+				var tab = htmlForTab(name, name.charAt(0).toUpperCase() + name.substring(1));
+
+				if (html && container) {
+					container.setAttribute('aria-labelledby', 'tab-' + name);
+					insert(container, '<div class="' + READING_COMPANION_CLASS + '__scroll-pane">' + html + '</div>');
+				} else if (container) {
+					// eslint-disable-next-line unicorn/prefer-node-remove
+					container.parentNode.removeChild(container);
 				}
 
-				return '<ul class="' + READING_COMPANION_CLASS + '__figures-list">' + items.map(function (item) {
-					return item.render();
-				}).join('') + '</ul>';
-			},
-			references: function (references) {
-				var items = [];
-				references.forEach(function (element) {
-					items.push(new Reference(element));
-				});
+				return (html && container) ? tab : false;
+			}).filter(function (tab) {
+				return Boolean(tab);
+			});
 
-				if (!items.length) { // eslint-disable-line unicorn/explicit-length-check
-					return '';
-				}
+			var firstTabPanel = _container.querySelector('.' + READING_COMPANION_CLASS + '__panel');
 
-				return '<ol class="' + READING_COMPANION_CLASS + '__references-list' + ((items[0].num) ? ' ' + READING_COMPANION_CLASS + '__references-list--numeric' : '') + '">' + items.map(function (item) {
-					return item.render();
-				}).join('') + '</ol>';
+			var tabCount = tabs.length;
+			if (tabCount > 1) {
+				insertBefore(firstTabPanel, buildTabBar(tabs));
+			} else if (tabCount === 1) {
+				insertBefore(firstTabPanel, '<h3 class="' + READING_COMPANION_CLASS + '__heading">Sections</h3>');
+			}
+			return tabCount;
+		}
+
+		return {
+			init: function (config, scheduler, emitter) {
+				_access = Boolean(config.access);
+				_offset = config.offset || 0;
+
+				var initialised = false;
+
+				var setup = function (mql) {
+					if (initialised || mql.matches) { // eslint-disable-line no-use-before-define
+						return;
+					}
+
+					_container = document_.querySelector('[' + COMPONENT_ATTR + '=reading-companion-sticky]');
+
+					if (!_container) {
+						return;
+					}
+
+					var tabCount = buildTabs();
+					if (tabCount === 0) {
+						return;
+					}
+
+					bindEvents(scheduler, emitter);
+					if (tabCount > 1) {
+						switchToTab('sections');
+					}
+
+					initialised = true; // eslint-disable-line no-use-before-define
+				};
+
+				var doSetup = function (mql) {
+					setup(mql);
+					emitter.emit('rc.display', !mql.matches && initialised);
+				};
+
+				var mq = win.matchMedia(config.matchMediaQuery || '(max-width: 639px)');
+				mq.addListener(doSetup);
+				doSetup(mq);
 			}
 		};
-		return (map[name]) ? map[name](data) : '';
 	}
-
-	function htmlForTab(id, text) {
-		return '<li role="presentation"><button ' + TAB_NAME_ATTR + '="' + id + '" role="tab" id="tab-' + id + '" ' + ARIA_CONTROLS_ATTR + '="tabpanel-' + id + '" ' + ARIA_SELECTED_ATTR + '="false" ' + TABINDEX_ATTR + '="-1" class="' + READING_COMPANION_CLASS + '__tab">' + text + '</button></li>';
-	}
-
-	function buildTabBar(tabs) {
-		return '<ul class="' + READING_COMPANION_CLASS + '__tabs" role="tablist">' + tabs.join('') + '</ul>';
-	}
-
-	// eslint-disable-next-line unicorn/consistent-function-scoping
-	function insert(element, html) {
-		element.insertAdjacentHTML('afterbegin', html);
-	}
-
-	// eslint-disable-next-line unicorn/consistent-function-scoping
-	function insertBefore(element, html) {
-		element.insertAdjacentHTML('beforebegin', html);
-	}
-
-	function buildTabs() {
-		var tabs = ['sections', 'figures', 'references'].map(function (name) {
-			var container = document_.querySelector('.' + READING_COMPANION_CLASS + '__' + name);
-			var html = htmlFor(name, select(document_, '.js-' + READING_COMPANION_CLASS + '-' + name + '-item'));
-			// eslint-disable-next-line unicorn/prefer-string-slice
-			var tab = htmlForTab(name, name.charAt(0).toUpperCase() + name.substring(1));
-
-			if (html && container) {
-				container.setAttribute('aria-labelledby', 'tab-' + name);
-				insert(container, '<div class="' + READING_COMPANION_CLASS + '__scroll-pane">' + html + '</div>');
-			} else if (container) {
-				// eslint-disable-next-line unicorn/prefer-node-remove
-				container.parentNode.removeChild(container);
-			}
-
-			return (html && container) ? tab : false;
-		}).filter(function (tab) {
-			return Boolean(tab);
-		});
-
-		var firstTabPanel = _container.querySelector('.' + READING_COMPANION_CLASS + '__panel');
-
-		var tabCount = tabs.length;
-		if (tabCount > 1) {
-			insertBefore(firstTabPanel, buildTabBar(tabs));
-		} else if (tabCount === 1) {
-			insertBefore(firstTabPanel, '<h3 class="' + READING_COMPANION_CLASS + '__heading">Sections</h3>');
-		}
-		return tabCount;
-	}
-
-	return {
-		init: function (config, scheduler, emitter) {
-			_access = Boolean(config.access);
-			_offset = config.offset || 0;
-
-			var initialised = false;
-
-			var setup = function (mql) {
-				if (initialised || mql.matches) { // eslint-disable-line no-use-before-define
-					return;
-				}
-
-				_container = document_.querySelector('[' + COMPONENT_ATTR + '=reading-companion-sticky]');
-
-				if (!_container) {
-					return;
-				}
-
-				var tabCount = buildTabs();
-				if (tabCount === 0) {
-					return;
-				}
-
-				bindEvents(scheduler, emitter);
-				if (tabCount > 1) {
-					switchToTab('sections');
-				}
-
-				initialised = true; // eslint-disable-line no-use-before-define
-			};
-
-			var doSetup = function (mql) {
-				setup(mql);
-				emitter.emit('rc.display', !mql.matches && initialised);
-			};
-
-			var mq = win.matchMedia(config.matchMediaQuery || '(max-width: 639px)');
-			mq.addListener(doSetup);
-			doSetup(mq);
-		}
-	};
 })(window, document);
+
+if (typeof module !== 'undefined') {
+	module.exports = ReadingCompanion;
+}

--- a/toolkits/global/packages/global-article/package.json
+++ b/toolkits/global/packages/global-article/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-article",
-  "version": "14.0.0",
+  "version": "15.0.0",
   "description": "Frontend package for article display",
   "license": "MIT",
   "peerDependencies": {


### PR DESCRIPTION
The changes on the reading-companion.js correspond mostly to indentation and other bits related to transforming the component in an IIFE function that returns another function. 
And lately, getting the component to export.

There is one test that can be added still. But for now, the tests cover 90% of the code.