### PR TITLE
add icon spacing to global-button

### DIFF
--- a/toolkits/global/packages/global-button/HISTORY.md
+++ b/toolkits/global/packages/global-button/HISTORY.md
@@ -5,6 +5,7 @@
     * Replace inline-block with inline-flex
     * Add icon spacing to buttons
     * Replace text-align with justify-content and variable rename 
+    * Move border-radius from base to themes
     * Update Readme
 
 ## 0.1.1 (2020-04-02)

--- a/toolkits/global/packages/global-button/HISTORY.md
+++ b/toolkits/global/packages/global-button/HISTORY.md
@@ -1,5 +1,12 @@
 # History
 
+## 0.2.0 (2020-04-06)
+    * Rename .c-button--block to .c-button--full-width
+    * Replace inline-block with inline-flex
+    * Add icon spacing to buttons
+    * Replace text-align with justify-content and variable rename 
+    * Update Readme
+
 ## 0.1.1 (2020-04-02)
     * Add padding to .c-button--large
     * Use spacing function for padding values 

--- a/toolkits/global/packages/global-button/HISTORY.md
+++ b/toolkits/global/packages/global-button/HISTORY.md
@@ -1,12 +1,12 @@
 # History
 
 ## 0.2.0 (2020-04-06)
-    * Rename .c-button--block to .c-button--full-width
+    * BREAKING: Rename .c-button--block to .c-button--full-width
     * Replace inline-block with inline-flex
-    * Add icon spacing to buttons
+    * Add SVG spacing to buttons with .c-button-icon--left and .c-button-icon--right
     * Replace text-align with justify-content and variable rename 
     * Move border-radius from base to themes
-    * Update Readme
+    * Update readme
 
 ## 0.1.1 (2020-04-02)
     * Add padding to .c-button--large

--- a/toolkits/global/packages/global-button/HISTORY.md
+++ b/toolkits/global/packages/global-button/HISTORY.md
@@ -2,9 +2,9 @@
 
 ## 0.2.0 (2020-04-06)
     * BREAKING: Rename .c-button--block to .c-button--full-width
+    * BREAKING: Replace text-align with justify-content and variable rename
     * Replace inline-block with inline-flex
     * Add SVG spacing to buttons with .c-button-icon--left and .c-button-icon--right
-    * Replace text-align with justify-content and variable rename 
     * Move border-radius from base to themes
     * Update readme
 

--- a/toolkits/global/packages/global-button/README.md
+++ b/toolkits/global/packages/global-button/README.md
@@ -29,9 +29,25 @@ Button styles to use on buttons and links.
 <button class="c-button c-button--primary">text</button>
 ```
 
-**Block**
+**Full width**
 ```html
-<button class="c-button c-button--block">text</button>
+<button class="c-button c-button--full-width">text</button>
+```
+
+**Icon left**
+```html
+<button class="c-button c-button--icon-left">
+    <svg></svg>
+    <span>text</span>
+</button>
+```
+
+**Icon right**
+```html
+<button class="c-button c-button--icon-right">
+    <span>text</span>
+    <svg></svg>
+</button>
 ```
 
 **Disabled**

--- a/toolkits/global/packages/global-button/package.json
+++ b/toolkits/global/packages/global-button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-button",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "license": "MIT",
   "description": "Button styles to use on buttons and links",
   "keywords": ["button"],

--- a/toolkits/global/packages/global-button/scss/10-settings/button.scss
+++ b/toolkits/global/packages/global-button/scss/10-settings/button.scss
@@ -10,9 +10,10 @@ $button--font-family: sans-serif;
 $button--font-size-small: 1.4rem;
 $button--font-size-normal: 1.6rem;
 $button--font-size-large: 1.8rem;
+$button--icon-margin: spacing(8);
 $button--padding: spacing(8);
 $button--padding-large: spacing(16);
-$button--text-align: center;
+$button--justify-content: center;
 $button--transition: 0.25s ease, color 0.25s ease, border-color 0.25s ease;
 
 /**

--- a/toolkits/global/packages/global-button/scss/10-settings/button.scss
+++ b/toolkits/global/packages/global-button/scss/10-settings/button.scss
@@ -22,7 +22,7 @@ $button--transition: 0.25s ease, color 0.25s ease, border-color 0.25s ease;
  */
 
 $button--default: (
-	'border-radius': $button--border-radius,
+	'border-radius': 2px,
 	'color': darkblue,
 	'backgroundColor': greyscale(95),
 	'backgroundImage': none,

--- a/toolkits/global/packages/global-button/scss/10-settings/button.scss
+++ b/toolkits/global/packages/global-button/scss/10-settings/button.scss
@@ -3,7 +3,6 @@
  *
  */
 
-$button--border-radius: 2px;
 $button--border-width-style: 1px solid;
 $button--line-height: 1.3;
 $button--font-family: sans-serif;
@@ -23,6 +22,7 @@ $button--transition: 0.25s ease, color 0.25s ease, border-color 0.25s ease;
  */
 
 $button--default: (
+	'border-radius': $button--border-radius,
 	'color': darkblue,
 	'backgroundColor': greyscale(95),
 	'backgroundImage': none,

--- a/toolkits/global/packages/global-button/scss/30-mixins/button.scss
+++ b/toolkits/global/packages/global-button/scss/30-mixins/button.scss
@@ -2,8 +2,9 @@
 // No theme
 
 @mixin button-base {
+	align-items: center;
 	cursor: pointer;
-	display: inline-block;
+	display: inline-flex;
 	margin: 0;
 	position: relative;
 	text-decoration: none;
@@ -12,8 +13,8 @@
 	font-family: $button--font-family;
 	font-size: $button--font-size-normal;
 	line-height: $button--line-height;
+	justify-content: $button--justify-content;
 	padding: $button--padding;
-	text-align: $button--text-align;
 	transition: $button--transition;
 }
 

--- a/toolkits/global/packages/global-button/scss/30-mixins/button.scss
+++ b/toolkits/global/packages/global-button/scss/30-mixins/button.scss
@@ -9,7 +9,6 @@
 	position: relative;
 	text-decoration: none;
 	width: auto;
-	border-radius: $button--border-radius;
 	font-family: $button--font-family;
 	font-size: $button--font-size-normal;
 	line-height: $button--line-height;

--- a/toolkits/global/packages/global-button/scss/50-components/button.scss
+++ b/toolkits/global/packages/global-button/scss/50-components/button.scss
@@ -20,9 +20,21 @@
 	@include button-theme($button--primary);
 }
 
-.c-button--block {
-	display: block;
+.c-button--full-width {
+	display: flex;
 	width: 100%;
+}
+
+.c-button--icon-left {
+	svg {
+		margin-right: $button--icon-margin;
+	 }
+}
+
+.c-button--icon-right {
+	svg {
+		margin-left: $button--icon-margin;
+	 }
 }
 
 .c-button--disabled,


### PR DESCRIPTION
* BREAKING: Rename .c-button--block to .c-button--full-width
* BREAKING: Replace text-align with justify-content and variable rename
* Replace inline-block with inline-flex
* Add SVG spacing to buttons with .c-button-icon--left and .c-button-icon--right
* Move border-radius from base to themes
* Update readme