### PR TITLE
Springer-button version bump

### DIFF
--- a/toolkits/springer/packages/springer-button/HISTORY.md
+++ b/toolkits/springer/packages/springer-button/HISTORY.md
@@ -2,9 +2,10 @@
 
 ## 0.2.0 (2020-04-08)
     * Fixed typo in $button--padding-large
-    * Replace variable from $button--text-align to $button--justify-content
-    * Move border-radius from base to themes
-    * Bump extendsPackage to latest
+    * Changes to be compatible with global-button@0.2.0
+        * Replace variable from $button--text-align to $button--justify-content
+        * Move border-radius from base to themes
+        * Bump extendsPackage to latest
 
 ## 0.1.1 (2020-04-02)
     * Bump extendsPackage and peerDependencies to latest

--- a/toolkits/springer/packages/springer-button/HISTORY.md
+++ b/toolkits/springer/packages/springer-button/HISTORY.md
@@ -1,5 +1,11 @@
 # History
 
+## 0.2.0 (2020-04-08)
+    * Fixed typo in $button--padding-large
+    * Replace variable from $button--text-align to $button--justify-content
+    * Move border-radius from base to themes
+    * Bump extendsPackage to latest
+
 ## 0.1.1 (2020-04-02)
     * Bump extendsPackage and peerDependencies to latest
     * Reduce $button--font-size-large

--- a/toolkits/springer/packages/springer-button/HISTORY.md
+++ b/toolkits/springer/packages/springer-button/HISTORY.md
@@ -4,7 +4,6 @@
     * Fixed typo in $button--padding-large
     * Changes to be compatible with global-button@0.2.0
         * Replace variable from $button--text-align to $button--justify-content
-        * Move border-radius from base to themes
         * Bump extendsPackage to latest
 
 ## 0.1.1 (2020-04-02)

--- a/toolkits/springer/packages/springer-button/package.json
+++ b/toolkits/springer/packages/springer-button/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@springernature/springer-button",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "license": "MIT",
   "description": "Springer branding for global-buttons",
   "keywords": ["button"],
   "author": "Springer Nature",
-  "extendsPackage": "global-button@0.1.1",
+  "extendsPackage": "global-button@0.2.0",
   "peerDependencies": {
     "@springernature/springer-context": "^19.1.0"
   }

--- a/toolkits/springer/packages/springer-button/scss/10-settings/button-springer.scss
+++ b/toolkits/springer/packages/springer-button/scss/10-settings/button-springer.scss
@@ -26,7 +26,6 @@ $button--default: (
 	'backgroundColor': greyscale(95),
 	'backgroundImage': linear-gradient(to bottom, white, greyscale(95)),
 	'border': $button--border-width-style greyscale(80),
-	'border-radius': 2px,
 	'visitedColor': color('action-base'),
 	'hoverColor': white,
 	'hoverBorder': $button--border-width-style greyscale(40),

--- a/toolkits/springer/packages/springer-button/scss/10-settings/button-springer.scss
+++ b/toolkits/springer/packages/springer-button/scss/10-settings/button-springer.scss
@@ -3,16 +3,16 @@
  *
  */
 
-$button--border-radius: 2px;
 $button--border-width-style: 1px solid;
 $button--line-height: 1.3;
 $button--font-family: $font-family-sans;
 $button--font-size-small: $font-size-xs;
 $button--font-size-normal: $font-size-sm;
 $button--font-size-large: $font-size-sm;
+$button--icon-margin: spacing(8);
 $button--padding: spacing(8);
-$button--padding--large: spacing(16);
-$button--text-align: center;
+$button--padding-large: spacing(16);
+$button--justify-content: center;
 $button--transition: 0.25s ease, color 0.25s ease, border-color 0.25s ease;
 
 /**
@@ -26,6 +26,7 @@ $button--default: (
 	'backgroundColor': greyscale(95),
 	'backgroundImage': linear-gradient(to bottom, white, greyscale(95)),
 	'border': $button--border-width-style greyscale(80),
+	'border-radius': 2px,
 	'visitedColor': color('action-base'),
 	'hoverColor': white,
 	'hoverBorder': $button--border-width-style greyscale(40),


### PR DESCRIPTION
* Fixed typo in $button--padding-large
* Changes to be compatible with global-button@0.2.0
  * Replace variable from $button--text-align to $button--justify-content
  * Move border-radius from base to themes
  * Bump extendsPackage to latest