### PR TITLE
update visited colors in springer-toolkit

### DIFF
--- a/toolkits/springer/packages/springer-context/HISTORY.md
+++ b/toolkits/springer/packages/springer-context/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 19.1.1 (2020-04-16)
+    * Change visited color
+    * Remove element state colors from heading-link mixin to maintain consistency with regular links
+
 ## 19.1.0 (2020-03-26)
 	* Bump global-context to 15.2.1
 	* Use global breakpoints

--- a/toolkits/springer/packages/springer-context/package.json
+++ b/toolkits/springer/packages/springer-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-context",
-  "version": "19.1.0",
+  "version": "19.1.1",
   "license": "MIT",
   "description": "Bootstrapping for all Springer components and products",
   "keywords": [

--- a/toolkits/springer/packages/springer-context/scss/10-settings/colors/default.scss
+++ b/toolkits/springer/packages/springer-context/scss/10-settings/colors/default.scss
@@ -11,7 +11,7 @@ $colors: (
 	'warning': #fc0,
 	'info': #004b83,
 	'success': #71ab0b,
-	'visited': #4500a7,
+	'visited': #a345C9,
 	'action-base': #004b83,
 	'action-light': scale-color(#004b83, $lightness: 10%),
 	'action-dull': #97bfd8,

--- a/toolkits/springer/packages/springer-context/scss/10-settings/colors/default.scss
+++ b/toolkits/springer/packages/springer-context/scss/10-settings/colors/default.scss
@@ -11,7 +11,7 @@ $colors: (
 	'warning': #fc0,
 	'info': #004b83,
 	'success': #71ab0b,
-	'visited': #a345C9,
+	'visited': #a345c9,
 	'action-base': #004b83,
 	'action-light': scale-color(#004b83, $lightness: 10%),
 	'action-dull': #97bfd8,

--- a/toolkits/springer/packages/springer-context/scss/30-mixins/headings.scss
+++ b/toolkits/springer/packages/springer-context/scss/30-mixins/headings.scss
@@ -2,21 +2,11 @@
 	a {
 		text-decoration: none;
 
-		&:hover,
-		&:active {
-			color: color('action-base');
-		}
-
-		&:visited {
-			color: color('visited');
-		}
-
 		&:hover {
 			text-decoration: underline;
 		}
 
 		&:active {
-			color: color('action-light');
 			text-decoration: none;
 		}
 	}

--- a/toolkits/springer/packages/springer-context/scss/30-mixins/headings.scss
+++ b/toolkits/springer/packages/springer-context/scss/30-mixins/headings.scss
@@ -1,14 +1,6 @@
 @mixin heading-link {
 	a {
-		text-decoration: none;
-
-		&:hover {
-			text-decoration: underline;
-		}
-
-		&:active {
-			text-decoration: none;
-		}
+		@include interface-link;
 	}
 }
 


### PR DESCRIPTION
* Change visited color
* Remove element state colors from heading-link mixin to maintain consistency with regular links