### PR TITLE
The IE error with closest in internal navigation appears to come from…

### DIFF
--- a/toolkits/global/packages/global-article/HISTORY.md
+++ b/toolkits/global/packages/global-article/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 19.1.0 (2020-04-20)
+	* `closest` polyfill doesn't work in IE on SVG elements, since `InternalNavigation` isn't triggered from any elements using SVG we can just guard against the error and carry on
+
 ## 19.0.0 (2020-04-16)
 	* Remove support for `activeMediaQuery` from animate icon, we don't seem to have anything that still uses this
 	* Remove `deviceState` now it's not needed for  `activeMediaQuery`

--- a/toolkits/global/packages/global-article/js/internal-navigation.js
+++ b/toolkits/global/packages/global-article/js/internal-navigation.js
@@ -72,8 +72,6 @@ var InternalNavigation = (function (window, document) {
 			var target = null;
 			if (event.target && event.target.closest) {
 				target = event.target.closest('a');
-			} else if (window.Raven && window.Raven.captureMessage) {
-				window.Raven.captureMessage('failed to find link ' + event.target);
 			}
 			if (!target || !target.hash || (_exclude && target.classList.contains(_exclude))) {
 				return;

--- a/toolkits/global/packages/global-article/package.json
+++ b/toolkits/global/packages/global-article/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-article",
-  "version": "19.0.0",
+  "version": "19.1.0",
   "description": "Frontend package for article display",
   "license": "MIT",
   "peerDependencies": {


### PR DESCRIPTION
… the polyfill not working if an svg is clicked. Since no elements using svg are used by internal navigation we can just guard against the error and carry on