### PR TITLE
Bumps the global article version number

### DIFF
--- a/toolkits/springer/packages/springer-article/HISTORY.md
+++ b/toolkits/springer/packages/springer-article/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 0.6.0 (2020-04-21)
+    * Bump global article version to 19.1.0
+
 ## 0.5.0 (2020-03-17)
     * Bump global article version to 14.0.0
 

--- a/toolkits/springer/packages/springer-article/package.json
+++ b/toolkits/springer/packages/springer-article/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@springernature/springer-article",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Frontend package for Springer article",
   "license": "MIT",
   "peerDependencies": {
     "@springernature/springer-context": "18.2.4"
   },
-  "extendsPackage": "global-article@14.0.0"
+  "extendsPackage": "global-article@19.1.0"
 }


### PR DESCRIPTION
So that we can get the latest global article which use the most up to date breakpoints and naming.