### PR TITLE
Allow for explorers lovely non-standard key identifiers

### DIFF
--- a/toolkits/global/packages/global-autocomplete/HISTORY.md
+++ b/toolkits/global/packages/global-autocomplete/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 3.1.1 (2020-04-23)
+    * Allow for Explorer's non standard keypress identifiers
+
 ## 3.1.0 (2020-03-20)
     * Add `selectOnSuggestionBrowsing` setting to disable input text update as user browses the suggestions.
     * Remove expectation from user to provide `data-index` on each suggestion element.

--- a/toolkits/global/packages/global-autocomplete/js/index.js
+++ b/toolkits/global/packages/global-autocomplete/js/index.js
@@ -68,7 +68,7 @@ const autoComplete = arguments_ => {
 		}
 
 		container().addEventListener('keydown', event => {
-			if (['Escape', 'ArrowUp', 'ArrowDown'].includes(event.key)) {
+			if (['Escape', 'ArrowUp', 'Up', 'ArrowDown', 'Down'].includes(event.key)) {
 				event.preventDefault();
 				event.stopPropagation();
 			}
@@ -78,40 +78,35 @@ const autoComplete = arguments_ => {
 			let previousSibling = activeElement.previousSibling;
 			let currentIndex = Array.from(activeElement.parentNode.children).indexOf(activeElement);
 
-			switch (event.key) {
-				case 'ArrowDown':
-					if (nextSibling) {
-						if (selectOnSuggestionBrowsing) {
-							if ((currentIndex + 1) < suggestions().length) {
-								input.value = nextSibling.textContent;
-							} else {
-								input.value = currentSearchTerm;
-							}
-						}
-						nextSibling.focus();
-					}
-					break;
-
-				case 'ArrowUp':
-					if (previousSibling) {
-						if (selectOnSuggestionBrowsing) {
-							input.value = previousSibling.textContent;
-						}
-						previousSibling.focus();
-					} else {
-						input.focus();
-						if (selectOnSuggestionBrowsing) {
+			if (/ArrowDown|Down/.test(event.key)) {
+				if (nextSibling) {
+					if (selectOnSuggestionBrowsing) {
+						if ((currentIndex + 1) < suggestions().length) {
+							input.value = nextSibling.textContent;
+						} else {
 							input.value = currentSearchTerm;
 						}
 					}
-					break;
+					nextSibling.focus();
+				}
+			}
 
-				case 'Escape':
-					removeSuggestions();
-					input.value = currentSearchTerm;
-					break;
-				default:
-					break;
+			else if (/ArrowUp|Up/.test(event.key)) {
+				if (previousSibling) {
+					if (selectOnSuggestionBrowsing) {
+						input.value = previousSibling.textContent;
+					}
+					previousSibling.focus();
+				} else {
+					input.focus();
+					if (selectOnSuggestionBrowsing) {
+						input.value = currentSearchTerm;
+					}
+				}
+			}
+			else if (event.key === 'Escape') {
+				removeSuggestions();
+				input.value = currentSearchTerm;
 			}
 		});
 

--- a/toolkits/global/packages/global-autocomplete/js/index.js
+++ b/toolkits/global/packages/global-autocomplete/js/index.js
@@ -101,8 +101,7 @@ const autoComplete = arguments_ => {
 						input.value = currentSearchTerm;
 					}
 				}
-			}
-			else if (event.key === 'Escape') {
+			} else if (event.key === 'Escape') {
 				removeSuggestions();
 				input.value = currentSearchTerm;
 			}

--- a/toolkits/global/packages/global-autocomplete/js/index.js
+++ b/toolkits/global/packages/global-autocomplete/js/index.js
@@ -89,9 +89,7 @@ const autoComplete = arguments_ => {
 					}
 					nextSibling.focus();
 				}
-			}
-
-			else if (/ArrowUp|Up/.test(event.key)) {
+			} else if (/ArrowUp|Up/.test(event.key)) {
 				if (previousSibling) {
 					if (selectOnSuggestionBrowsing) {
 						input.value = previousSibling.textContent;

--- a/toolkits/global/packages/global-autocomplete/js/index.js
+++ b/toolkits/global/packages/global-autocomplete/js/index.js
@@ -31,7 +31,7 @@ const autoComplete = arguments_ => {
 		return Array.from(document.querySelectorAll(`${resultSelector}`));
 	};
 
-	const eventKeys = ['ArrowDown', 'ArrowUp', 'Escape', 'Enter', 'Tab'];
+	const eventKeys = ['ArrowDown', 'Down', 'ArrowUp', 'Up', 'Escape', 'Enter', 'Tab'];
 
 	let inputTimer = null;
 	let fetchTimer = null;
@@ -39,7 +39,7 @@ const autoComplete = arguments_ => {
 
 	// Keyboard Event Listeners for text input
 	const inputEvents = event => {
-		if (event.key === 'ArrowDown') {
+		if (/ArrowDown|Down/.test(event.key)) {
 			event.preventDefault();
 			if (suggestions().length > 0) {
 				suggestions()[0].focus();

--- a/toolkits/global/packages/global-autocomplete/package.json
+++ b/toolkits/global/packages/global-autocomplete/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-autocomplete",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "license": "MIT",
   "description": "Autocomplete/suggest component",
   "keywords": [],


### PR DESCRIPTION
Internet Explorer uses non-standard key identifiers, so this change allows for 'Down' in place of 'ArrrowDown' and 'Up' in place of 'ArrowUp'.



