### PR TITLE
Fixes a bug when using the color mapping

### DIFF
--- a/toolkits/springernature/packages/springer-nature-context/HISTORY.md
+++ b/toolkits/springernature/packages/springer-nature-context/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 2.0.2 (2019-06-21)
+	* BUG: 10-settings/colors.scss missing greyscale options required by colour mapping mixin
+
 ## 2.0.1 (2019-06-21)
 	* BUG: 30-mixins/breakpoints.scss from global renamed 30-mixins/media-query
 

--- a/toolkits/springernature/packages/springer-nature-context/HISTORY.md
+++ b/toolkits/springernature/packages/springer-nature-context/HISTORY.md
@@ -1,6 +1,6 @@
 # History
 
-## 2.0.2 (2019-06-21)
+## 2.0.2 (2020-05-04)
 	* BUG: 10-settings/colors.scss missing greyscale options required by colour mapping mixin
 
 ## 2.0.1 (2019-06-21)

--- a/toolkits/springernature/packages/springer-nature-context/package.json
+++ b/toolkits/springernature/packages/springer-nature-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-nature-context",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "license": "MIT",
   "description": "Boostrapping for all Springer Nature components and products",
   "keywords": [],

--- a/toolkits/springernature/packages/springer-nature-context/scss/10-settings/colors.scss
+++ b/toolkits/springernature/packages/springer-nature-context/scss/10-settings/colors.scss
@@ -22,3 +22,14 @@ $colors: (
 	'blue': #007e99,
 	'red': #c64040,
 );
+
+/**
+ * Color and gray scales
+ *
+ */
+
+$page-base: #f8f;
+$greyscale-base: #555;
+$greyscale-min: 20;
+$greyscale-max: 95;
+$greyscale-stops: 5;


### PR DESCRIPTION
Fixes a bug when using the color mapping as sprignernature-context colors.scss did not contain greyscale references.

Greyscale colors taken from references designs for Springer Nature product design language