### PR TITLE
global-javascript

### DIFF
--- a/toolkits/global/packages/global-javascript/HISTORY.md
+++ b/toolkits/global/packages/global-javascript/HISTORY.md
@@ -1,0 +1,4 @@
+# History
+
+## 1.0.0 (2020-04-30)
+    * Copied out of `global-context@15.3.1`

--- a/toolkits/global/packages/global-javascript/README.md
+++ b/toolkits/global/packages/global-javascript/README.md
@@ -1,0 +1,79 @@
+# Global Javascript
+
+Shared Javascript that can be included in your project or component.
+
+## Helpers
+
+A collection of JavaScript helpers to achieve common, repetitive tasks.
+
+### Usage
+
+You can import as many of the named exports from the helpers as you require for your project.
+
+```javascript
+    import {helper1, helper2} from '@springernature/global-context/helpers';
+```
+
+**Util**
+- [makeArray](#makearray)
+
+
+**Dom**
+- [getDataOptions](#getDataOptions)
+
+### Util
+Util helpers are used to help achieve JavaScript tasks that do not involve touching the DOM.
+
+#### makeArray
+Makes an array from an iterable.
+Commonly used for converting a NodeList into an Array so array methods can then be used on the iterable.
+
+```javascript
+const elementsNodeList = document.querySelectorAll('.elements');
+const elementsArray = makeArray(elementsNodeList);
+
+elementsArray.forEach(element => {
+	// Do something
+});
+```
+
+### Dom
+Dom helpers are used to help achieve JavaScript tasks that involve getting information from, or manipulating the DOM.
+
+#### getDataOptions
+Takes an element and an Object of component options and data-attribute selectors and returns the an Object with the value for those data-attributes.
+Because it returns an Object, it is easy to merge with other options Objects, such as the default options.
+
+```html
+<div class="my-component" data-mycomponent-option1="foo" data-mycomponent-option2="bar" data-mycomponent-option3="baz">My Component</div>
+```
+
+```javascript
+// my-component.js
+const DataOptions = {
+	OPTION_1: 'data-mycomponent-option1',
+	OPTION_2: 'data-mycomponent-option2',
+	OPTION_3: 'data-mycomponent-option3',
+};
+
+const component = document.querySelector('.my-component');
+
+const options = getDataOptions(component, DataOptions);
+
+console.log(options);
+
+// Output:
+
+// {
+//	OPTION_1: 'foo',
+//	OPTION_2: 'bar',
+//	OPTION_3: 'baz',
+// }
+``` 
+
+
+## License
+
+[MIT License][info-license] &copy; 2020, Springer Nature
+
+[info-license]: https://github.com/springernature/frontend-toolkits/blob/master/LICENSE

--- a/toolkits/global/packages/global-javascript/__tests__/unit/dom/get-data-options.spec.js
+++ b/toolkits/global/packages/global-javascript/__tests__/unit/dom/get-data-options.spec.js
@@ -1,0 +1,22 @@
+import {getDataOptions} from '../../../js/helpers';
+
+describe('getDataOptions', () => {
+	const DataOptions = {
+		OPTION_1: 'data-mycomponent-option1',
+		OPTION_2: 'data-mycomponent-option2',
+		OPTION_3: 'data-mycomponent-option3'
+	};
+
+	beforeEach(() => {
+		document.body.innerHTML = `
+			<div data-mycomponent-option1="foo" data-mycomponent-option2="bar" data-mycomponent-option3="baz" data-notmycomponent="test">My Component</div>
+		`;
+	});
+
+	test('Should return an Object with the values for each key as the values of the data-attributes', () => {
+		const component = document.querySelector('div');
+		const options = getDataOptions(component, DataOptions);
+
+		expect(options).toMatchObject({OPTION_1: 'foo', OPTION_2: 'bar', OPTION_3: 'baz'});
+	});
+});

--- a/toolkits/global/packages/global-javascript/__tests__/unit/util/make-array.spec.js
+++ b/toolkits/global/packages/global-javascript/__tests__/unit/util/make-array.spec.js
@@ -1,0 +1,18 @@
+import {makeArray} from '../../../js/helpers';
+
+describe('makeArray', () => {
+	test('Should take a node list and return an array', () => {
+		// Given
+		document.body.innerHTML = `
+			<div>Node 1</div>
+			<div>Node 2</div>
+			<div>Node 3</div>
+			<div>Node 4</div>
+		`;
+		let nodes = document.querySelectorAll('div');
+		// When
+		nodes = makeArray(nodes);
+		// Then
+		expect(Array.isArray(nodes)).toBe(true);
+	});
+});

--- a/toolkits/global/packages/global-javascript/js/helpers/dom/get-data-options.js
+++ b/toolkits/global/packages/global-javascript/js/helpers/dom/get-data-options.js
@@ -1,0 +1,26 @@
+/**
+ * @param element
+ * @param attributeMap - An Object of data attribute options
+ * @returns Object
+ */
+const getDataOptions = (element, attributeMap) => {
+	const dataOptions = {};
+
+	for (const key in attributeMap) {
+		// eslint-disable-next-line no-prototype-builtins
+		if (attributeMap.hasOwnProperty(key)) {
+			let value = attributeMap[key];
+			const attributeValue = element.hasAttribute(value) && element.getAttribute(value);
+
+			if (attributeValue) {
+				dataOptions[key] = attributeValue;
+			}
+		}
+	}
+
+	return dataOptions;
+};
+
+export {
+	getDataOptions
+};

--- a/toolkits/global/packages/global-javascript/js/helpers/index.js
+++ b/toolkits/global/packages/global-javascript/js/helpers/index.js
@@ -1,0 +1,7 @@
+// Util
+import {makeArray} from './util/make-array';
+
+// Dom
+import {getDataOptions} from './dom/get-data-options';
+
+export {makeArray, getDataOptions};

--- a/toolkits/global/packages/global-javascript/js/helpers/util/make-array.js
+++ b/toolkits/global/packages/global-javascript/js/helpers/util/make-array.js
@@ -1,0 +1,15 @@
+const makeArray = iterable => {
+	const list = [];
+
+	if (!iterable) {
+		return list;
+	}
+
+	for (const item of iterable) {
+		list.push(item);
+	}
+
+	return list;
+};
+
+export {makeArray};

--- a/toolkits/global/packages/global-javascript/package.json
+++ b/toolkits/global/packages/global-javascript/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@springernature/global-javascript",
+  "version": "1.0.0",
+  "license": "MIT",
+  "description": "Globally shared Javascript helpers",
+  "keywords": [
+    "javascript",
+    "modules",
+    "helpers",
+    "es6"
+  ],
+  "author": "Springer Nature"
+}


### PR DESCRIPTION
Move javascript helpers out of `global-context` into its own package. No new code here, just publishing as a separate package