### PR TITLE
[CM] Add print hiding utility class to brand context

### DIFF
--- a/context/brand-context/default/scss/60-utilities/hiding.scss
+++ b/context/brand-context/default/scss/60-utilities/hiding.scss
@@ -51,8 +51,6 @@
 	overflow: hidden;
 }
 
-/* hide from print */
-
 @media print {
 	.u-hide-print {
 		display: none;

--- a/context/brand-context/default/scss/60-utilities/hiding.scss
+++ b/context/brand-context/default/scss/60-utilities/hiding.scss
@@ -50,3 +50,11 @@
 .u-hide-overflow {
 	overflow: hidden;
 }
+
+/* hide from print */
+
+@media print {
+	.u-hide-print {
+		display: none;
+	}
+}


### PR DESCRIPTION
Adding `.u-hide-print` to the brand context (as advised by @davidpauljunior ) so that the Briefing banner can use it.