### PR TITLE
v2.1.1

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,7 +1,10 @@
 # History
 
+## 2.1.1 (2020-05-22)
+    * BUG: missing dependency `rfs`, used for `font-size()` in Springer brand
+
 ## 2.1.0 (2020-05-14)
- * Adds springer nature heading typography and utilities
+    * Adds springer nature heading typography and utilities
 
 ## 2.0.0 (2020-05-12)
 	* FEATURE: add `.u-hide-print` utility class

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@springernature/brand-context",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],
-  "author": "Springer Nature"
+  "author": "Springer Nature",
+  "dependencies": {
+    "rfs": "^8.0.4"
+  }
 }


### PR DESCRIPTION
BUG FIX: Missing dependency `rfs`, used by the springer context brand to do responsive font sizing using `font-size()` @mixin.