### PR TITLE
Update Springer Heading Typography

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,5 +1,14 @@
 # History
 
+## 2.2.0 (2020-06-03)
+    * FEATURE: Change heading typography to improve page hierarchy
+        * All headings to use $line-height-tight
+        * All headings to have 1em margin bottom
+        * All headings to stop using rfs mixin
+        * h1: 28px => 32px
+        * h2: 26px => 28px
+        * h4: serif => sans-serif
+
 ## 2.1.1 (2020-05-22)
     * BUG: missing dependency `rfs`, used for `font-size()` in Springer brand
 

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/springer/scss/10-settings/typography.scss
+++ b/context/brand-context/springer/scss/10-settings/typography.scss
@@ -11,7 +11,13 @@ $font-size-xxl: 32px;
 $font-size-h1: 3.2rem;
 $font-size-h2: 2.8rem;
 $font-size-h3: 2.4rem;
-$font-size-h4: 1.8rem;
+$font-size-h4: 2rem;
+
+// Fluid typography
+$font-size-h1-min: $font-size-h2;
+$font-size-h2-min: $font-size-h3;
+$font-size-h3-min: $font-size-h4;
+$font-size-h4-min: 1.8rem; // Body typography size
 
 $font-size-furniture: $font-size-sm;
 $font-size-interface: $font-size-sm;

--- a/context/brand-context/springer/scss/10-settings/typography.scss
+++ b/context/brand-context/springer/scss/10-settings/typography.scss
@@ -5,20 +5,19 @@ $font-size-xs: 14px;
 $font-size-sm: 16px;
 $font-size-md: 18px;
 $font-size-lg: 24px;
-$font-size-xl: 26px;
-$font-size-xxl: 28px;
+$font-size-xl: 28px;
+$font-size-xxl: 32px;
+
+$font-size-h1: 3.2rem;
+$font-size-h2: 2.8rem;
+$font-size-h3: 2.4rem;
+$font-size-h4: 1.8rem;
 
 $font-size-furniture: $font-size-sm;
 $font-size-interface: $font-size-sm;
 
 $font-weight-normal: 400;
 $font-weight-bold: 700;
-
-$font-weight: (
-	// sass-lint:disable-block indentation
-	normal: 400,
-	bold: 700,
-);
 
 $line-height-base: 1.61803398875; // golden ratio
 $line-height-tight: 1.4;

--- a/context/brand-context/springer/scss/30-mixins/headings.scss
+++ b/context/brand-context/springer/scss/30-mixins/headings.scss
@@ -11,6 +11,7 @@
 @mixin h1 {
 	@include heading-base;
 	font-size: $font-size-h1;
+	font-size: min(max($font-size-h1-min, 4vw), $font-size-h1);
 	font-family: $font-family-serif;
 	font-weight: $font-weight-normal;
 }
@@ -18,6 +19,7 @@
 @mixin h2 {
 	@include heading-base;
 	font-size: $font-size-h2;
+	font-size: min(max($font-size-h2-min, 3.5vw), $font-size-h2);
 	font-family: $font-family-serif;
 	font-weight: $font-weight-normal;
 }
@@ -25,6 +27,7 @@
 @mixin h3 {
 	@include heading-base;
 	font-size: $font-size-h3;
+	font-size: min(max($font-size-h3-min, 3vw), $font-size-h3);
 	font-family: $font-family-serif;
 	font-weight: $font-weight-normal;
 }
@@ -32,6 +35,7 @@
 @mixin h4 {
 	@include heading-base;
 	font-size: $font-size-h4;
+	font-size: min(max($font-size-h4-min, 2.5vw), $font-size-h4);
 	font-family: $font-family-sans;
 	font-weight: $font-weight-bold;
 }

--- a/context/brand-context/springer/scss/30-mixins/headings.scss
+++ b/context/brand-context/springer/scss/30-mixins/headings.scss
@@ -1,45 +1,37 @@
-@mixin heading-link {
+@mixin heading-base {
+	font-style: normal;
+	margin-bottom: 1em;
+	line-height: $line-height-tight;
+
 	a {
 		@include interface-link;
 	}
 }
 
 @mixin h1 {
-	@include heading-link;
-	@include font-size($font-size-xxl);
+	@include heading-base;
+	font-size: $font-size-h1;
 	font-family: $font-family-serif;
-	font-style: normal;
-	font-weight: 400;
-	line-height: (42 / 32);
-	margin-bottom: 0.5em;
+	font-weight: $font-weight-normal;
 }
 
 @mixin h2 {
-	@include heading-link;
-	@include font-size($font-size-xl);
+	@include heading-base;
+	font-size: $font-size-h2;
 	font-family: $font-family-serif;
-	font-style: normal;
-	font-weight: 400;
-	line-height: (36 / 26);
-	margin-bottom: 0.5em;
+	font-weight: $font-weight-normal;
 }
 
 @mixin h3 {
-	@include heading-link;
-	@include font-size($font-size-lg);
+	@include heading-base;
+	font-size: $font-size-h3;
 	font-family: $font-family-serif;
-	font-style: normal;
-	font-weight: 400;
-	line-height: (28 / 21);
-	margin-bottom: 0.7em;
+	font-weight: $font-weight-normal;
 }
 
 @mixin h4 {
-	@include heading-link;
-	@include font-size($font-size-md);
-	font-family: $font-family-serif;
-	font-style: normal;
-	font-weight: 700;
-	line-height: (28 / 20);
-	margin-bottom: 0.7em;
+	@include heading-base;
+	font-size: $font-size-h4;
+	font-family: $font-family-sans;
+	font-weight: $font-weight-bold;
 }

--- a/context/brand-context/springer/scss/60-utilities/typography.scss
+++ b/context/brand-context/springer/scss/60-utilities/typography.scss
@@ -30,10 +30,12 @@
 	@include u-text-right;
 }
 
-@each $weight, $value in $font-weight {
-	.u-text-#{$weight} {
-		@include u-text-weight($weight);
-	}
+.u-text-normal {
+	font-weight: $font-weight-normal;
+}
+
+.u-text-bold {
+	font-weight: $font-weight-bold;
 }
 
 .u-word-wrap {


### PR DESCRIPTION
* All headings to use $line-height-tight
* All headings to have 1em margin bottom
* All headings to stop using rfs mixin
* h1: 28px => 32px
* h2: 26px => 28px
* h4: serif => sans-serif

**Old**
<img width="878" alt="Screenshot 2020-06-03 at 08 26 20" src="https://user-images.githubusercontent.com/1489314/83611191-8e488f80-a578-11ea-8681-adb2cf0c9b4f.png">

**New**
<img width="890" alt="Screenshot 2020-06-03 at 08 28 21" src="https://user-images.githubusercontent.com/1489314/83611239-9acce800-a578-11ea-8560-b28502c643c1.png">
