### PR TITLE
Springer headings variable compilation fix

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 2.2.1 (2020-06-03)
+    * BUG: unquote use of native css min/max variables to fix scss compilation error
+
 ## 2.2.0 (2020-06-03)
     * FEATURE: Change heading typography to improve page hierarchy
         * All headings to use $line-height-tight

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/springer/scss/30-mixins/headings.scss
+++ b/context/brand-context/springer/scss/30-mixins/headings.scss
@@ -11,7 +11,7 @@
 @mixin h1 {
 	@include heading-base;
 	font-size: $font-size-h1;
-	font-size: min(max($font-size-h1-min, 4vw), $font-size-h1);
+	font-size: unquote('min(max(#{$font-size-h1-min}, 4vw), #{$font-size-h1})');
 	font-family: $font-family-serif;
 	font-weight: $font-weight-normal;
 }
@@ -19,7 +19,7 @@
 @mixin h2 {
 	@include heading-base;
 	font-size: $font-size-h2;
-	font-size: min(max($font-size-h2-min, 3.5vw), $font-size-h2);
+	font-size: unquote('min(max(#{$font-size-h2-min}, 3.5vw), #{$font-size-h2})');
 	font-family: $font-family-serif;
 	font-weight: $font-weight-normal;
 }
@@ -27,7 +27,7 @@
 @mixin h3 {
 	@include heading-base;
 	font-size: $font-size-h3;
-	font-size: min(max($font-size-h3-min, 3vw), $font-size-h3);
+	font-size: unquote('min(max(#{$font-size-h3-min}, 3vw), #{$font-size-h3})');
 	font-family: $font-family-serif;
 	font-weight: $font-weight-normal;
 }
@@ -35,7 +35,7 @@
 @mixin h4 {
 	@include heading-base;
 	font-size: $font-size-h4;
-	font-size: min(max($font-size-h4-min, 2.5vw), $font-size-h4);
+	font-size: unquote('min(max(#{$font-size-h4-min}, 2.5vw), #{$font-size-h4})');
 	font-family: $font-family-sans;
 	font-weight: $font-weight-bold;
 }


### PR DESCRIPTION
Native CSS variables and SCSS variables clash, causing a compilation error.
