### PR TITLE
Add button styles to the `brand-context`

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,5 +1,10 @@
 # History
 
+## 3.0.0 (2020-06-03)
+	* FEATURE: include branded button styles from `global-button` so they can be used in components
+	* BREAKING: Move `u-button-reset` mixin/utility to avoid confusion
+	    * From `60-utilities/buttons` to `60-utilities/style`
+
 ## 2.2.1 (2020-06-03)
     * BUG: unquote use of native css min/max variables to fix scss compilation error
 

--- a/context/brand-context/default/README.md
+++ b/context/brand-context/default/README.md
@@ -7,6 +7,7 @@ Use this context configuration in your product to skin components with the `defa
 	- [Greyscale](#greyscale)
 	- [Color](#color)
 	- [Foreground color](#foreground-color)
+- [Buttons](#buttons)
 - [Layers](#layers)
 - [Icons](#icons)
 
@@ -140,6 +141,151 @@ color: foreground-color(30);                               // returns the foregr
 color: foreground-color('blue');                           // returns the foreground color for the color from $colors
 color: foreground-color('npj-primary', $brand-colors);     // returns the foreground color for the color from $brand-colors
 color: foreground-color($var);                             // returns the foreground color for color stored as variable
+```
+
+## Buttons
+
+The context comes with branded button styles to use on buttons and links.
+
+### Use via `@mixin`
+
+If button styles are available for you brand then you get mixins included via the context
+
+#### Basic usage
+
+```scss
+// Default
+.my-class {
+	@include button-default;
+}
+```
+
+#### Themes
+
+Add theme classes for different branding styles. If a theme does not exist for the brand you are using it will be ignored.
+
+```scss
+// Primary
+.my-class {
+	@include button-default;
+	@include button-primary;
+}
+
+// Ghost
+.my-class {
+	@include button-default;
+	@include button-ghost;
+}
+
+// Disabled
+.my-class {
+	@include button-default;
+	@include button-disabled;
+}
+```
+
+#### Variants
+
+Variant modifiers can be added to the default class, as well as to themes.
+
+```scss
+// Small
+.my-class {
+	@include button-default;
+	@include button-small;
+}
+
+// Large
+.my-class {
+	@include button-default;
+	@include button-large;
+}
+
+
+// Full width
+.my-class {
+	@include button-default;
+	@include button-full-width;
+}
+
+// Icon left
+.my-class {
+	@include button-default;
+	@include button-icon-left;
+}
+
+// Icon right
+.my-class {
+	@include button-default;
+	@include button-icon-right;
+}
+```
+
+### Use via utility classes
+
+The button utility classes are an exception to how utilities usually work, as they modify the styling of elements. For this reason it is preferable to use the relevant `@mixin` within an existing component, but the utility classes can be used if you need them.
+
+```scss
+// Incude the button utility classes
+@import '@springernature/brand-context/default/scss/60-utilities/buttons';
+```
+
+#### Basic usage
+
+```html
+<button class="c-button">text</button>
+
+<a class="c-button" href="#">text</a> 
+```
+
+#### Themes
+
+Add theme classes for different branding styles. If a theme does not exist for the brand you are using it will be ignored.
+
+```html
+<!-- Primary -->
+<button class="c-button c-button--primary">text</button>
+
+<!-- Ghost -->
+<button class="c-button c-button--ghost">text</button>
+
+<!-- Disabled -->
+<button class="c-button c-button--disabled" disabled>text</button>
+```
+
+#### Variants
+
+Variant modifiers can be added to the default class, as well as to themes.
+
+```html
+<!-- Small -->
+<button class="c-button c-button--small">text</button>
+```
+
+```html
+<!-- Large -->
+<button class="c-button c-button--large">text</button>
+```
+
+```html
+<!-- Full width -->
+<button class="c-button c-button--full-width">text</button>
+```
+
+```html
+<!-- Icon left -->
+<button class="c-button c-button--icon-left">
+    <svg></svg>
+    <span>text</span>
+</button>
+```
+
+```html
+<!-- Icon right -->
+<button class="c-button c-button--icon-right">
+    <span>text</span>
+    <svg></svg>
+</button>
 ```
 
 ## Layers

--- a/context/brand-context/default/scss/10-settings/buttons.scss
+++ b/context/brand-context/default/scss/10-settings/buttons.scss
@@ -1,0 +1,65 @@
+/**
+ *  Button settings
+ *  Default
+ *
+ */
+
+$button--border-width-style: 1px solid;
+$button--line-height: 1.3;
+$button--font-family: sans-serif;
+$button--font-size-small: 1.4rem;
+$button--font-size-normal: 1.6rem;
+$button--font-size-large: 1.8rem;
+$button--icon-margin: spacing(8);
+$button--padding: spacing(8);
+$button--padding-large: spacing(16);
+$button--justify-content: center;
+$button--transition: 0.25s ease, color 0.25s ease, border-color 0.25s ease;
+
+// Button Themes
+// Variables to set themes styles
+
+$button--default: (
+	'border-radius': 2px,
+	'color': darkblue,
+	'backgroundColor': greyscale(95),
+	'backgroundImage': none,
+	'border': $button--border-width-style greyscale(80),
+	'visitedColor': darkblue,
+	'hoverColor': white,
+	'hoverBorder': $button--border-width-style greyscale(40),
+	'hoverBackgroundColor': greyscale(40),
+	'hoverBackgroundImage': none,
+	'hoverTextDecoration': none,
+	'focusBorder': $button--border-width-style greyscale(40),
+	'focusTextDecoration': none
+);
+
+$button--primary: (
+	'color': white,
+	'backgroundColor': darkblue,
+	'backgroundImage': none,
+	'border': $button--border-width-style blue,
+	'visitedColor': white,
+	'hoverColor': white,
+	'hoverBorder': $button--border-width-style blue,
+	'hoverBackgroundColor': blue,
+	'hoverBackgroundImage': none,
+	'focusBorder': $button--border-width-style blue,
+);
+
+$button--disabled: (
+	'color': greyscale(),
+	'backgroundColor': transparent,
+	'backgroundImage': none,
+	'border': $button--border-width-style greyscale(80),
+	'visitedColor': greyscale(),
+	'opacity': 0.7,
+	'hoverColor': greyscale(),
+	'hoverBorder': $button--border-width-style greyscale(80),
+	'hoverBackgroundColor': transparent,
+	'hoverBackgroundImage': none,
+	'hoverTextDecoration': none,
+	'focusBorder': $button--border-width-style greyscale(80),
+	'focusTextDecoration': none
+);

--- a/context/brand-context/default/scss/10-settings/buttons.scss
+++ b/context/brand-context/default/scss/10-settings/buttons.scss
@@ -4,6 +4,10 @@
  *
  */
 
+// Function dependencies
+@import '../20-functions/colors';
+@import '../20-functions/spacing';
+
 $button--border-width-style: 1px solid;
 $button--line-height: 1.3;
 $button--font-family: sans-serif;

--- a/context/brand-context/default/scss/30-mixins/buttons.scss
+++ b/context/brand-context/default/scss/30-mixins/buttons.scss
@@ -1,5 +1,77 @@
-@mixin u-button-reset {
-	background-color: transparent;
-	border: 0;
-	padding: 0;
+// Base button styles
+// No theme
+
+@mixin button-base {
+	align-items: center;
+	cursor: pointer;
+	display: inline-flex;
+	margin: 0;
+	position: relative;
+	text-decoration: none;
+	width: auto;
+	font-family: $button--font-family;
+	font-size: $button--font-size-normal;
+	line-height: $button--line-height;
+	justify-content: $button--justify-content;
+	padding: $button--padding;
+	transition: $button--transition;
 }
+
+// Add base button styles
+// with optional theme styles on top
+
+@mixin button($theme: false) {
+	@include button-base;
+	@if $theme {
+		@include button-theme($theme);
+	}
+}
+
+/**
+ * Add button theme
+ *
+ */
+
+@mixin button-theme($theme) {
+	color: map-get($theme, 'color');
+	background-color: map-get($theme, 'backgroundColor');
+	background-image: map-get($theme, 'backgroundImage');
+	border: map-get($theme, 'border');
+
+	&:visited {
+		color: map-get($theme, 'visitedColor');
+	}
+
+	&:hover {
+		border: map-get($theme, 'hoverBorder');
+		text-decoration: map-get($theme, 'hoverTextDecoration');
+	}
+
+	&:focus {
+		border: map-get($theme, 'focusBorder');
+		text-decoration: map-get($theme, 'focusTextDecoration');
+	}
+
+	&:hover,
+	&:focus {
+		color: map-get($theme, 'hoverColor');
+		background-color: map-get($theme, 'hoverBackgroundColor');
+		background-image: map-get($theme, 'hoverBackgroundImage');
+
+		svg path {
+			fill: map-get($theme, 'hoverColor');
+		}
+	}
+}
+
+/**
+ * Disabled Button
+ *
+ */
+
+@mixin button-disabled {
+	@include button-theme($button--disabled);
+	opacity: map-get($button--disabled, 'opacity');
+	cursor: default;
+}
+

--- a/context/brand-context/default/scss/30-mixins/buttons.scss
+++ b/context/brand-context/default/scss/30-mixins/buttons.scss
@@ -1,3 +1,67 @@
+/**
+ * Entrypoints
+ *
+ */
+
+// Default button
+
+@mixin button-default {
+	@include button($button--default);
+}
+
+// Button themes
+
+@mixin button-primary {
+	@if variable-exists('button--primary') {
+		@include button-theme($button--primary);
+	}
+}
+
+@mixin button-ghost {
+	@if variable-exists('button--ghost') {
+		@include button-theme($button--ghost);
+	}
+}
+
+@mixin button-disabled {
+	@if variable-exists('button--disabled') {
+		@include button-theme($button--disabled);
+	}
+}
+
+// Button variants
+
+@mixin button-small {
+	font-size: $button--font-size-small;
+}
+
+@mixin button-large {
+	font-size: $button--font-size-large;
+	padding: $button--padding-large;
+}
+
+@mixin button-full-width {
+	display: flex;
+	width: 100%;
+}
+
+@mixin button-icon-left {
+	svg {
+		margin-right: $button--icon-margin;
+	}
+}
+
+@mixin button-icon-right {
+	svg {
+		margin-left: $button--icon-margin;
+	}
+}
+
+/**
+ * Style mixins
+ *
+ */
+
 // Base button styles
 // No theme
 
@@ -27,10 +91,7 @@
 	}
 }
 
-/**
- * Add button theme
- *
- */
+// Add button theme
 
 @mixin button-theme($theme) {
 	color: map-get($theme, 'color');
@@ -62,16 +123,10 @@
 			fill: map-get($theme, 'hoverColor');
 		}
 	}
-}
 
-/**
- * Disabled Button
- *
- */
-
-@mixin button-disabled {
-	@include button-theme($button--disabled);
-	opacity: map-get($button--disabled, 'opacity');
-	cursor: default;
+	@if $theme == $button--disabled {
+		opacity: map-get($button--disabled, 'opacity');
+		cursor: default;
+	}
 }
 

--- a/context/brand-context/default/scss/30-mixins/style.scss
+++ b/context/brand-context/default/scss/30-mixins/style.scss
@@ -11,8 +11,18 @@
 	}
 }
 
-// Utilities
+// Style Utilities
+// Have conrresponding utility classes
+
+// Box shadow
 @mixin u-shadow {
 	border: 1px solid $context--shadow-border-color; // make optional?
 	box-shadow: $context--shadow-style $context--shadow-color;
+}
+
+// Button element reset
+@mixin u-button-reset {
+	background-color: transparent;
+	border: 0;
+	padding: 0;
 }

--- a/context/brand-context/default/scss/30-mixins/style.scss
+++ b/context/brand-context/default/scss/30-mixins/style.scss
@@ -20,7 +20,8 @@
 	box-shadow: $context--shadow-style $context--shadow-color;
 }
 
-// Button element reset
+// <button> element reset
+// Does not reset the branded buttons provided in context
 @mixin u-button-reset {
 	background-color: transparent;
 	border: 0;

--- a/context/brand-context/default/scss/60-utilities/buttons.scss
+++ b/context/brand-context/default/scss/60-utilities/buttons.scss
@@ -3,57 +3,45 @@
  * These are for styled branded buttons
  */
 
-// Regular buttons
+// Default button
 
 .u-button {
-	@include button($button--default);
+	@include button-default;
 }
 
-// button themes
+// Button themes
 
 .u-button--primary {
-	@if variable-exists('button--primary') {
-		@include button-theme($button--primary);
-	}
+	@include button-primary
 }
 
 .u-button--ghost {
-	@if variable-exists('button--ghost') {
-		@include button-theme($button--ghost);
-	}
+	@include button-ghost
 }
 
 .u-button--disabled,
 .u-button:disabled {
-	@if variable-exists('button--disabled') {
-		@include button-disabled;
-	}
+	@include button-disabled
 }
 
-// button variants
+// Button variants
 
 .u-button--small {
-	font-size: $button--font-size-small;
+	@include button-small;
 }
 
 .u-button--large {
-	font-size: $button--font-size-large;
-	padding: $button--padding-large;
+	@include button-large;
 }
 
 .u-button--full-width {
-	display: flex;
-	width: 100%;
+	@include button-full-width;
 }
 
 .u-button--icon-left {
-	svg {
-		margin-right: $button--icon-margin;
-	 }
+	@include button-icon-left;
 }
 
 .u-button--icon-right {
-	svg {
-		margin-left: $button--icon-margin;
-	 }
+	@include button-icon-right;
 }

--- a/context/brand-context/default/scss/60-utilities/buttons.scss
+++ b/context/brand-context/default/scss/60-utilities/buttons.scss
@@ -1,3 +1,59 @@
-.u-button-reset {
-	@include u-button-reset;
+/**
+ * Button utilities
+ * These are for styled branded buttons
+ */
+
+// Regular buttons
+
+.u-button {
+	@include button($button--default);
+}
+
+// button themes
+
+.u-button--primary {
+	@if variable-exists('button--primary') {
+		@include button-theme($button--primary);
+	}
+}
+
+.u-button--ghost {
+	@if variable-exists('button--ghost') {
+		@include button-theme($button--ghost);
+	}
+}
+
+.u-button--disabled,
+.u-button:disabled {
+	@if variable-exists('button--disabled') {
+		@include button-disabled;
+	}
+}
+
+// button variants
+
+.u-button--small {
+	font-size: $button--font-size-small;
+}
+
+.u-button--large {
+	font-size: $button--font-size-large;
+	padding: $button--padding-large;
+}
+
+.u-button--full-width {
+	display: flex;
+	width: 100%;
+}
+
+.u-button--icon-left {
+	svg {
+		margin-right: $button--icon-margin;
+	 }
+}
+
+.u-button--icon-right {
+	svg {
+		margin-left: $button--icon-margin;
+	 }
 }

--- a/context/brand-context/default/scss/60-utilities/style.scss
+++ b/context/brand-context/default/scss/60-utilities/style.scss
@@ -1,3 +1,7 @@
 .u-shadow {
 	@include u-shadow;
 }
+
+.u-button-reset {
+	@include u-button-reset;
+}

--- a/context/brand-context/default/scss/60-utilities/style.scss
+++ b/context/brand-context/default/scss/60-utilities/style.scss
@@ -2,6 +2,8 @@
 	@include u-shadow;
 }
 
+// <button> element reset
+// Does not reset the branded buttons provided in context
 .u-button-reset {
 	@include u-button-reset;
 }

--- a/context/brand-context/default/scss/abstracts.scss
+++ b/context/brand-context/default/scss/abstracts.scss
@@ -5,6 +5,7 @@
  */
 
 @import '10-settings/breakpoints';
+@import '10-settings/buttons';
 @import '10-settings/colors/default';
 @import '10-settings/colors/shared';
 @import '10-settings/spacing'; // needs to appear before container

--- a/context/brand-context/default/scss/abstracts.scss
+++ b/context/brand-context/default/scss/abstracts.scss
@@ -5,11 +5,11 @@
  */
 
 @import '10-settings/breakpoints';
-@import '10-settings/buttons';
 @import '10-settings/colors/default';
 @import '10-settings/colors/shared';
-@import '10-settings/spacing'; // needs to appear before container
-@import '10-settings/container';
+@import '10-settings/spacing';
+@import '10-settings/buttons'; // needs to appear after spacing
+@import '10-settings/container'; // needs to appear after spacing
 @import '10-settings/keyframes';
 @import '10-settings/layers';
 @import '10-settings/style';

--- a/context/brand-context/nature/scss/10-settings/buttons.scss
+++ b/context/brand-context/nature/scss/10-settings/buttons.scss
@@ -1,0 +1,50 @@
+/**
+ *  Button settings
+ *  Nature
+ *
+ */
+
+// Button Themes
+// Variables to set themes styles
+
+$button--default: (
+	'color': color('blue'),
+	'backgroundColor': transparent,
+	'backgroundImage': none,
+	'border': $button--border-width-style color('blue'),
+	'visitedColor': color('blue'),
+	'hoverColor': white,
+	'hoverBorder': $button--border-width-style color('blue'),
+	'hoverBackgroundColor': color('blue'),
+	'hoverBackgroundImage': none,
+	'focusBorder': $button--border-width-style color('blue')
+);
+
+$button--primary: (
+	'color': white,
+	'backgroundColor': color('blue'),
+	'backgroundImage': none,
+	'border': $button--border-width-style color('blue'),
+	'visitedColor': white,
+	'hoverColor': color('blue'),
+	'hoverBorder': $button--border-width-style color('blue'),
+	'hoverBackgroundColor': white,
+	'hoverBackgroundImage': none,
+	'focusBorder': $button--border-width-style color('blue')
+);
+
+$button--disabled: (
+	'color': greyscale(),
+	'backgroundColor': transparent,
+	'backgroundImage': none,
+	'border': $button--border-width-style greyscale(80),
+	'visitedColor': greyscale(),
+	'opacity': 0.7,
+	'hoverColor': greyscale(),
+	'hoverBorder': $button--border-width-style greyscale(80),
+	'hoverBackgroundColor': transparent,
+	'hoverBackgroundImage': none,
+	'hoverTextDecoration': none,
+	'focusBorder': $button--border-width-style greyscale(80),
+	'focusTextDecoration': none
+);

--- a/context/brand-context/nature/scss/abstracts.scss
+++ b/context/brand-context/nature/scss/abstracts.scss
@@ -4,6 +4,7 @@
  * These files don’t output any CSS when compiled
  */
 
+@import '10-settings/buttons';
 @import '10-settings/colors/default';
 @import '10-settings/keyframes';
 @import '10-settings/style';

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "2.2.1",
+  "version": "3.0.0",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/springer/scss/10-settings/buttons.scss
+++ b/context/brand-context/springer/scss/10-settings/buttons.scss
@@ -1,0 +1,70 @@
+/**
+ *  Button settings
+ *  Springer
+ *
+ */
+
+$button--font-family: $font-family-sans;
+$button--font-size-small: $font-size-xs;
+$button--font-size-normal: $font-size-sm;
+$button--font-size-large: $font-size-sm;
+
+// Button Themes
+// Variables to set themes styles
+
+$button--default: (
+	'color': color('action-base'),
+	'backgroundColor': greyscale(95),
+	'backgroundImage': linear-gradient(to bottom, white, greyscale(95)),
+	'border': $button--border-width-style greyscale(80),
+	'visitedColor': color('action-base'),
+	'hoverColor': white,
+	'hoverBorder': $button--border-width-style greyscale(40),
+	'hoverBackgroundColor': greyscale(40),
+	'hoverBackgroundImage': none,
+	'hoverTextDecoration': none,
+	'focusBorder': $button--border-width-style greyscale(40),
+	'focusTextDecoration': none
+);
+
+$button--primary: (
+	'color': white,
+	'backgroundColor': mix(white, color('corporate-light'), 20%),
+	'backgroundImage': linear-gradient(to bottom, mix(white, color('corporate-light'), 30%), mix(white, color('corporate-light'), 20%)),
+	'border': $button--border-width-style color('corporate-light', 0.5),
+	'visitedColor': white,
+	'hoverColor': white,
+	'hoverBorder': $button--border-width-style color('action-light'),
+	'hoverBackgroundColor': color('action-light'),
+	'hoverBackgroundImage': none,
+	'focusBorder': $button--border-width-style color('action-light')
+);
+
+$button--ghost: (
+	'color': greyscale(),
+	'backgroundColor': transparent,
+	'backgroundImage': none,
+	'borderColor': greyscale(70),
+	'visitedColor': greyscale(),
+	'hoverColor': greyscale(),
+	'hoverBorderColor': greyscale(40),
+	'hoverBackgroundColor': greyscale(95, 0.5),
+	'hoverBackgroundImage': none,
+	'focusBorderColor': greyscale(40),
+);
+
+$button--disabled: (
+	'color': greyscale(),
+	'backgroundColor': transparent,
+	'backgroundImage': none,
+	'border': $button--border-width-style greyscale(80),
+	'visitedColor': greyscale(),
+	'opacity': 0.67,
+	'hoverColor': greyscale(),
+	'hoverBorder': $button--border-width-style greyscale(80),
+	'hoverBackgroundColor': transparent,
+	'hoverBackgroundImage': none,
+	'hoverTextDecoration': none,
+	'focusBorder': $button--border-width-style greyscale(80),
+	'focusTextDecoration': none
+);

--- a/context/brand-context/springer/scss/abstracts.scss
+++ b/context/brand-context/springer/scss/abstracts.scss
@@ -4,9 +4,9 @@
  * These files don’t output any CSS when compiled
  */
 
-@import '10-settings/buttons';
 @import '10-settings/colors/default';
 @import '10-settings/typography';
+@import '10-settings/buttons'; // needs to appear after colors & typography
 
 @import '20-functions/em';
 @import '20-functions/strip-unit';

--- a/context/brand-context/springer/scss/abstracts.scss
+++ b/context/brand-context/springer/scss/abstracts.scss
@@ -4,6 +4,7 @@
  * These files don’t output any CSS when compiled
  */
 
+@import '10-settings/buttons';
 @import '10-settings/colors/default';
 @import '10-settings/typography';
 


### PR DESCRIPTION
Button styling is fairly "low level" and we have a few instances of components that need to use button styles, but we want to avoid cross-component dependencies.

This PR moves the code from `global-button` into the `brand-context` so that button styles are available to any component.

## Breaking Change

This involves a breaking change that moves the `u-button-reset` utility out of the `buttons.scss` file and into `style.scss` to make it more obvious that this does not relate to branded buttons, but rather the `<button>` element.