### PR TITLE
increase specificity on font styles for global-ad

### DIFF
--- a/toolkits/global/packages/global-ad/HISTORY.md
+++ b/toolkits/global/packages/global-ad/HISTORY.md
@@ -1,5 +1,10 @@
 # History
 
+## 0.0.3 (2020-06-11)
+    * Move font styles to `.c-ad__label` 
+    * Update readme examples
+	* Bump `brand-context` version
+	
 ## 0.0.2 (2020-06-08)
 	* Bump `brand-context` version
 

--- a/toolkits/global/packages/global-ad/HISTORY.md
+++ b/toolkits/global/packages/global-ad/HISTORY.md
@@ -3,7 +3,7 @@
 ## 0.0.3 (2020-06-11)
     * Move font styles to `.c-ad__label` 
     * Update readme examples
-	* Bump `brand-context` version
+    * Bump `brand-context` version
 	
 ## 0.0.2 (2020-06-08)
 	* Bump `brand-context` version

--- a/toolkits/global/packages/global-ad/README.md
+++ b/toolkits/global/packages/global-ad/README.md
@@ -12,7 +12,7 @@ Minimum height set for leaderboard and mpu slots to prevent reflow of layout.
 The `global-ad` component currently uses the `DEFAULT` brand only.
 
 ```scss
-// Inlcude this with your settings
+// Include this with your settings
 @import '@springernature/global-ad/scss/10-settings/default';
 
 // Include this with your other components
@@ -24,33 +24,33 @@ The `global-ad` component currently uses the `DEFAULT` brand only.
 #### HTML
 ```html
 <!--leaderboard-->
-<div class="c-ad c-ad--728x90">
+<aside class="c-ad c-ad--728x90">
     <div class="c-ad__inner">
         <p class="c-ad__label">Advertisement</p>
         <!--ad slot content here-->
     </div>
-</div>
+</aside>
 
-<div class="c-ad c-ad--970x90">
+<aside class="c-ad c-ad--970x90">
     <div class="c-ad__inner">
         <p class="c-ad__label">Advertisement</p>
         <!--ad slot content here-->
     </div>
-</div>
+</aside>
 
 <!--mpu-->
-<div class="c-ad c-ad--300x250">
+<aside class="c-ad c-ad--300x250">
     <div class="c-ad__inner">
         <p class="c-ad__label">Advertisement</p>
         <!--ad slot content here-->
     </div>
-</div>
+</aside>
 
 <!--skyscraper-->
-<div class="c-ad c-ad--160x600">
+<aside class="c-ad c-ad--160x600">
     <div class="c-ad__inner">
         <p class="c-ad__label">Advertisement</p>
         <!--ad slot content here-->
     </div>
-</div>
+</aside>
 ```

--- a/toolkits/global/packages/global-ad/package.json
+++ b/toolkits/global/packages/global-ad/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@springernature/global-ad",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "license": "MIT",
   "description": "adverts",
   "keywords": [],
   "author": "Springer Nature",
-  "brandContext": "^3.0.0"
+  "brandContext": "^3.1.0"
 }

--- a/toolkits/global/packages/global-ad/scss/10-settings/default.scss
+++ b/toolkits/global/packages/global-ad/scss/10-settings/default.scss
@@ -6,6 +6,7 @@
 
 $ad--font-family: $font-family-sans;
 $ad--font-size: 1.4rem;
+$ad--font-weight: normal;
 $ad--label-margin-bottom: spacing(4);
 $ad--label-color: #333;
 $ad--label-line-height: 1.5;

--- a/toolkits/global/packages/global-ad/scss/50-components/ad.scss
+++ b/toolkits/global/packages/global-ad/scss/50-components/ad.scss
@@ -1,7 +1,5 @@
 .c-ad {
 	display: none;
-	font-size: $ad--font-size;
-	font-family: $ad--font-family;
 	padding: $ad--leaderboard-padding;
 	text-align: center;
 
@@ -59,6 +57,9 @@
 }
 
 .c-ad__label {
+	font-size: $ad--font-size;
+	font-family: $ad--font-family;
+	font-weight: $ad--font-weight;
 	margin-bottom: $ad--label-margin-bottom;
 	color: $ad--label-color;
 	line-height: $ad--label-line-height;


### PR DESCRIPTION
- Move font styles to `.c-ad__label`
- Update readme examples
- Bump `brand-context` version