### PR TITLE
createEvent helper

### DIFF
--- a/toolkits/global/packages/global-javascript/HISTORY.md
+++ b/toolkits/global/packages/global-javascript/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 2.1.0 (2020-06-17)
+    * FEATURE: createEvent, custom namespaced events
+
 ## 2.0.0 (2020-05-13)
     * BREAKING: Rename folder from `js` to `src`
     * BUG: Fix package name in README

--- a/toolkits/global/packages/global-javascript/README.md
+++ b/toolkits/global/packages/global-javascript/README.md
@@ -16,6 +16,7 @@ You can import as many of the named exports from the helpers as you require for 
 
 **Util**
 - [makeArray](#makearray)
+- [createEvent](#createevent)
 
 
 **Dom**
@@ -35,6 +36,32 @@ const elementsArray = makeArray(elementsNodeList);
 elementsArray.forEach(element => {
 	// Do something
 });
+```
+
+#### createEvent
+Simple wrapper for [`customEvent`](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent) that enforces an event namespace of the form `namespace:event`.
+
+This should be the **default** method for component module communication, where the name of the component is used as the namespace.
+
+```javascript
+const elementToBind = document.getElementById('element');
+
+// Create event namespaced to component
+const event = createEvent('eventName', 'componentName', {
+	bubbles:true,
+	cancelable: true,
+	detail: {
+		hazcheeseburger: true
+	}
+});
+
+// Dispatch event
+elementToBind.dispatchEvent(event);
+
+// Listen for event
+elementToBind.addEventListener('componentName:eventName', function (event) {
+	// Do something
+}, false);
 ```
 
 ### Dom

--- a/toolkits/global/packages/global-javascript/README.md
+++ b/toolkits/global/packages/global-javascript/README.md
@@ -34,7 +34,7 @@ const elementsNodeList = document.querySelectorAll('.elements');
 const elementsArray = makeArray(elementsNodeList);
 
 elementsArray.forEach(element => {
-	// Do something
+    // Do something
 });
 ```
 
@@ -48,11 +48,11 @@ const elementToBind = document.getElementById('element');
 
 // Create event namespaced to component
 const event = createEvent('eventName', 'componentName', {
-	bubbles:true,
-	cancelable: true,
-	detail: {
-		hazcheeseburger: true
-	}
+    bubbles:true,
+    cancelable: true,
+    detail: {
+        hazcheeseburger: true
+    }
 });
 
 // Dispatch event
@@ -60,7 +60,7 @@ elementToBind.dispatchEvent(event);
 
 // Listen for event
 elementToBind.addEventListener('componentName:eventName', function (event) {
-	// Do something
+    // Do something
 }, false);
 ```
 
@@ -78,9 +78,9 @@ Because it returns an Object, it is easy to merge with other options Objects, su
 ```javascript
 // my-component.js
 const DataOptions = {
-	OPTION_1: 'data-mycomponent-option1',
-	OPTION_2: 'data-mycomponent-option2',
-	OPTION_3: 'data-mycomponent-option3',
+    OPTION_1: 'data-mycomponent-option1',
+    OPTION_2: 'data-mycomponent-option2',
+    OPTION_3: 'data-mycomponent-option3',
 };
 
 const component = document.querySelector('.my-component');

--- a/toolkits/global/packages/global-javascript/__tests__/unit/util/create-event.spec.js
+++ b/toolkits/global/packages/global-javascript/__tests__/unit/util/create-event.spec.js
@@ -1,0 +1,97 @@
+import {createEvent} from '../../../src/helpers';
+
+describe('createEvent: customEvent supported', function () {
+	it('Should be defined as a function', function () {
+		expect(function () {
+			createEvent('test', 'component');
+		}).not.toThrow();
+	});
+
+	it('Should work as expected', function () {
+		var event = createEvent('test', 'component');
+		expect(event.type).toEqual('component:test');
+	});
+
+	it('Should work as expected, with custom parameters', function () {
+		var event = createEvent('test', 'component', {
+			bubbles: true,
+			detail: {
+				hazcheeseburger: true
+			}
+		});
+		expect(event.type).toEqual('component:test');
+		expect(event.bubbles).toEqual(true);
+		expect(event.detail).toEqual({hazcheeseburger: true});
+	});
+
+	it('Should throw when no namespace defined', function () {
+		expect(function () {
+			createEvent('test');
+		}).toThrowError(new Error('Missing namespace in `createEvent` function'));
+	});
+
+	it('Should be possible to call .preventDefault', function () {
+		var event = createEvent('test', 'component', {cancelable: true});
+		event.preventDefault();
+		expect(event.defaultPrevented).toEqual(true);
+	});
+
+	it('Should be NOT be possible to call .preventDefault if cancelable not set', function () {
+		var event = createEvent('test', 'component');
+		event.preventDefault();
+		expect(event.defaultPrevented).toEqual(false);
+	});
+});
+
+describe('createEvent: customEvent NOT supported', function () {
+	const originalCustomEvent = window.CustomEvent;
+
+	beforeEach(() => {
+		window.CustomEvent = null;
+	});
+
+	afterEach(() => {
+		window.CustomEvent = originalCustomEvent;
+	});
+
+	it('Should be defined as a function', function () {
+		expect(function () {
+			createEvent('test', 'component');
+		}).not.toThrow();
+	});
+
+	it('Should work as expected', function () {
+		var event = createEvent('test', 'component');
+		expect(event.type).toEqual('component:test');
+	});
+
+	it('Should work as expected, with custom parameters', function () {
+		var event = createEvent('test', 'component', {
+			bubbles: true,
+			detail: {
+				hazcheeseburger: true
+			}
+		});
+		expect(event.type).toEqual('component:test');
+		expect(event.bubbles).toEqual(true);
+		expect(event.detail).toEqual({hazcheeseburger: true});
+	});
+
+	it('Should throw when no namespace defined', function () {
+		expect(function () {
+			createEvent('test');
+		}).toThrowError(new Error('Missing namespace in `createEvent` function'));
+	});
+
+	it('Should be possible to call .preventDefault', function () {
+		var event = createEvent('test', 'component', {cancelable: true});
+		event.preventDefault();
+		expect(event.defaultPrevented).toEqual(true);
+	});
+
+	it('Should be NOT be possible to call .preventDefault if cancelable not set', function () {
+		var event = createEvent('test', 'component');
+		event.preventDefault();
+		expect(event.defaultPrevented).toEqual(false);
+	});
+});

--- a/toolkits/global/packages/global-javascript/__tests__/unit/util/create-event.spec.js
+++ b/toolkits/global/packages/global-javascript/__tests__/unit/util/create-event.spec.js
@@ -2,7 +2,7 @@ import {createEvent} from '../../../src/helpers';
 
 describe('createEvent: customEvent supported', () => {
 	it('Should be defined as a function', () => {
-		expect(function () {
+		expect(() => {
 			createEvent('test', 'component');
 		}).not.toThrow();
 	});
@@ -25,7 +25,7 @@ describe('createEvent: customEvent supported', () => {
 	});
 
 	it('Should throw when no namespace defined', () => {
-		expect(function () {
+		expect(() => {
 			createEvent('test');
 		}).toThrowError(new Error('Missing namespace in `createEvent` function'));
 	});
@@ -55,7 +55,7 @@ describe('createEvent: customEvent NOT supported', () => {
 	});
 
 	it('Should be defined as a function', () => {
-		expect(function () {
+		expect(() => {
 			createEvent('test', 'component');
 		}).not.toThrow();
 	});
@@ -78,7 +78,7 @@ describe('createEvent: customEvent NOT supported', () => {
 	});
 
 	it('Should throw when no namespace defined', () => {
-		expect(function () {
+		expect(() => {
 			createEvent('test');
 		}).toThrowError(new Error('Missing namespace in `createEvent` function'));
 	});

--- a/toolkits/global/packages/global-javascript/__tests__/unit/util/create-event.spec.js
+++ b/toolkits/global/packages/global-javascript/__tests__/unit/util/create-event.spec.js
@@ -1,18 +1,18 @@
 import {createEvent} from '../../../src/helpers';
 
-describe('createEvent: customEvent supported', function () {
-	it('Should be defined as a function', function () {
+describe('createEvent: customEvent supported', () => {
+	it('Should be defined as a function', () => {
 		expect(function () {
 			createEvent('test', 'component');
 		}).not.toThrow();
 	});
 
-	it('Should work as expected', function () {
+	it('Should work as expected', () => {
 		var event = createEvent('test', 'component');
 		expect(event.type).toEqual('component:test');
 	});
 
-	it('Should work as expected, with custom parameters', function () {
+	it('Should work as expected, with custom parameters', () => {
 		var event = createEvent('test', 'component', {
 			bubbles: true,
 			detail: {
@@ -24,26 +24,26 @@ describe('createEvent: customEvent supported', function () {
 		expect(event.detail).toEqual({hazcheeseburger: true});
 	});
 
-	it('Should throw when no namespace defined', function () {
+	it('Should throw when no namespace defined', () => {
 		expect(function () {
 			createEvent('test');
 		}).toThrowError(new Error('Missing namespace in `createEvent` function'));
 	});
 
-	it('Should be possible to call .preventDefault', function () {
+	it('Should be possible to call .preventDefault', () => {
 		var event = createEvent('test', 'component', {cancelable: true});
 		event.preventDefault();
 		expect(event.defaultPrevented).toEqual(true);
 	});
 
-	it('Should be NOT be possible to call .preventDefault if cancelable not set', function () {
+	it('Should be NOT be possible to call .preventDefault if cancelable not set', () => {
 		var event = createEvent('test', 'component');
 		event.preventDefault();
 		expect(event.defaultPrevented).toEqual(false);
 	});
 });
 
-describe('createEvent: customEvent NOT supported', function () {
+describe('createEvent: customEvent NOT supported', () => {
 	const originalCustomEvent = window.CustomEvent;
 
 	beforeEach(() => {
@@ -54,18 +54,18 @@ describe('createEvent: customEvent NOT supported', function () {
 		window.CustomEvent = originalCustomEvent;
 	});
 
-	it('Should be defined as a function', function () {
+	it('Should be defined as a function', () => {
 		expect(function () {
 			createEvent('test', 'component');
 		}).not.toThrow();
 	});
 
-	it('Should work as expected', function () {
+	it('Should work as expected', () => {
 		var event = createEvent('test', 'component');
 		expect(event.type).toEqual('component:test');
 	});
 
-	it('Should work as expected, with custom parameters', function () {
+	it('Should work as expected, with custom parameters', () => {
 		var event = createEvent('test', 'component', {
 			bubbles: true,
 			detail: {
@@ -77,19 +77,19 @@ describe('createEvent: customEvent NOT supported', function () {
 		expect(event.detail).toEqual({hazcheeseburger: true});
 	});
 
-	it('Should throw when no namespace defined', function () {
+	it('Should throw when no namespace defined', () => {
 		expect(function () {
 			createEvent('test');
 		}).toThrowError(new Error('Missing namespace in `createEvent` function'));
 	});
 
-	it('Should be possible to call .preventDefault', function () {
+	it('Should be possible to call .preventDefault', () => {
 		var event = createEvent('test', 'component', {cancelable: true});
 		event.preventDefault();
 		expect(event.defaultPrevented).toEqual(true);
 	});
 
-	it('Should be NOT be possible to call .preventDefault if cancelable not set', function () {
+	it('Should be NOT be possible to call .preventDefault if cancelable not set', () => {
 		var event = createEvent('test', 'component');
 		event.preventDefault();
 		expect(event.defaultPrevented).toEqual(false);

--- a/toolkits/global/packages/global-javascript/package.json
+++ b/toolkits/global/packages/global-javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-javascript",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "description": "Globally shared Javascript helpers",
   "keywords": [

--- a/toolkits/global/packages/global-javascript/src/helpers/index.js
+++ b/toolkits/global/packages/global-javascript/src/helpers/index.js
@@ -1,7 +1,8 @@
 // Util
 import {makeArray} from './util/make-array';
+import {createEvent} from './util/create-event';
 
 // Dom
 import {getDataOptions} from './dom/get-data-options';
 
-export {makeArray, getDataOptions};
+export {makeArray, createEvent, getDataOptions};

--- a/toolkits/global/packages/global-javascript/src/helpers/util/create-event.js
+++ b/toolkits/global/packages/global-javascript/src/helpers/util/create-event.js
@@ -1,0 +1,46 @@
+/**
+ * create-event.js
+ * Wrapper for customEvent
+ * Generate namespaced events
+ */
+'use strict';
+
+/**
+ * Polyfill customEvent
+ * @function customEvent
+ * @param {String} eventName namespaced name of the event
+ * @param {Object=} _parameters customEvent options
+ * @return {Event}
+ */
+const customEvent = (eventName, _parameters) => {
+	_parameters = _parameters || {bubbles: false, cancelable: false, detail: null};
+	var event = document.createEvent('CustomEvent');
+	event.initCustomEvent(eventName, _parameters.bubbles, _parameters.cancelable, _parameters.detail);
+	return event;
+};
+
+/**
+ * Create a custom event
+ * @function createEvent
+ * @param {String} eventName name of the event
+ * @param {String} namespace namespace e.g. component name
+ * @param {Object=} _parameters customEvent options
+ * @return {Event}
+ */
+const createEvent = (eventName, namespace, _parameters) => {
+	let event;
+
+	if (namespace === undefined) {
+		throw new Error('Missing namespace in `createEvent` function');
+	}
+
+	if (typeof window.CustomEvent === 'function') {
+		event = new CustomEvent(`${namespace}:${eventName}`, _parameters);
+	} else {
+		event = customEvent(`${namespace}:${eventName}`, _parameters);
+	}
+
+	return event;
+};
+
+export {createEvent};


### PR DESCRIPTION
Creates a wrapper around `customEvent` that allows components to communicate with each other safely using namespaced events.

```javascript
const elementToBind = document.getElementById('element');

// Create event namespaced to component
const event = createEvent('eventName', 'componentName', {
    bubbles:true,
    cancelable: true,
    detail: {
        hazcheeseburger: true
    }
});

// Dispatch event
elementToBind.dispatchEvent(event);

// Listen for event
elementToBind.addEventListener('componentName:eventName', function (event) {
    // Do something
}, false);
```