### PR TITLE
Adds option to expander for callback that fires just before focus and…

### DIFF
--- a/toolkits/global/packages/global-expander/HISTORY.md
+++ b/toolkits/global/packages/global-expander/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 1.1.0 (2020-06-29)
+    * Adds beforeFocus option for calling a function just before target focus
+
 ## 1.0.0 (2020-05-13)
     * Use @springernature/global-javascript instead of deprecated global-context
 

--- a/toolkits/global/packages/global-expander/README.md
+++ b/toolkits/global/packages/global-expander/README.md
@@ -37,6 +37,7 @@ myExpander.init();
 | TRIGGER_OPEN_LABEL | -             | String  | Text to set on the trigger when open                                                                                  |
 | CLOSE_ON_FOCUS_OUT  | true          | Boolean | Closes when you click or tab outside of the target                                                                           |
 | AUTOFOCUS          | false         | Boolean | Set focus on the first tabbable element inside the target (will highlight text if appropriate, e.g. input with value) |
+| BEFORE_FOCUS       | undefined     | Function | Call callback just before Global Expander focuses on target |
 
 The data attribute options are the same, but are lowercase and hyphenated (and strings where the option is a boolean):
 
@@ -45,6 +46,7 @@ The data attribute options are the same, but are lowercase and hyphenated (and s
 - `data-expander-trigger-open-label`
 - `data-expander-close-on-clickoff`
 - `data-expander-autofocus`
+- `data-expander-before-focus`
 
 Note: data attribute options will take precedence over any options set during initialisation.
 

--- a/toolkits/global/packages/global-expander/__tests__/expander.spec.js
+++ b/toolkits/global/packages/global-expander/__tests__/expander.spec.js
@@ -358,6 +358,23 @@ describe('Expander', () => {
 			expect(input.selectionStart === 0).toBe(true);
 			expect(input.selectionEnd === input.value.length).toBe(true);
 		});
+
+		test('Should call BEFORE_FOCUS function if passed to constructor', () => {
+			// Given
+			const callback = () => {
+				const div = document.createElement('div');
+				div.setAttribute('data-before-focus', "");
+				document.body.appendChild(div);
+			};
+			const expander = new Expander(element.BUTTON, element.TARGET, {
+				BEFORE_FOCUS: callback
+			});
+			expander.init();
+			// When
+			element.BUTTON.click();
+			// Then
+			expect(document.querySelector('[data-before-focus]')).not.toBe(null);
+		});
 	});
 });
 

--- a/toolkits/global/packages/global-expander/__tests__/index.spec.js
+++ b/toolkits/global/packages/global-expander/__tests__/index.spec.js
@@ -50,7 +50,8 @@ describe('Data Attribute API', () => {
 			TRIGGER_OPEN_CLASS: 'init-trigger-open-class',
 			TRIGGER_OPEN_LABEL: 'init-trigger-open-label',
 			CLOSE_ON_CLICKOFF: false,
-			AUTOFOCUS: true
+			AUTOFOCUS: true,
+			BEFORE_FOCUS: undefined
 		};
 
 		// When
@@ -67,7 +68,8 @@ describe('Data Attribute API', () => {
 			TRIGGER_OPEN_CLASS: 'init-trigger-open-class',
 			TRIGGER_OPEN_LABEL: 'init-trigger-open-label',
 			CLOSE_ON_CLICKOFF: false,
-			AUTOFOCUS: true
+			AUTOFOCUS: true,
+			BEFORE_FOCUS: undefined
 		};
 
 		// When
@@ -79,7 +81,8 @@ describe('Data Attribute API', () => {
 			TRIGGER_OPEN_CLASS: 'data-trigger-open-class',
 			TRIGGER_OPEN_LABEL: 'data-trigger-shown-label',
 			CLOSE_ON_CLICKOFF: 'true',
-			AUTOFOCUS: 'false'
+			AUTOFOCUS: 'false',
+			BEFORE_FOCUS: undefined
 		});
 	});
 });

--- a/toolkits/global/packages/global-expander/js/expander.js
+++ b/toolkits/global/packages/global-expander/js/expander.js
@@ -9,7 +9,8 @@ const defaultOptions = {
 	TRIGGER_OPEN_CLASS: 'is-open',
 	TRIGGER_OPEN_LABEL: undefined,
 	CLOSE_ON_FOCUS_OUT: true,
-	AUTOFOCUS: false
+	AUTOFOCUS: false,
+	BEFORE_FOCUS: undefined
 };
 
 const Expander = class {
@@ -138,6 +139,10 @@ const Expander = class {
 
 		if (this._options.TRIGGER_OPEN_LABEL) {
 			this._triggerEl.textContent = this._options.TRIGGER_OPEN_LABEL;
+		}
+
+		if (this._options.BEFORE_FOCUS) {
+			this._options.BEFORE_FOCUS();
 		}
 
 		if (this._options.AUTOFOCUS) {

--- a/toolkits/global/packages/global-expander/js/expander.js
+++ b/toolkits/global/packages/global-expander/js/expander.js
@@ -142,7 +142,9 @@ const Expander = class {
 		}
 
 		if (this._options.BEFORE_FOCUS) {
+			/* eslint-disable new-cap */
 			this._options.BEFORE_FOCUS();
+			/* eslint-enable new-cap */
 		}
 
 		if (this._options.AUTOFOCUS) {

--- a/toolkits/global/packages/global-expander/js/index.js
+++ b/toolkits/global/packages/global-expander/js/index.js
@@ -8,7 +8,8 @@ const attributes = {
 	TRIGGER_OPEN_CLASS: DATA_COMPONENT + '-trigger-open-class',
 	TRIGGER_OPEN_LABEL: DATA_COMPONENT + '-trigger-open-label',
 	CLOSE_ON_CLICKOFF: DATA_COMPONENT + '-close-on-clickoff',
-	AUTOFOCUS: DATA_COMPONENT + '-autofocus'
+	AUTOFOCUS: DATA_COMPONENT + '-autofocus',
+	BEFORE_FOCUS: DATA_COMPONENT + '-before-focus'
 };
 
 /**

--- a/toolkits/global/packages/global-expander/package.json
+++ b/toolkits/global/packages/global-expander/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@springernature/global-expander",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Frontend package for expanding a target when clicking a toggle",
   "license": "MIT",
   "dependencies": {
-    "@springernature/global-javascript": "^2.0.0"
+    "@springernature/global-javascript": "^2.1.0"
   }
 }


### PR DESCRIPTION
… adds tests

If you want to use global-expander in a component that also needs to add click event handlers to the expander trigger element then you might run in to race condition issues between the handler that expander adds and the handler that your component adds.

This adds an option to expander to allow you to pass in a callback that is called just before expander focuses on the target element. And therefore prevents consumers of the expander from having to manage sequencing of handlers / race conditions.