### PR TITLE
Adds focus event to global expander

### DIFF
--- a/toolkits/global/packages/global-expander/HISTORY.md
+++ b/toolkits/global/packages/global-expander/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 1.1.0 (2020-06-30)
+    * Adds option to fire custom event just before expander focuses on target
+
 ## 1.0.0 (2020-05-13)
     * Use @springernature/global-javascript instead of deprecated global-context
 

--- a/toolkits/global/packages/global-expander/README.md
+++ b/toolkits/global/packages/global-expander/README.md
@@ -37,6 +37,7 @@ myExpander.init();
 | TRIGGER_OPEN_LABEL | -             | String  | Text to set on the trigger when open                                                                                  |
 | CLOSE_ON_FOCUS_OUT  | true          | Boolean | Closes when you click or tab outside of the target                                                                           |
 | AUTOFOCUS          | false         | Boolean | Set focus on the first tabbable element inside the target (will highlight text if appropriate, e.g. input with value) |
+| FOCUS_EVENT          | false         | Boolean | Dispatch custom event on trigger just before expander focuses on target |
 
 The data attribute options are the same, but are lowercase and hyphenated (and strings where the option is a boolean):
 
@@ -45,6 +46,7 @@ The data attribute options are the same, but are lowercase and hyphenated (and s
 - `data-expander-trigger-open-label`
 - `data-expander-close-on-clickoff`
 - `data-expander-autofocus`
+- `data-expander-focus-event`
 
 Note: data attribute options will take precedence over any options set during initialisation.
 

--- a/toolkits/global/packages/global-expander/__tests__/expander.spec.js
+++ b/toolkits/global/packages/global-expander/__tests__/expander.spec.js
@@ -358,6 +358,32 @@ describe('Expander', () => {
 			expect(input.selectionStart === 0).toBe(true);
 			expect(input.selectionEnd === input.value.length).toBe(true);
 		});
+
+		test('Should not fire focus event by default', () => {
+			// Given
+			const button = document.querySelector('[data-expander]');
+			const spy = jest.spyOn(button, 'dispatchEvent');
+			const expander = new Expander(element.BUTTON, element.TARGET, {});
+			expander.init();
+			// When
+			element.BUTTON.click();
+			// Then
+			expect(spy).not.toHaveBeenCalled();
+		});
+
+		test('Should fire event if FOCUS_EVENT: true option passed to constructor', () => {
+			// Given
+			const button = document.querySelector('[data-expander]');
+			const spy = jest.spyOn(button, 'dispatchEvent');
+			const expander = new Expander(element.BUTTON, element.TARGET, {
+				FOCUS_EVENT: true
+			});
+			expander.init();
+			// When
+			element.BUTTON.click();
+			// Then
+			expect(spy).toHaveBeenCalled();
+		});
 	});
 });
 

--- a/toolkits/global/packages/global-expander/__tests__/index.spec.js
+++ b/toolkits/global/packages/global-expander/__tests__/index.spec.js
@@ -50,7 +50,8 @@ describe('Data Attribute API', () => {
 			TRIGGER_OPEN_CLASS: 'init-trigger-open-class',
 			TRIGGER_OPEN_LABEL: 'init-trigger-open-label',
 			CLOSE_ON_CLICKOFF: false,
-			AUTOFOCUS: true
+			AUTOFOCUS: true,
+			FOCUS_EVENT: false
 		};
 
 		// When
@@ -67,7 +68,8 @@ describe('Data Attribute API', () => {
 			TRIGGER_OPEN_CLASS: 'init-trigger-open-class',
 			TRIGGER_OPEN_LABEL: 'init-trigger-open-label',
 			CLOSE_ON_CLICKOFF: false,
-			AUTOFOCUS: true
+			AUTOFOCUS: true,
+			FOCUS_EVENT: false
 		};
 
 		// When
@@ -79,7 +81,8 @@ describe('Data Attribute API', () => {
 			TRIGGER_OPEN_CLASS: 'data-trigger-open-class',
 			TRIGGER_OPEN_LABEL: 'data-trigger-shown-label',
 			CLOSE_ON_CLICKOFF: 'true',
-			AUTOFOCUS: 'false'
+			AUTOFOCUS: 'false',
+			FOCUS_EVENT: false
 		});
 	});
 });

--- a/toolkits/global/packages/global-expander/js/expander.js
+++ b/toolkits/global/packages/global-expander/js/expander.js
@@ -1,4 +1,4 @@
-import {makeArray} from '@springernature/global-javascript/src/helpers';
+import {makeArray, createEvent} from '@springernature/global-javascript/src/helpers';
 
 /**
  * Local Constants
@@ -9,7 +9,8 @@ const defaultOptions = {
 	TRIGGER_OPEN_CLASS: 'is-open',
 	TRIGGER_OPEN_LABEL: undefined,
 	CLOSE_ON_FOCUS_OUT: true,
-	AUTOFOCUS: false
+	AUTOFOCUS: false,
+	FOCUS_EVENT: false
 };
 
 const Expander = class {
@@ -138,6 +139,13 @@ const Expander = class {
 
 		if (this._options.TRIGGER_OPEN_LABEL) {
 			this._triggerEl.textContent = this._options.TRIGGER_OPEN_LABEL;
+		}
+
+		if (this._options.FOCUS_EVENT) {
+			const event = createEvent('focusTarget', 'globalExpander', {
+				bubbles: false
+			});
+			this._triggerEl.dispatchEvent(event);
 		}
 
 		if (this._options.AUTOFOCUS) {

--- a/toolkits/global/packages/global-expander/js/index.js
+++ b/toolkits/global/packages/global-expander/js/index.js
@@ -8,7 +8,8 @@ const attributes = {
 	TRIGGER_OPEN_CLASS: DATA_COMPONENT + '-trigger-open-class',
 	TRIGGER_OPEN_LABEL: DATA_COMPONENT + '-trigger-open-label',
 	CLOSE_ON_CLICKOFF: DATA_COMPONENT + '-close-on-clickoff',
-	AUTOFOCUS: DATA_COMPONENT + '-autofocus'
+	AUTOFOCUS: DATA_COMPONENT + '-autofocus',
+	FOCUS_EVENT: DATA_COMPONENT + '-focus-event'
 };
 
 /**

--- a/toolkits/global/packages/global-expander/package.json
+++ b/toolkits/global/packages/global-expander/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@springernature/global-expander",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Frontend package for expanding a target when clicking a toggle",
   "license": "MIT",
   "dependencies": {
-    "@springernature/global-javascript": "^2.0.0"
+    "@springernature/global-javascript": "^2.1.0"
   }
 }


### PR DESCRIPTION
Following on from https://github.com/springernature/frontend-toolkits/pull/289

When using global expander in another component there are times where you need to do something before global expander focuses on the target element. This custom event allows the consumer of global expander to set an event listener and react accordingly.