### PR TITLE
Makes it clear that open and close method are public

### DIFF
--- a/toolkits/global/packages/global-expander/HISTORY.md
+++ b/toolkits/global/packages/global-expander/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 1.1.1 (2020-06-30)
+    * Makes it clear that open and close methods are public
+
 ## 1.1.0 (2020-06-30)
     * Adds option to fire custom event just before expander focuses on target
 

--- a/toolkits/global/packages/global-expander/README.md
+++ b/toolkits/global/packages/global-expander/README.md
@@ -28,6 +28,13 @@ const myExpander = new Expander(trigger, target, options);
 myExpander.init();
 ``` 
 
+You can also manually open and close any instance of expander with:
+
+```javascript
+expander.open();
+expander.close();
+```
+
 ### Options
 
 | Option             | Default Value | Type    | Description |

--- a/toolkits/global/packages/global-expander/js/expander.js
+++ b/toolkits/global/packages/global-expander/js/expander.js
@@ -39,7 +39,7 @@ const Expander = class {
 		event.preventDefault();
 
 		if (this._isOpen) {
-			this._close();
+			this.close();
 		} else {
 			this.open();
 		}
@@ -50,7 +50,7 @@ const Expander = class {
 			event.preventDefault();
 
 			if (this._isOpen) {
-				this._close();
+				this.close();
 			} else {
 				this.open();
 			}
@@ -59,7 +59,7 @@ const Expander = class {
 
 	_handleDocumentKeydown(event) {
 		if (event.key === 'Escape') {
-			this._close();
+			this.close();
 			this._triggerEl.focus();
 		}
 
@@ -67,7 +67,7 @@ const Expander = class {
 			if (event.key === 'Tab') {
 				window.requestAnimationFrame(() => {
 					if (!this._targetTabbableItems.includes(document.activeElement)) {
-						this._close();
+						this.close();
 						this._triggerEl.focus();
 					}
 				});
@@ -82,7 +82,7 @@ const Expander = class {
 			return;
 		}
 
-		this._close();
+		this.close();
 	}
 
 	/**
@@ -169,7 +169,7 @@ const Expander = class {
 		this._updateAriaAttributes();
 		this._setupTemporaryEventListeners();
 	}
-	
+
 	close() {
 		if (!this._isOpen) {
 			return;

--- a/toolkits/global/packages/global-expander/js/expander.js
+++ b/toolkits/global/packages/global-expander/js/expander.js
@@ -169,8 +169,7 @@ const Expander = class {
 		this._updateAriaAttributes();
 		this._setupTemporaryEventListeners();
 	}
-
-
+	
 	close() {
 		if (!this._isOpen) {
 			return;

--- a/toolkits/global/packages/global-expander/js/expander.js
+++ b/toolkits/global/packages/global-expander/js/expander.js
@@ -41,7 +41,7 @@ const Expander = class {
 		if (this._isOpen) {
 			this._close();
 		} else {
-			this._open();
+			this.open();
 		}
 	}
 
@@ -52,7 +52,7 @@ const Expander = class {
 			if (this._isOpen) {
 				this._close();
 			} else {
-				this._open();
+				this.open();
 			}
 		}
 	}
@@ -124,10 +124,14 @@ const Expander = class {
 	}
 
 	/**
+	 * @public
+	 */
+
+	/**
 	 * Toggling
 	 */
 
-	_open() {
+	open() {
 		if (this._isOpen) {
 			return;
 		}
@@ -166,7 +170,8 @@ const Expander = class {
 		this._setupTemporaryEventListeners();
 	}
 
-	_close() {
+
+	close() {
 		if (!this._isOpen) {
 			return;
 		}
@@ -183,10 +188,6 @@ const Expander = class {
 		this._updateAriaAttributes();
 		this._removeTemporaryEventListeners();
 	}
-
-	/**
-	 * @public
-	 */
 
 	init() {
 		if (this._triggerEl.tagName === 'A' && this._triggerEl.getAttribute('href').charAt(0) === '#') {


### PR DESCRIPTION
Whether it was intentional or not I'm unsure but it already was the case that you can call `expander._close()` and `expander._open()` but this makes it more obvious when reading the code.

Also note that it is needed to expose these methods. For example if you have a close button on a popup that uses global-expander. That close button needs a way to close the popup, the best way being to manually call something like `expander.close()` (because you need to update expander instance's `isOpen` state)