### PR TITLE
handle AUTOFOCUS option in global-expander

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10647,9 +10647,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "lodash._reinterpolate": {

--- a/toolkits/global/packages/global-expander/HISTORY.md
+++ b/toolkits/global/packages/global-expander/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 2.0.1 (2020-07-20)
+    * Replace switch with if/else if when detecting AUTOFOCUS option
+    * Handle incorrect AUTOFOCUS options 
+
 ## 2.0.0 (2020-07-15)
     * Refactor AUTOFOCUS from boolean to string to set options
     * Update readme on refactored AUTOFOCUS option

--- a/toolkits/global/packages/global-expander/__tests__/expander.spec.js
+++ b/toolkits/global/packages/global-expander/__tests__/expander.spec.js
@@ -452,6 +452,33 @@ describe('Expander', () => {
 			expect(element.TARGET.classList.contains(className.HIDE)).toBe(false);
 		});
 
+		it('Should throw error when incorrect string option set on AUTOFOCUS', () => {
+			expect(() => {
+				const expander = new Expander(element.BUTTON, element.TARGET, {
+					AUTOFOCUS: 'firstTabbbbbbbbbbable'
+				});
+				expander.init()
+			}).toThrow(`AUTOFOCUS should be null, 'firstTabbable' or 'target'`);
+		});
+
+		it('Should throw error when number option set on AUTOFOCUS', () => {
+			expect(() => {
+				const expander = new Expander(element.BUTTON, element.TARGET, {
+					AUTOFOCUS: 1234
+				});
+				expander.init()
+			}).toThrow(`AUTOFOCUS should be null, 'firstTabbable' or 'target'`);
+		});
+
+		it('Should throw error when boolean option set on AUTOFOCUS', () => {
+			expect(() => {
+				const expander = new Expander(element.BUTTON, element.TARGET, {
+					AUTOFOCUS: true
+				});
+				expander.init()
+			}).toThrow(`AUTOFOCUS should be null, 'firstTabbable' or 'target'`);
+		});
+
 		test('Should focus on first tababble element inside target when AUTOFOCUS: firstTabbable and button is clicked on', () => {
 			// Given
 			element.TARGET.innerHTML = '<input type="text" value="value">';

--- a/toolkits/global/packages/global-expander/js/expander.js
+++ b/toolkits/global/packages/global-expander/js/expander.js
@@ -25,10 +25,14 @@ const Expander = class {
 
 		this._isOpen = false;
 
-		this._handleButtonClick = this._handleButtonClick.bind(this);
-		this._handleButtonKeydown = this._handleButtonKeydown.bind(this);
-		this._handleDocumentClick = this._handleDocumentClick.bind(this);
-		this._handleDocumentKeydown = this._handleDocumentKeydown.bind(this);
+		if (this._options.AUTOFOCUS === null || this._options.AUTOFOCUS === 'firstTabbable' || this._options.AUTOFOCUS === 'target') {
+			this._handleButtonClick = this._handleButtonClick.bind(this);
+			this._handleButtonKeydown = this._handleButtonKeydown.bind(this);
+			this._handleDocumentClick = this._handleDocumentClick.bind(this);
+			this._handleDocumentKeydown = this._handleDocumentKeydown.bind(this);
+		} else {
+			throw new Error(`AUTOFOCUS should be null, 'firstTabbable' or 'target'`);
+		}
 	}
 
 	/**
@@ -152,23 +156,20 @@ const Expander = class {
 			this._triggerEl.dispatchEvent(event);
 		}
 
-		switch (this._options.AUTOFOCUS) {
-			case 'firstTabbable':
-				if (this._targetTabbableItems.length > 0) {
-					const firstTabbableItem = this._targetTabbableItems[0];
-					firstTabbableItem.focus();
+		if (this._options.AUTOFOCUS === null) {
+			this._triggerEl.focus();
+		} else if (this._options.AUTOFOCUS === 'firstTabbable') {
+			if (this._targetTabbableItems.length > 0) {
+				const firstTabbableItem = this._targetTabbableItems[0];
+				firstTabbableItem.focus();
 
-					if (firstTabbableItem.setSelectionRange) {
-						firstTabbableItem.setSelectionRange(0, firstTabbableItem.value.length);
-					}
+				if (firstTabbableItem.setSelectionRange) {
+					firstTabbableItem.setSelectionRange(0, firstTabbableItem.value.length);
 				}
-				break;
-			case 'target':
-				this._targetEl.setAttribute('tabindex', '-1');
-				this._targetEl.focus();
-				break;
-			default:
-				break;
+			}
+		} else if (this._options.AUTOFOCUS === 'target') {
+			this._targetEl.setAttribute('tabindex', '-1');
+			this._targetEl.focus();
 		}
 
 		this._updateAriaAttributes();

--- a/toolkits/global/packages/global-expander/package.json
+++ b/toolkits/global/packages/global-expander/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-expander",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Frontend package for expanding a target when clicking a toggle",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
- handle values that are not accepted for `AUTOFOCUS`
- swap out `switch` for `if/else` when detecting values on `AUTOFOCUS`