### PR TITLE
Detect last tabbable item on tab out to set focus on trigger

### DIFF
--- a/toolkits/global/packages/global-expander/HISTORY.md
+++ b/toolkits/global/packages/global-expander/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 2.0.2 (2020-07-27)
+    * Detect last tabbable item on tab out to set focus on trigger    
+
 ## 2.0.1 (2020-07-20)
     * Replace switch with if/else if when detecting AUTOFOCUS option
     * Move AUTOFOCUS into private helper class

--- a/toolkits/global/packages/global-expander/HISTORY.md
+++ b/toolkits/global/packages/global-expander/HISTORY.md
@@ -1,7 +1,7 @@
 # History
 
-## 2.0.2 (2020-07-27)
-    * Detect last tabbable item on tab out to set focus on trigger    
+## 2.0.2 (2020-07-28)
+    * Refactor when to focus back to trigger during tabbing 
 
 ## 2.0.1 (2020-07-20)
     * Replace switch with if/else if when detecting AUTOFOCUS option

--- a/toolkits/global/packages/global-expander/__tests__/expander.spec.js
+++ b/toolkits/global/packages/global-expander/__tests__/expander.spec.js
@@ -27,12 +27,12 @@ const createKeydownEvent = key => {
 		case 'Escape':
 			event.key = 'Escape';
 			break;
-		case 'Tab':
-			event.key = 'Tab';
-			break;
 		case 'TabShift':
 			event.key = 'Tab';
 			event.shiftKey = true;
+			break;
+		case 'Tab':
+			event.key = 'Tab';
 			break;
 		default:
 			throw new Error('key should be "Enter", " " (Space), "Spacebar", "Escape" or "Tab"');

--- a/toolkits/global/packages/global-expander/__tests__/expander.spec.js
+++ b/toolkits/global/packages/global-expander/__tests__/expander.spec.js
@@ -54,6 +54,7 @@ describe('Expander', () => {
 
 		element.BUTTON = document.querySelector('button');
 		element.TARGET = document.querySelector('div');
+		element.FIRSTTABBABLE = document.querySelector('a');
 	});
 
 	describe('Expander Class Definition', () => {
@@ -357,13 +358,12 @@ describe('Expander', () => {
 
 		test('Should close and set focus on trigger when tab out of the target', done => {
 			// Given
-			element.ANCHOR = document.querySelector('a');
 			const expander = new Expander(element.BUTTON, element.TARGET);
 			expander.init();
 			element.BUTTON.click();
 			// When
 			const keydownTabEvent = createKeydownEvent('Tab');
-			element.ANCHOR.dispatchEvent(keydownTabEvent);
+			element.FIRSTTABBABLE.dispatchEvent(keydownTabEvent);
 			// Then
 			window.requestAnimationFrame(() => {
 				expect(element.BUTTON.classList.contains(className.OPEN)).toBe(false);
@@ -374,13 +374,12 @@ describe('Expander', () => {
 
 		test('Should close and set focus on trigger when tab out backwards of the target', done => {
 			// Given
-			element.ANCHOR = document.querySelector('a');
 			const expander = new Expander(element.BUTTON, element.TARGET, {AUTOFOCUS: 'target'});
 			expander.init();
 			element.BUTTON.click();
 			// When
 			const keydownTabShiftEvent = createKeydownEvent('TabShift');
-			element.ANCHOR.dispatchEvent(keydownTabShiftEvent);
+			element.FIRSTTABBABLE.dispatchEvent(keydownTabShiftEvent);
 			// Then
 			window.requestAnimationFrame(() => {
 				expect(element.BUTTON.classList.contains(className.OPEN)).toBe(false);

--- a/toolkits/global/packages/global-expander/__tests__/expander.spec.js
+++ b/toolkits/global/packages/global-expander/__tests__/expander.spec.js
@@ -360,7 +360,6 @@ describe('Expander', () => {
 			// When
 			const keydownTabEvent = createKeydownEvent('Tab');
 			element.ANCHOR.dispatchEvent(keydownTabEvent);
-
 			// Then
 			window.requestAnimationFrame(() => {
 				expect(element.BUTTON.classList.contains(className.OPEN)).toBe(false);

--- a/toolkits/global/packages/global-expander/__tests__/expander.spec.js
+++ b/toolkits/global/packages/global-expander/__tests__/expander.spec.js
@@ -353,16 +353,14 @@ describe('Expander', () => {
 
 		test('Should close and set focus on trigger when tab out of the target', done => {
 			// Given
-			const outsideElement = document.createElement('div');
-			outsideElement.setAttribute('tabindex', '-1');
-			element.TARGET.parentNode.insertBefore(outsideElement, element.TARGET.nextSibling);
+			element.ANCHOR = document.querySelector('a');
 			const expander = new Expander(element.BUTTON, element.TARGET);
 			expander.init();
 			element.BUTTON.click();
-			outsideElement.focus();
 			// When
 			const keydownTabEvent = createKeydownEvent('Tab');
-			element.TARGET.dispatchEvent(keydownTabEvent);
+			element.ANCHOR.dispatchEvent(keydownTabEvent);
+
 			// Then
 			window.requestAnimationFrame(() => {
 				expect(element.BUTTON.classList.contains(className.OPEN)).toBe(false);

--- a/toolkits/global/packages/global-expander/__tests__/expander.spec.js
+++ b/toolkits/global/packages/global-expander/__tests__/expander.spec.js
@@ -30,6 +30,10 @@ const createKeydownEvent = key => {
 		case 'Tab':
 			event.key = 'Tab';
 			break;
+		case 'TabShift':
+			event.key = 'Tab';
+			event.shiftKey = true;
+			break;
 		default:
 			throw new Error('key should be "Enter", " " (Space), "Spacebar", "Escape" or "Tab"');
 	}
@@ -360,6 +364,23 @@ describe('Expander', () => {
 			// When
 			const keydownTabEvent = createKeydownEvent('Tab');
 			element.ANCHOR.dispatchEvent(keydownTabEvent);
+			// Then
+			window.requestAnimationFrame(() => {
+				expect(element.BUTTON.classList.contains(className.OPEN)).toBe(false);
+				expect(element.TARGET.classList.contains(className.HIDE)).toBe(true);
+				done();
+			});
+		});
+
+		test('Should close and set focus on trigger when tab out backwards of the target', done => {
+			// Given
+			element.ANCHOR = document.querySelector('a');
+			const expander = new Expander(element.BUTTON, element.TARGET, {AUTOFOCUS: 'target'});
+			expander.init();
+			element.BUTTON.click();
+			// When
+			const keydownTabShiftEvent = createKeydownEvent('TabShift');
+			element.ANCHOR.dispatchEvent(keydownTabShiftEvent);
 			// Then
 			window.requestAnimationFrame(() => {
 				expect(element.BUTTON.classList.contains(className.OPEN)).toBe(false);

--- a/toolkits/global/packages/global-expander/js/expander.js
+++ b/toolkits/global/packages/global-expander/js/expander.js
@@ -65,16 +65,24 @@ const Expander = class {
 		}
 
 		if (this._options.CLOSE_ON_FOCUS_OUT) {
-			if (event.key === 'Tab') {
-				window.requestAnimationFrame(() => {
-					if (!this._targetTabbableItems.includes(document.activeElement)) {
-						if (event.target === this._lastTargetTabbableItem) {
-							event.preventDefault();
-						}
+			if (event.key === 'Tab' && event.shiftKey === true) {
+				if (event.target === this._targetTabbableItems[0] || event.target === this._triggerEl || event.target === this._targetEl) {
+					event.preventDefault();
+					window.requestAnimationFrame(() => {
 						this.close();
 						this._triggerEl.focus();
-					}
-				});
+					});
+				}
+			}
+
+			if (event.key === 'Tab') {
+				if (event.target === this._lastTargetTabbableItem) {
+					event.preventDefault();
+					window.requestAnimationFrame(() => {
+						this.close();
+						this._triggerEl.focus();
+					});
+				}
 			}
 		}
 	}

--- a/toolkits/global/packages/global-expander/js/expander.js
+++ b/toolkits/global/packages/global-expander/js/expander.js
@@ -23,7 +23,6 @@ const Expander = class {
 		this._targetTabbableItems = makeArray(target.querySelectorAll(
 			'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
 		));
-		this._lastTargetTabbableItem = this._targetTabbableItems[this._targetTabbableItems.length - 1];
 		this._isOpen = false;
 
 		this._handleButtonClick = this._handleButtonClick.bind(this);
@@ -76,7 +75,7 @@ const Expander = class {
 			}
 
 			if (event.key === 'Tab') {
-				if (event.target === this._lastTargetTabbableItem) {
+				if (event.target === this._targetTabbableItems[this._targetTabbableItems.length - 1]) {
 					event.preventDefault();
 					window.requestAnimationFrame(() => {
 						this.close();

--- a/toolkits/global/packages/global-expander/js/expander.js
+++ b/toolkits/global/packages/global-expander/js/expander.js
@@ -66,13 +66,15 @@ const Expander = class {
 
 		if (this._options.CLOSE_ON_FOCUS_OUT) {
 			if (event.key === 'Tab') {
-				if (event.target === this._lastTargetTabbableItem) {
-					event.preventDefault();
-					window.requestAnimationFrame(() => {
+				window.requestAnimationFrame(() => {
+					if (!this._targetTabbableItems.includes(document.activeElement)) {
+						if (event.target === this._lastTargetTabbableItem) {
+							event.preventDefault();
+						}
 						this.close();
 						this._triggerEl.focus();
-					});
-				}
+					}
+				});
 			}
 		}
 	}

--- a/toolkits/global/packages/global-expander/js/expander.js
+++ b/toolkits/global/packages/global-expander/js/expander.js
@@ -23,6 +23,7 @@ const Expander = class {
 		this._targetTabbableItems = makeArray(target.querySelectorAll(
 			'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
 		));
+		this._lastTargetTabbableItem = this._targetTabbableItems[this._targetTabbableItems.length - 1];
 		this._isOpen = false;
 
 		this._handleButtonClick = this._handleButtonClick.bind(this);
@@ -65,12 +66,13 @@ const Expander = class {
 
 		if (this._options.CLOSE_ON_FOCUS_OUT) {
 			if (event.key === 'Tab') {
-				window.requestAnimationFrame(() => {
-					if (!this._targetTabbableItems.includes(document.activeElement)) {
+				if (event.target === this._lastTargetTabbableItem) {
+					event.preventDefault();
+					window.requestAnimationFrame(() => {
 						this.close();
 						this._triggerEl.focus();
-					}
-				});
+					});
+				}
 			}
 		}
 	}

--- a/toolkits/global/packages/global-expander/package.json
+++ b/toolkits/global/packages/global-expander/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-expander",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Frontend package for expanding a target when clicking a toggle",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Fixes focus being lost from expander when there is no other tabbable item after it on the page.