### PR TITLE
Removes hook option from global-popup

### DIFF
--- a/toolkits/global/packages/global-popup/HISTORY.md
+++ b/toolkits/global/packages/global-popup/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 1.1.0 (2020-08-06)
+    * Removes hook option
+    * Popups are now always direct children of <body> to fix mobile layout issues
+
 ## 1.0.1 (2020-08-05)
     * Fixes issue with position calculation
     * Makes styles js only

--- a/toolkits/global/packages/global-popup/README.md
+++ b/toolkits/global/packages/global-popup/README.md
@@ -18,11 +18,9 @@ popup();
 ```
 
 ```html
-<div class="hook-selector">
-    <span data-popup data-popup-hook="hook-selector" data-popup-target="popupContent1">Popup trigger</span>
-    <div id="popupContent1">
-        <p>Some popup text</p>
-    </div>
+<span data-popup data-popup-target="popupContent1">Popup trigger</span>
+<div id="popupContent1">
+    <p>Some popup text</p>
 </div>
 
 ```
@@ -40,7 +38,6 @@ There are also options (add these to trigger element):
 |-----------------------|---------|-------------|
 | data-popup-min-width  | String  | Sets a min-width in css on the popup, e.g. "100px" |
 | data-popup-max-width  | String  | Sets a max-width in css on the popup, e.g. "600px" |
-| data-popup-hook       | String  | CSS selector. A popup will be inserted in to and positioned relative to this element. If this option is ommitted it defaults to the parent of the trigger. |
 
 #### Directly
 
@@ -48,17 +45,14 @@ There are also options (add these to trigger element):
 import {Popup} from 'global-popup/js/popup';
 
 const trigger = document.querySelector('span');
-new Popup(trigger, 'popupContent1', { MIN_WIDTH: "100px", MAX_WIDTH: "600px", HOOK: ".some-classname" });
+new Popup(trigger, 'popupContent1', { MIN_WIDTH: "100px", MAX_WIDTH: "600px" });
 ```
 
 ```html
-<div class="some-classname">
-    <div>
-        <span>Popup trigger</span>
-        <div id="popupContent1">
-            <p>Some popup text</p>
-        </div>
+<div>
+    <span>Popup trigger</span>
+    <div id="popupContent1">
+        <p>Some popup text</p>
     </div>
-</div>
-			
+</div>		
 ```

--- a/toolkits/global/packages/global-popup/__tests__/popup.spec.js
+++ b/toolkits/global/packages/global-popup/__tests__/popup.spec.js
@@ -40,7 +40,7 @@ describe('Global Popup: popup.js', () => {
 		trigger.dispatchEvent(event);
 
 		expect(spy).toHaveBeenCalled();
-		expect(typeof spy.mock.results[0].value).toBe('number');
+		expect(typeof spy.mock.results[0].value.top).toBe('number');
 
 	});
 

--- a/toolkits/global/packages/global-popup/js/popup.js
+++ b/toolkits/global/packages/global-popup/js/popup.js
@@ -130,7 +130,7 @@ const Popup = class {
 		return {
 			left: (windowWidth < 600) ? 0 : offset.left,
 			top: top
-		}
+		};
 	}
 };
 

--- a/toolkits/global/packages/global-popup/js/popup.js
+++ b/toolkits/global/packages/global-popup/js/popup.js
@@ -23,14 +23,7 @@ const Popup = class {
 
 	_build() {
 		this._content.insertAdjacentHTML('beforeend', this._closeButton + this._arrow);
-		let hook = this._trigger.parentNode;
-
-		if (document.querySelector(this._options.HOOK)) {
-			hook = document.querySelector(this._options.HOOK);
-		}
-
-		hook.appendChild(this._content);
-		hook.style.position = 'relative';
+		document.body.appendChild(this._content);
 	}
 
 	_getCloseButton() {
@@ -41,7 +34,8 @@ const Popup = class {
 		this._isOpen = true;
 
 		const pos = this._calcPositioning();
-		this._content.style.top = this._px(pos);
+		this._content.style.top = this._px(pos.top);
+		this._content.style.transform = `translateX(${pos.left}px)`;
 		if (this._options.MAX_WIDTH) {
 			this._content.style.maxWidth = this._options.MAX_WIDTH;
 		}
@@ -110,8 +104,8 @@ const Popup = class {
 		// calc space above trigger
 		const spaceAbove = offset.top - this._content.offsetHeight - arrowHeight;
 
-		const abovePosition = 0 - this._content.offsetHeight - arrowHeight;
-		const belowPosition = 0 + triggerMetrics.height + arrowHeight;
+		const abovePosition = offset.top - this._content.offsetHeight - arrowHeight;
+		const belowPosition = offset.top + triggerMetrics.height + arrowHeight;
 
 		let top;
 		// if there is not enough room for popup above trigger
@@ -133,7 +127,10 @@ const Popup = class {
 			arrow.style.left = this._px(Math.round((triggerMetrics.width / 2) - arrowWidth));
 		}
 
-		return top;
+		return {
+			left: (windowWidth < 600) ? 0 : offset.left,
+			top: top
+		}
 	}
 };
 

--- a/toolkits/global/packages/global-popup/package.json
+++ b/toolkits/global/packages/global-popup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-popup",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Builds and styles a popup that can be opened and closed",
   "license": "MIT",
   "peerDependencies": {


### PR DESCRIPTION
The hook option was causing issues on mobile so needed a rethink. It's better to always position a popup relative to the body. It makes `width: auto` easier to think about as well as any `MAX_WIDTH` option that may have been set.