### PR TITLE
A better fix for global popup border colours not being found

### DIFF
--- a/toolkits/global/packages/global-popup/HISTORY.md
+++ b/toolkits/global/packages/global-popup/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 1.1.3 (2020-08-14)
+    * A better fix for an issue with border colours not being found
+
 ## 1.1.2 (2020-08-13)
     * Fixes bug with popup border colour not being found on non-Springer products
 

--- a/toolkits/global/packages/global-popup/package.json
+++ b/toolkits/global/packages/global-popup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-popup",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Builds and styles a popup that can be opened and closed",
   "license": "MIT",
   "peerDependencies": {

--- a/toolkits/global/packages/global-popup/scss/10-settings/_global-popup.scss
+++ b/toolkits/global/packages/global-popup/scss/10-settings/_global-popup.scss
@@ -2,7 +2,7 @@ $c-popup--padding: spacing(16, 32, 16, 24);
 $c-popup--close-top: spacing(16);
 $c-popup--close-right: spacing(16);
 $c-popup--box-shadow: 0 0 5px 0 greyscale(50, 0.1);
-$c-popup--border-color: color(#97bfd8, 0.3);
+$c-popup--border-color: rgba(151,191,216,.3);
 $c-popup--border-radius: spacing(2);
 $c-popup--background-color: #fff;
 $c-popup--zindex: 100;

--- a/toolkits/global/packages/global-popup/scss/10-settings/_global-popup.scss
+++ b/toolkits/global/packages/global-popup/scss/10-settings/_global-popup.scss
@@ -2,7 +2,7 @@ $c-popup--padding: spacing(16, 32, 16, 24);
 $c-popup--close-top: spacing(16);
 $c-popup--close-right: spacing(16);
 $c-popup--box-shadow: 0 0 5px 0 greyscale(50, 0.1);
-$c-popup--border-color: rgba(151,191,216,.3);
+$c-popup--border-color: rgba(151, 191, 216, .3);
 $c-popup--border-radius: spacing(2);
 $c-popup--background-color: #fff;
 $c-popup--zindex: 100;


### PR DESCRIPTION
I attempted to fix this yesterday but it didn't work. This just hardcodes the colour which I think is fine. The colour looks good on both Nature and Springer products. And if anyone wants to override they can simply with a 10-settings scss file in the app.
