### PR TITLE
use font-size mixin in global-corporate-footer

### DIFF
--- a/toolkits/global/packages/global-corporate-footer/HISTORY.md
+++ b/toolkits/global/packages/global-corporate-footer/HISTORY.md
@@ -1,4 +1,8 @@
 # History
 
+## 0.1.1 (2020-09-02)
+    * Use font-size mixin
+    * Use pixel value for nature font-size to workaround clash of mixin
+    
 ## 0.1.0 (2020-09-02)
     * Initial commit

--- a/toolkits/global/packages/global-corporate-footer/package.json
+++ b/toolkits/global/packages/global-corporate-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-corporate-footer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "corporate footer",
   "license": "MIT",
   "brandContext": "^4.2.0"

--- a/toolkits/global/packages/global-corporate-footer/scss/10-settings/nature.scss
+++ b/toolkits/global/packages/global-corporate-footer/scss/10-settings/nature.scss
@@ -2,7 +2,7 @@ $corporate-footer--font-family: $font-family-sans;
 $corporate-footer--background-color: #222;
 $corporate-footer--border: none;
 $corporate-footer--legal-padding-top: spacing(4);
-$corporate-footer--font-size: 1.3rem;
+$corporate-footer--font-size: 13px;
 $corporate-footer--text-color: #a2a2a2;
 $corporate-footer--margin-bottom: spacing(0);
 $corporate-footer--padding-top: spacing(16);

--- a/toolkits/global/packages/global-corporate-footer/scss/50-components/corporate-footer.scss
+++ b/toolkits/global/packages/global-corporate-footer/scss/50-components/corporate-footer.scss
@@ -7,6 +7,7 @@
 }
 
 .c-corporate-footer__legal {
+	@include font-size($corporate-footer--font-size);
 	font-size: $corporate-footer--font-size;
 	color: $corporate-footer--text-color;
 	margin-bottom: $corporate-footer--margin-bottom;


### PR DESCRIPTION
- Use font-size mixin
- Use pixel value for nature font-size to workaround clash of mixin