### PR TITLE
fix visually hidden on focus mixin

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 4.2.1 (2020-09-07) 
+    * BUG: `.u-visually-hidden-focus` is not working
+
 ## 4.2.0 (2020-07-22)
     * Add default variable $font-family-serif-save-data and uae within nature
     

--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,7 +1,7 @@
 # History
 
 ## 4.2.1 (2020-09-07) 
-    * BUG: `.u-visually-hidden-focus` is not working
+    * BUG: `.u-visually-hidden-focus` reset margin and position override
 
 ## 4.2.0 (2020-07-22)
     * Add default variable $font-family-serif-save-data and uae within nature

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/springer/scss/30-mixins/hiding.scss
+++ b/context/brand-context/springer/scss/30-mixins/hiding.scss
@@ -39,12 +39,13 @@
 @mixin visually-hidden-focus {
 	&:active,
 	&:focus {
-		position: static;
+		position: static !important;
 		width: auto;
 		height: auto;
 		overflow: visible;
 		clip: auto;
 		white-space: normal;
 		clip-path: none;
+		margin: 0;
 	}
 }


### PR DESCRIPTION
on springer "skip link" is not visible the cause are: 
- `position: absolute !important;` in `.u-visually-hidden` overrides `position: static`  
-  `margin: -100%;` from  `.u-visually-hidden` is not reset

I took this approach because not sure if I can remove `!important` from `.u-visually-hidden`