### PR TITLE
Fix references to global-spacing in typography.scss

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 4.2.1 (2020-09-08)
+    * Fix references to defunct `global-spacing` in SpringerNature context.
+
 ## 4.2.0 (2020-07-22)
     * Add default variable $font-family-serif-save-data and uae within nature
     

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/springernature/scss/30-mixins/typography.scss
+++ b/context/brand-context/springernature/scss/30-mixins/typography.scss
@@ -4,7 +4,7 @@
 @mixin u-h1() {
 	font-weight: lighter;
 	font-size: $context--font-size-h1;
-	margin-bottom: global-spacing(40);
+	margin-bottom: spacing(48);
 	font-family: $font-family-serif;
   line-height: 1.2;
 }
@@ -12,7 +12,7 @@
 @mixin u-h2() {
 	font-weight: lighter;
 	font-size: $context--font-size-h2;
-	margin-bottom:  global-spacing(40);
+	margin-bottom:  spacing(32);
 	font-family: $font-family-serif;
   line-height: $context--heading-line-height;
 }
@@ -20,7 +20,7 @@
 @mixin u-h3() {
 	font-weight: bold;
 	font-size: $context--font-size-h3;
-	margin-bottom: global-spacing(30);
+	margin-bottom: spacing(24);
 	font-family: $font-family-serif;
   line-height: $context--heading-line-height;
 }
@@ -28,7 +28,7 @@
 @mixin u-h4() {
 	font-weight: normal;
 	font-size: $context--font-size-h3;
-	margin-bottom: global-spacing(30);
+	margin-bottom: spacing(16);
 	font-family: $font-family-serif;
   line-height: $context--heading-line-height;
 }
@@ -36,7 +36,7 @@
 @mixin u-h5() {
 	font-weight: bold;
 	font-size: $context--font-size-base;
-	margin-bottom: global-spacing(30);
+	margin-bottom: spacing(16);
 	font-family: $font-family-serif;
   line-height: 1.2;
 }


### PR DESCRIPTION
There are still some references to the `global-spacing` function, which does not exist and seems to have been replaced by `spacing` in the Default branding context. This PR changes the function reference and alters sizing to permitted values.