### PR TITLE
Add global-meta package

### DIFF
--- a/toolkits/global/packages/global-meta/HISTORY.md
+++ b/toolkits/global/packages/global-meta/HISTORY.md
@@ -1,0 +1,5 @@
+# History
+
+## 1.0.0 (2020-09-30)
+    * Initial commit
+	* Moves `springer-meta` to the global toolkit

--- a/toolkits/global/packages/global-meta/README.md
+++ b/toolkits/global/packages/global-meta/README.md
@@ -1,0 +1,38 @@
+# Global Meta
+
+Brief information about the content.
+
+## Branding
+
+To include `global-meta` in your application, you need to choose **ONE** brand from those available. The `DEFAULT` brand is included in all other brands, and any settings that are not configured will fall back to default.
+
+```scss
+// Pick ONE of the brands below to include
+@import '@springernature/global-meta/scss/10-settings/default';
+@import '@springernature/global-meta/scss/10-settings/springer';
+
+// Include this with your other components
+@import '@springernature/global-meta/scss/50-components/meta';
+```
+
+## Usage
+
+```html
+<!-- single item-->
+<div class="c-meta">
+    <span class="c-meta__item">Article</span>
+</div>
+
+<!-- multiple items-->
+<div class="c-meta">
+    <span class="c-meta__item">Editorial</span>
+    <span class="c-meta__item">15 October 2019</span>
+</div>
+
+<!-- force uppercase -->
+<div class="c-meta">
+    <span class="c-meta__item">
+        <span class="c-meta__type">Editorial</span>
+    </span>
+</div>
+```

--- a/toolkits/global/packages/global-meta/package.json
+++ b/toolkits/global/packages/global-meta/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@springernature/global-meta",
+  "version": "1.0.0",
+  "license": "MIT",
+  "description": "Brief information about the content",
+  "keywords": [],
+  "author": "Springer Nature",
+  "brandContext": "^3.0.0"
+}

--- a/toolkits/global/packages/global-meta/scss/10-settings/_default.scss
+++ b/toolkits/global/packages/global-meta/scss/10-settings/_default.scss
@@ -1,0 +1,14 @@
+/**
+ * Meta
+ * Default branding for component
+ */
+
+$meta--font-size: 14px;
+$meta--font-family: inherit;
+$meta--line-height: inherit;
+$meta--padding-right: 0.5em;
+$meta--margin-right: 0.5em;
+$meta--border: 1px solid #eee;
+$meta--color: #222;
+$meta--margin-bottom: 10px;
+$meta--font-weight: 700;

--- a/toolkits/global/packages/global-meta/scss/10-settings/_springer.scss
+++ b/toolkits/global/packages/global-meta/scss/10-settings/_springer.scss
@@ -1,0 +1,13 @@
+/**
+ * Meta
+ * Springer branding for component
+ */
+
+// Default button setting
+@import 'default';
+
+$meta--font-size: 1.4rem;
+$meta--font-family: $font-family-sans;
+$meta--border: 1px solid greyscale(80);
+$meta--color: greyscale(40);
+$meta--margin-bottom: 4px;

--- a/toolkits/global/packages/global-meta/scss/50-components/_meta.scss
+++ b/toolkits/global/packages/global-meta/scss/50-components/_meta.scss
@@ -1,0 +1,23 @@
+.c-meta {
+	@include u-list-reset();
+	@include font-size($meta--font-size);
+	font-family: $meta--font-family;
+	color: $meta--color;
+	line-height: $meta--line-height;
+}
+
+.c-meta__item {
+	display: inline-block;
+	margin-bottom: $meta--margin-bottom;
+
+	&:not(:last-child) {
+		padding-right: $meta--padding-right;
+		margin-right: $meta--margin-right;
+		border-right: $meta--border;
+	}
+}
+
+.c-meta__type {
+	text-transform: uppercase;
+	font-weight: $meta--font-weight;
+}


### PR DESCRIPTION
## `springer-meta` => `global-meta`

The Springer nature brand is going to be using the `springer-meta` component, so the first stage is to create a `global-meta` component, copy the code across and create branded entrypoints for `default` and `springer`. Later we will add the springernature brand.

Once all products are moved from `springer-meta` to `global-meta`, we will delete the `springer-meta` code and deprecate the package on NPM.