### PR TITLE
fix logo alignment in nature header

### DIFF
--- a/toolkits/nature/packages/nature-header/HISTORY.md
+++ b/toolkits/nature/packages/nature-header/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 1.0.1 (2020-10-08)
+    * Maintain logo alignment when scaling SVG
+    * Bump global-expander to 2.1.0
+
 ## 1.0.0 (2020-09-24)
     * Remove .c-header__layout--right
     * Promote new layer in `.c-header__logo` for mobile safari to avoid mangled logo during log in/my account layout repaint

--- a/toolkits/nature/packages/nature-header/package.json
+++ b/toolkits/nature/packages/nature-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/nature-header",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "description": "Publisher level header",
   "keywords": [],
@@ -8,6 +8,6 @@
   "brandContext": "^4.2.2",
   "dependencies": {
     "@springernature/global-javascript": "^2.4.0",
-    "@springernature/global-expander": "^2.0.2"
+    "@springernature/global-expander": "^2.1.0"
   }
 }

--- a/toolkits/nature/packages/nature-header/scss/50-components/header.scss
+++ b/toolkits/nature/packages/nature-header/scss/50-components/header.scss
@@ -24,11 +24,14 @@
 .c-header__logo {
 	display: flex;
 	margin-right: $header--logo-margin-right;
-	max-height: $header--logo-max-height;
 	transform: translateZ(0); // promote new layer for mobile safari to avoid mangled logo during layout repaint
 
 	@include media-query('md') {
 		margin-right: spacing(0);
+	}
+
+	img {
+		max-height: $header--logo-max-height;
 	}
 }
 


### PR DESCRIPTION
* Maintain logo alignment when scaling SVG
* Bump global-expander to 2.1.0