### PR TITLE
Autocomplete readme

### DIFF
--- a/toolkits/global/packages/global-autocomplete/HISTORY.md
+++ b/toolkits/global/packages/global-autocomplete/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 5.0.1 (2020-10-12)
+    * BUG: unescaped HTML in README
+
 ## 5.0.0 (2020-10-06)
     * BREAKING: Use ESM exports
 	* BREAKING: Update major version of brand-context

--- a/toolkits/global/packages/global-autocomplete/README.md
+++ b/toolkits/global/packages/global-autocomplete/README.md
@@ -21,4 +21,6 @@ Please see contents of `demo/` folder for sample client JS.
 A full handlebars demo is also in the demo folder, but following is the only HTML the
  component actually requires:
 
+```html
 <input type="text" autocomplete="off" class="c-autocomplete" data-component-autocomplete>
+```

--- a/toolkits/global/packages/global-autocomplete/package.json
+++ b/toolkits/global/packages/global-autocomplete/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-autocomplete",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "license": "MIT",
   "description": "Autocomplete/suggest component",
   "keywords": [],


### PR DESCRIPTION
Unescaped code in `README.md` meant that we were trying to render that HTML on the styleguide, instead of chowing the code.