### PR TITLE
Changes Global Expander's FOCUS_EVENT option to OPEN_EVENT

### DIFF
--- a/toolkits/global/packages/global-expander/HISTORY.md
+++ b/toolkits/global/packages/global-expander/HISTORY.md
@@ -1,7 +1,7 @@
 # History
 
 ## 3.0.0 (2020-10-19)
-    * Changes FOCUS_EVENT to OPEN_EVENT as open event is what is needed on Oscar components at this time and for any future consumer this will likely be a more useful event than the focus event in any case.
+    * Changes FOCUS_EVENT to OPEN_EVENT.
 
 ## 2.1.0 (2020-09-21)
     * Use `_isOpen` state flag as the source of truth to toggle aria and class

--- a/toolkits/global/packages/global-expander/HISTORY.md
+++ b/toolkits/global/packages/global-expander/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 3.0.0 (2020-10-19)
+    * Changes FOCUS_EVENT to OPEN_EVENT as open event is what is needed on Oscar components at this time and for any future consumer this will likely be a more useful event than the focus event in any case.
+
 ## 2.1.0 (2020-09-21)
     * Use `_isOpen` state flag as the source of truth to toggle aria and class
         attributes as well as the trigger's label upon `init`/`open`/`close`

--- a/toolkits/global/packages/global-expander/HISTORY.md
+++ b/toolkits/global/packages/global-expander/HISTORY.md
@@ -1,6 +1,6 @@
 # History
 
-## 3.0.0 (2020-10-19)
+## 3.0.0 (2020-10-20)
     * Changes FOCUS_EVENT to OPEN_EVENT.
 
 ## 2.1.0 (2020-09-21)

--- a/toolkits/global/packages/global-expander/README.md
+++ b/toolkits/global/packages/global-expander/README.md
@@ -46,7 +46,7 @@ expander.close();
 | AUTOFOCUS          | null          | String  | Moves focus to an element when hitting trigger:                                                                                    |
 |                    |               |         |`firstTabbable` will find the first tabbable element inside the target (will highlight text if appropriate, e.g. input with value). |
 |                    |               |         |`target` will set focus on target element                                                                                           |
-| OPEN_EVENT         | false         | Boolean | Dispatch custom event on trigger just before expander focuses on target                                                            |
+| OPEN_EVENT         | false         | Boolean | Dispatch custom event on trigger once Global Expander has completed it's Open method                                                           |
 
 The data attribute options are the same, but are lowercase and hyphenated (and strings where the option is a boolean):
 
@@ -55,7 +55,7 @@ The data attribute options are the same, but are lowercase and hyphenated (and s
 - `data-expander-trigger-open-label`
 - `data-expander-close-on-clickoff`
 - `data-expander-autofocus`
-- `data-expander-focus-event`
+- `data-expander-open-event`
 
 Note: data attribute options will take precedence over any options set during initialisation.
 

--- a/toolkits/global/packages/global-expander/README.md
+++ b/toolkits/global/packages/global-expander/README.md
@@ -46,7 +46,7 @@ expander.close();
 | AUTOFOCUS          | null          | String  | Moves focus to an element when hitting trigger:                                                                                    |
 |                    |               |         |`firstTabbable` will find the first tabbable element inside the target (will highlight text if appropriate, e.g. input with value). |
 |                    |               |         |`target` will set focus on target element                                                                                           |
-| FOCUS_EVENT        | false         | Boolean | Dispatch custom event on trigger just before expander focuses on target                                                            |
+| OPEN_EVENT         | false         | Boolean | Dispatch custom event on trigger just before expander focuses on target                                                            |
 
 The data attribute options are the same, but are lowercase and hyphenated (and strings where the option is a boolean):
 

--- a/toolkits/global/packages/global-expander/__tests__/expander.spec.js
+++ b/toolkits/global/packages/global-expander/__tests__/expander.spec.js
@@ -532,12 +532,12 @@ describe('Expander', () => {
 			expect(spy).not.toHaveBeenCalled();
 		});
 
-		test('Should fire event if FOCUS_EVENT: true option passed to constructor', () => {
+		test('Should fire event if OPEN_EVENT: true option passed to constructor', () => {
 			// Given
 			const button = document.querySelector('[data-expander]');
 			const spy = jest.spyOn(button, 'dispatchEvent');
 			const expander = new Expander(element.BUTTON, element.TARGET, {
-				FOCUS_EVENT: true
+				OPEN_EVENT: true
 			});
 			expander.init();
 			// When

--- a/toolkits/global/packages/global-expander/__tests__/index.spec.js
+++ b/toolkits/global/packages/global-expander/__tests__/index.spec.js
@@ -51,7 +51,7 @@ describe('Data Attribute API', () => {
 			TRIGGER_OPEN_LABEL: 'init-trigger-open-label',
 			CLOSE_ON_CLICKOFF: false,
 			AUTOFOCUS: true,
-			FOCUS_EVENT: false
+			OPEN_EVENT: false
 		};
 
 		// When
@@ -69,7 +69,7 @@ describe('Data Attribute API', () => {
 			TRIGGER_OPEN_LABEL: 'init-trigger-open-label',
 			CLOSE_ON_CLICKOFF: false,
 			AUTOFOCUS: true,
-			FOCUS_EVENT: false
+			OPEN_EVENT: false
 		};
 
 		// When
@@ -82,7 +82,7 @@ describe('Data Attribute API', () => {
 			TRIGGER_OPEN_LABEL: 'data-trigger-shown-label',
 			CLOSE_ON_CLICKOFF: 'true',
 			AUTOFOCUS: 'false',
-			FOCUS_EVENT: false
+			OPEN_EVENT: false
 		});
 	});
 });

--- a/toolkits/global/packages/global-expander/js/expander.js
+++ b/toolkits/global/packages/global-expander/js/expander.js
@@ -10,7 +10,7 @@ const defaultOptions = {
 	TRIGGER_OPEN_LABEL: undefined,
 	CLOSE_ON_FOCUS_OUT: true,
 	AUTOFOCUS: null,
-	FOCUS_EVENT: false
+	OPEN_EVENT: false
 };
 
 const Expander = class {
@@ -183,12 +183,6 @@ const Expander = class {
 
 		this._isOpen = true;
 
-		if (this._options.FOCUS_EVENT) {
-			const event = createEvent('focusTarget', 'globalExpander', {
-				bubbles: false
-			});
-			this._triggerEl.dispatchEvent(event);
-		}
 
 		this._updateTriggerLabel();
 		this._updateAriaAttributes();
@@ -196,6 +190,13 @@ const Expander = class {
 
 		this._setupTemporaryEventListeners();
 		this._handleAutoFocus();
+
+		if (this._options.OPEN_EVENT) {
+			const event = createEvent('open', 'globalExpander', {
+				bubbles: false
+			});
+			this._triggerEl.dispatchEvent(event);
+		}
 	}
 
 	close() {

--- a/toolkits/global/packages/global-expander/js/expander.js
+++ b/toolkits/global/packages/global-expander/js/expander.js
@@ -182,8 +182,7 @@ const Expander = class {
 		}
 
 		this._isOpen = true;
-
-
+		
 		this._updateTriggerLabel();
 		this._updateAriaAttributes();
 		this._updateClassAttributes();

--- a/toolkits/global/packages/global-expander/js/expander.js
+++ b/toolkits/global/packages/global-expander/js/expander.js
@@ -182,7 +182,7 @@ const Expander = class {
 		}
 
 		this._isOpen = true;
-		
+
 		this._updateTriggerLabel();
 		this._updateAriaAttributes();
 		this._updateClassAttributes();

--- a/toolkits/global/packages/global-expander/js/index.js
+++ b/toolkits/global/packages/global-expander/js/index.js
@@ -9,7 +9,7 @@ const attributes = {
 	TRIGGER_OPEN_LABEL: DATA_COMPONENT + '-trigger-open-label',
 	CLOSE_ON_CLICKOFF: DATA_COMPONENT + '-close-on-clickoff',
 	AUTOFOCUS: DATA_COMPONENT + '-autofocus',
-	FOCUS_EVENT: DATA_COMPONENT + '-focus-event'
+	OPEN_EVENT: DATA_COMPONENT + '-open-event'
 };
 
 /**

--- a/toolkits/global/packages/global-expander/package.json
+++ b/toolkits/global/packages/global-expander/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-expander",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Frontend package for expanding a target when clicking a toggle",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
At the moment Oscar repo is the only consumer of Global Expander that uses the FOCUS_EVENT option. We have a bug on Oscar at the moment which has led me to the realisation that we do not need Global Expander to focus on an element once it has done its thing. But there is still a requirement to know when Global Expander has finished opening a toggle-able element, therefore an event dispatched by Global Expander is still needed.

Therefore this PR changes the event to be what Oscar needs. Plus, it is likely to be a more useful event to any other consumer of the component. As the option now means that it is sending an event when it opens a toggle-able element, rather than an event specifically concerned with when it focused on a target element during the open process.

Relates to PR https://github.com/springernature/frontend-toolkits/pull/361