### PR TITLE
Global Popup now focuses on the Popup itself and stops using some of Global Expander's options

### DIFF
--- a/toolkits/global/packages/global-popup/HISTORY.md
+++ b/toolkits/global/packages/global-popup/HISTORY.md
@@ -1,5 +1,11 @@
 # History
 
+## 2.0.0 (2020-10-19)
+    * Removes use Global Expander AUTOFOCUS, FOCUS_EVENT and CLOSE_EVENT options
+    * Uses Global Expander's new OPEN_EVENT option
+    * Global Popup now waits until the next tick using rAF before positioning the popup to allow the popup to finish rendering before calculating it's height 
+    * Global Popup now focuses on the popup once Global Expander has finished opening it
+    
 ## 1.1.3 (2020-08-14)
     * A better fix for an issue with border colours not being found
 

--- a/toolkits/global/packages/global-popup/__tests__/popup.spec.js
+++ b/toolkits/global/packages/global-popup/__tests__/popup.spec.js
@@ -36,7 +36,7 @@ describe('Global Popup: popup.js', () => {
 		trigger.click();
 
 		// mock global expander's sending of event
-		const event = new CustomEvent('globalExpander:focusEvent');
+		const event = new CustomEvent('globalExpander:open');
 		trigger.dispatchEvent(event);
 
 		expect(spy).toHaveBeenCalled();
@@ -123,7 +123,7 @@ describe('Global Popup: popup.js', () => {
 		trigger.click();
 
 		// mock global expander's sending of event
-		const event = new CustomEvent('globalExpander:focusEvent');
+		const event = new CustomEvent('globalExpander:open');
 		trigger.dispatchEvent(event);
 
 		expect(document.querySelector('.is-open')).not.toBe(null);

--- a/toolkits/global/packages/global-popup/__tests__/popup.spec.js
+++ b/toolkits/global/packages/global-popup/__tests__/popup.spec.js
@@ -30,7 +30,7 @@ describe('Global Popup: popup.js', () => {
 		expect(document.querySelector('.c-popup__close')).not.toBe(null);
 	});
 
-	it('should calculate number values for popup positioning', () => {
+	it('should calculate number values for popup positioning', done => {
 		const popup = new Popup(trigger, 'popupContent1');
 		const spy = jest.spyOn(popup, '_calcPositioning');
 		trigger.click();
@@ -39,8 +39,11 @@ describe('Global Popup: popup.js', () => {
 		const event = new CustomEvent('globalExpander:open');
 		trigger.dispatchEvent(event);
 
-		expect(spy).toHaveBeenCalled();
-		expect(typeof spy.mock.results[0].value.top).toBe('number');
+		setTimeout(() => {
+			expect(spy).toHaveBeenCalled();
+			expect(typeof spy.mock.results[0].value.top).toBe('number');
+			done();
+		},100)
 
 	});
 
@@ -157,12 +160,19 @@ describe('Global Popup: popup.js', () => {
 		expect(trigger.classList.contains('is-open')).toBe(false);
 	});
 
-	it('should set css style if passed in as option', () => {
+	it('should set css style if passed in as option', done => {
 		new Popup(trigger, 'popupContent1', { MAX_WIDTH: "600px" });
 
 		trigger.click();
-		const popup = document.querySelector('.c-popup');
 
-		expect(popup.style.maxWidth).toBe("600px");
+		// mock global expander's sending of event
+		const event = new CustomEvent('globalExpander:open');
+		trigger.dispatchEvent(event);
+
+		setTimeout(() => {
+			const popup = document.querySelector('.c-popup');
+			expect(popup.style.maxWidth).toBe("600px");
+			done();
+		},100)
 	});
 });

--- a/toolkits/global/packages/global-popup/js/popup.js
+++ b/toolkits/global/packages/global-popup/js/popup.js
@@ -34,7 +34,6 @@ const Popup = class {
 		this._isOpen = true;
 
 		if (this._options.MAX_WIDTH) {
-			console.log('i just set the max width');
 			this._content.style.maxWidth = this._options.MAX_WIDTH;
 		}
 		if (this._options.MIN_WIDTH) {

--- a/toolkits/global/packages/global-popup/js/popup.js
+++ b/toolkits/global/packages/global-popup/js/popup.js
@@ -17,7 +17,7 @@ const Popup = class {
 			this._close();
 		};
 		this._build();
-		this._expander = new Expander(this._trigger, this._content, {AUTOFOCUS: 'target', FOCUS_EVENT: true, CLOSE_EVENT: true});
+		this._expander = new Expander(this._trigger, this._content, {OPEN_EVENT: true});
 		this._bindEvents();
 	}
 
@@ -57,13 +57,17 @@ const Popup = class {
 	_bindEvents() {
 		this._expander.init();
 
-		this._trigger.addEventListener('globalExpander:focusTarget', event => {
+		this._trigger.addEventListener('globalExpander:open', event => {
 			event.preventDefault();
 
 			if (this._isOpen) {
 				return;
 			}
-			this._positionPopup();
+			requestAnimationFrame(() => {
+				this._positionPopup();
+				this._content.focus();
+			});
+
 			window.addEventListener('resize', this._closeHandler);
 		});
 

--- a/toolkits/global/packages/global-popup/js/popup.js
+++ b/toolkits/global/packages/global-popup/js/popup.js
@@ -33,15 +33,16 @@ const Popup = class {
 	_positionPopup() {
 		this._isOpen = true;
 
-		const pos = this._calcPositioning();
-		this._content.style.top = this._px(pos.top);
-		this._content.style.transform = `translateX(${pos.left}px)`;
 		if (this._options.MAX_WIDTH) {
+			console.log('i just set the max width');
 			this._content.style.maxWidth = this._options.MAX_WIDTH;
 		}
 		if (this._options.MIN_WIDTH) {
 			this._content.style.minWidth = this._options.MIN_WIDTH;
 		}
+		const pos = this._calcPositioning();
+		this._content.style.top = this._px(pos.top);
+		this._content.style.transform = `translateX(${pos.left}px)`;
 	}
 
 	_close() {

--- a/toolkits/global/packages/global-popup/package.json
+++ b/toolkits/global/packages/global-popup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-popup",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Builds and styles a popup that can be opened and closed",
   "license": "MIT",
   "peerDependencies": {

--- a/toolkits/global/packages/global-popup/package.json
+++ b/toolkits/global/packages/global-popup/package.json
@@ -8,6 +8,6 @@
   },
   "dependencies": {
     "@springernature/global-javascript": "^2.3.0",
-    "@springernature/global-expander": "^2.0.2"
+    "@springernature/global-expander": "^3.0.0"
   }
 }


### PR DESCRIPTION
A recent bug led me to the realisation that it is problematic if Global Expander focuses on a Popup when it opens. A popup has not finished rendering when we try and calculate its height when Global Expander opens and focuses the popup element. This results in incorrect height calculations and subsequent broken positioning of the popup element.

Therefore it's better to not ask Global Expander to focus on the popup. Instead Global Popup focuses on the popup itself but only once Global Expander has fired an event to announce that it has finished opening the popup.

Relates to PR https://github.com/springernature/frontend-toolkits/pull/360