### PR TITLE
fix mixin name in global-form 

### DIFF
--- a/toolkits/global/packages/global-forms/HISTORY.md
+++ b/toolkits/global/packages/global-forms/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 3.0.1 (2020-10-19)
+    * Refer to mixin name in component file correctly
+    
 ## 3.0.0 (2020-06-08)
     * BREAKING: Rename mixin and component files
     * Update README

--- a/toolkits/global/packages/global-forms/README.md
+++ b/toolkits/global/packages/global-forms/README.md
@@ -7,7 +7,7 @@ This module gives you some generic styles for text, checkbox, radio button, text
 The `global-forms` component currently uses the `DEFAULT` brand only.
 
 ```scss
-// Inlcude this with your settings
+// Include this with your settings
 @import '@springernature/global-forms/scss/10-settings/default';
 
 // Include this with your other components

--- a/toolkits/global/packages/global-forms/package.json
+++ b/toolkits/global/packages/global-forms/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@springernature/global-forms",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"license": "MIT",
 	"description": "form component",
 	"keywords": [

--- a/toolkits/global/packages/global-forms/scss/10-settings/_default.scss
+++ b/toolkits/global/packages/global-forms/scss/10-settings/_default.scss
@@ -16,4 +16,4 @@ $global-form--label-spacing: 10px;
 $global-form--color: #000;
 $global-form--color-required: #c64127;
 $global-form--color-disabled: #aca9a3;
-$global-form--grid-gutter-width:  10px;
+$global-form--grid-gutter-width: 10px;

--- a/toolkits/global/packages/global-forms/scss/50-components/_forms.scss
+++ b/toolkits/global/packages/global-forms/scss/50-components/_forms.scss
@@ -1,5 +1,3 @@
-
-
 /* Input row component */
 
 .c-input-row {
@@ -8,7 +6,6 @@
 	flex-direction: row;
 	margin-right: -$global-form--grid-gutter-width / 2;
 	margin-left: -$global-form--grid-gutter-width / 2;
-
 }
 
 .c-input-row__item {
@@ -31,7 +28,6 @@
 	font-size: $global-form--label-font-size;
 	margin-bottom: $global-form--label-spacing;
 
-
 	&--check {
 		padding-right: 0.5rem;
 	}
@@ -42,7 +38,7 @@
 }
 
 .c-input-group__control {
-	@include global-form-input;
+	@include form-input;
 
 	&--check {
 		width: auto;


### PR DESCRIPTION
Fix mixin name in component file as the build was complaining it could not find `global-form-input` mixin which got renamed to `form-input`.

