### PR TITLE
fix for explorer image sizing

### DIFF
--- a/toolkits/springernature/packages/springernature-header/HISTORY.md
+++ b/toolkits/springernature/packages/springernature-header/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 0.3.0 (2020-10-23)
+	* Fix for explorer img sizing
+
 ## 0.2.0 (2020-10-21)
 	* Update styles
 

--- a/toolkits/springernature/packages/springernature-header/package.json
+++ b/toolkits/springernature/packages/springernature-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springernature-header",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "description": "Springer Nature branded header component",
   "keywords": [],

--- a/toolkits/springernature/packages/springernature-header/scss/50-components/enhanced.scss
+++ b/toolkits/springernature/packages/springernature-header/scss/50-components/enhanced.scss
@@ -12,12 +12,8 @@
 
 	.c-header__site-logo,
 	.c-header__journal-logo {
-		@include media-query('lg') {
-			width: auto;
-		}
-
+		width: auto;
 		height: auto;
-		width: 48%;
 		min-width: 130px;
 		max-width: 209px;
 	}


### PR DESCRIPTION
Use auto sizes for logo image, as explorer doesn't maintain ratio