### PR TITLE
reposition chevron on global-breadcrumbs

### DIFF
--- a/toolkits/global/packages/global-breadcrumbs/HISTORY.md
+++ b/toolkits/global/packages/global-breadcrumbs/HISTORY.md
@@ -1,3 +1,7 @@
+## 0.6.0 (2020-11-11)
+    * Update $breadcrumbs-chevron-spacing to reposition chevron
+    * Removed unused $breadcrumbs-bottom-spacing
+    
 ## 0.5.0 (2020-08-20)
     * Removed font size for Nature
 

--- a/toolkits/global/packages/global-breadcrumbs/package.json
+++ b/toolkits/global/packages/global-breadcrumbs/package.json
@@ -1,9 +1,9 @@
 {
     "name": "@springernature/global-breadcrumbs",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "license": "MIT",
     "description": "breadcrumbs",
     "keywords": [],
     "author": "Springer Nature",
     "brandContext": "^3.2.2"
-  } 
+  }

--- a/toolkits/global/packages/global-breadcrumbs/scss/10-settings/default.scss
+++ b/toolkits/global/packages/global-breadcrumbs/scss/10-settings/default.scss
@@ -2,5 +2,4 @@ $breadcrumbs-font-family: $font-family-sans;
 $breadcrumbs-font-size: 16px;
 $breadcrumbs-color: black;
 $breadcrumbs-link-color: greyscale(40);
-$breadcrumbs-bottom-spacing: spacing(16);
-$breadcrumbs-chevron-spacing: spacing(4);
+$breadcrumbs-chevron-spacing: spacing(4) spacing(4) 0;

--- a/toolkits/global/packages/global-breadcrumbs/scss/50-components/breadcrumbs.scss
+++ b/toolkits/global/packages/global-breadcrumbs/scss/50-components/breadcrumbs.scss
@@ -17,5 +17,5 @@
 }
 
 .c-breadcrumbs__chevron {
-	margin: 0 $breadcrumbs-chevron-spacing;
+	margin: $breadcrumbs-chevron-spacing;
 }


### PR DESCRIPTION
Chevrons got misaligned after swapping out c-icon(refactor-pandora) for u-icon(brand-context)