### PR TITLE
global-javascript getDataOptions: Convert "true" and "false" attributes to boolean

### DIFF
--- a/toolkits/global/packages/global-javascript/HISTORY.md
+++ b/toolkits/global/packages/global-javascript/HISTORY.md
@@ -1,7 +1,7 @@
 # History
 
-## 2.4.1 (2020-11-13)
-    * BUG: Convert "true" and "false" attributes to boolean
+## 3.0.0 (2020-11-13)
+    * BREAKING: Convert "true" and "false" attributes to boolean
 
 ## 2.4.0 (2020-08-24)
     * FEATURE: setCookie util

--- a/toolkits/global/packages/global-javascript/HISTORY.md
+++ b/toolkits/global/packages/global-javascript/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 2.4.1 (2020-11-13)
+    * BUG: Convert "true" and "false" attributes to boolean
+
 ## 2.4.0 (2020-08-24)
     * FEATURE: setCookie util
     * FEATURE: deleteCookie util

--- a/toolkits/global/packages/global-javascript/__tests__/unit/dom/get-data-options.spec.js
+++ b/toolkits/global/packages/global-javascript/__tests__/unit/dom/get-data-options.spec.js
@@ -4,19 +4,24 @@ describe('getDataOptions', () => {
 	const DataOptions = {
 		OPTION_1: 'data-mycomponent-option1',
 		OPTION_2: 'data-mycomponent-option2',
-		OPTION_3: 'data-mycomponent-option3'
+		OPTION_3: 'data-mycomponent-option3',
+		OPTION_4: 'data-mycomponent-option4',
+		OPTION_5: 'data-mycomponent-option5'
 	};
+
+	const element = {};
 
 	beforeEach(() => {
 		document.body.innerHTML = `
-			<div data-mycomponent-option1="foo" data-mycomponent-option2="bar" data-mycomponent-option3="baz" data-notmycomponent="test">My Component</div>
+			<div data-mycomponent-option1="foo" data-mycomponent-option2="bar" data-mycomponent-option3="baz" data-mycomponent-option4="true" data-mycomponent-option5="false" data-notmycomponent="test">My Component</div>
 		`;
+
+		element.COMPONENT = document.querySelector('div');
 	});
 
 	test('Should return an Object with the values for each key as the values of the data-attributes', () => {
-		const component = document.querySelector('div');
-		const options = getDataOptions(component, DataOptions);
+		const options = getDataOptions(element.COMPONENT, DataOptions);
 
-		expect(options).toMatchObject({OPTION_1: 'foo', OPTION_2: 'bar', OPTION_3: 'baz'});
+		expect(options).toMatchObject({OPTION_1: 'foo', OPTION_2: 'bar', OPTION_3: 'baz', OPTION_4: true, OPTION_5: false});
 	});
 });

--- a/toolkits/global/packages/global-javascript/package.json
+++ b/toolkits/global/packages/global-javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-javascript",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "license": "MIT",
   "description": "Globally shared Javascript helpers",
   "keywords": [

--- a/toolkits/global/packages/global-javascript/package.json
+++ b/toolkits/global/packages/global-javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-javascript",
-  "version": "2.4.1",
+  "version": "3.0.0",
   "license": "MIT",
   "description": "Globally shared Javascript helpers",
   "keywords": [

--- a/toolkits/global/packages/global-javascript/src/helpers/dom/get-data-options.js
+++ b/toolkits/global/packages/global-javascript/src/helpers/dom/get-data-options.js
@@ -13,7 +13,7 @@ const getDataOptions = (element, attributeMap) => {
 			const attributeValue = element.hasAttribute(value) && element.getAttribute(value);
 
 			if (attributeValue) {
-				dataOptions[key] = attributeValue;
+				dataOptions[key] = (attributeValue === 'true' || attributeValue === 'false') ? attributeValue === 'true' : attributeValue;
 			}
 		}
 	}

--- a/toolkits/global/packages/global-javascript/src/helpers/dom/get-data-options.js
+++ b/toolkits/global/packages/global-javascript/src/helpers/dom/get-data-options.js
@@ -13,6 +13,8 @@ const getDataOptions = (element, attributeMap) => {
 			const attributeValue = element.hasAttribute(value) && element.getAttribute(value);
 
 			if (attributeValue) {
+				// 'true' and 'false' attribute values need to be converted to a boolean
+				// Checking equality against 'true' will return a boolean of true or false. e.g. 'false' === 'true' returns false
 				dataOptions[key] = (attributeValue === 'true' || attributeValue === 'false') ? attributeValue === 'true' : attributeValue;
 			}
 		}


### PR DESCRIPTION
Previously they were set in the object as strings, meaning that `"false"` options would be evaluated to true.