### PR TITLE
add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
       # Check for npm updates on Sundays at 9am UTC
       day: "sunday"
       time: "09:00"
+    commit-message:
+      prefix: "[skip travis]"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Specify the day for weekly checks
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      # Check for npm updates on Sundays at 9am UTC
+      day: "sunday"
+      time: "09:00"


### PR DESCRIPTION
Add a config for dependabot so that it only checks once a week, on a Sunday. This is to try and avoid clogging up the travis queue.

HOWEVER, one thing we can't do anything about is that every time a dependabot PR goes stale it will force push to trigger another build. For example [this PR](https://github.com/springernature/frontend-toolkits/pull/339) has been run over 30 times as it keeps updating itself to stay current. This will always trigger a new build on Travis and the only way to stop this is to either merge the PR or cancel it.

In short, we need to stay on top of dependabot PR's to stop them clogging up the travis queue

UPDATE: as soon as I created this PR it auto-pushed to the one referenced above and triggered a new build. The dependabot PR always seems to run first.

UPDATE: attempt to skip travis completely with custom commit message