### PR TITLE
Adds important to hide utilities

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 6.3.0 (2020-12-11)
+    * Adds !important to utlities that hide content to prevent selector specificity trumping hide utlity classnames 
+
 ## 6.2.0 (2020-12-11)
     * Adds media-query hiding utilities
 

--- a/context/brand-context/default/scss/30-mixins/hiding.scss
+++ b/context/brand-context/default/scss/30-mixins/hiding.scss
@@ -1,6 +1,6 @@
 @mixin u-hide {
-	display: none;
-	visibility: hidden;
+	display: none !important;
+	visibility: hidden !important;
 }
 
 @mixin u-show {

--- a/context/brand-context/default/scss/60-utilities/hiding.scss
+++ b/context/brand-context/default/scss/60-utilities/hiding.scss
@@ -1,5 +1,5 @@
 .u-display-none {
-	display: none;
+	display: none !important;
 }
 
 /* hide from both screenreaders and browsers */
@@ -35,7 +35,7 @@
 /* make invisible but retain dimensions */
 
 .u-invisible {
-	visibility: hidden;
+	visibility: hidden !important;
 }
 
 /* hide only the text, keep element visible */
@@ -53,7 +53,7 @@
 
 @media print {
 	.u-hide-print {
-		display: none;
+		display: none !important;
 	}
 }
 

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/springer/scss/30-mixins/hiding.scss
+++ b/context/brand-context/springer/scss/30-mixins/hiding.scss
@@ -2,7 +2,7 @@
 	display: block;
 
 	.js & {
-		display: none;
+		display: none !important;
 	}
 }
 

--- a/context/brand-context/springer/scss/30-mixins/hiding.scss
+++ b/context/brand-context/springer/scss/30-mixins/hiding.scss
@@ -2,7 +2,7 @@
 	display: block;
 
 	.js & {
-		display: none !important;
+		display: none;
 	}
 }
 


### PR DESCRIPTION
Had an issue today where our u-hide utility classnames were not working because of selector specificity, i.e. we had some css that set display: block and because of the specificity of it it trumped the hide utility. I think it makes sense to add important to hide utilities in general. If we've made the conscious choice to add a classname like u-hide to the html then it should be a certainty that the element is hidden.