### PR TITLE
nature-header: Zeros line-height to allow use of h1

### DIFF
--- a/toolkits/nature/packages/nature-header/HISTORY.md
+++ b/toolkits/nature/packages/nature-header/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 4.0.1 (2021-01-20)
+    * Zeros the line-height on logo to cater for use with <h1> 
+
 ## 4.0.0 (2021-01-13)
     * BREAKING: Refactored to update nature header in narrow viewport
     * Updated README with updated example

--- a/toolkits/nature/packages/nature-header/package.json
+++ b/toolkits/nature/packages/nature-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/nature-header",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "license": "MIT",
   "description": "Publisher level header",
   "keywords": [],

--- a/toolkits/nature/packages/nature-header/scss/50-components/header.scss
+++ b/toolkits/nature/packages/nature-header/scss/50-components/header.scss
@@ -28,6 +28,7 @@
 .c-header__logo-container {
 	flex: 1 1 0;
 	margin-right: spacing(24);
+	line-height: 0; // Can be an h1 or a div
 }
 
 .c-header__logo {


### PR DESCRIPTION
The logo can be an `h1`, for example on journal homepages.