### PR TITLE
dropdown is full width on narrow viewport

### DIFF
--- a/toolkits/nature/packages/nature-header/HISTORY.md
+++ b/toolkits/nature/packages/nature-header/HISTORY.md
@@ -1,5 +1,10 @@
 # History
 
+## 4.1.0 (2021-01-21)
+    * Expander full width at narrow viewports
+    * Aligned last expander in list of dropdown to right of screen to prevent horizontal scroll
+    * Reduced font-size and space between chevrons on journal menu items to get all on one line for 320px/'xs' breakpoint and above    
+
 ## 4.0.1 (2021-01-20)
     * Zeros the line-height on logo to cater for use with <h1> 
 

--- a/toolkits/nature/packages/nature-header/package.json
+++ b/toolkits/nature/packages/nature-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/nature-header",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "license": "MIT",
   "description": "Publisher level header",
   "keywords": [],

--- a/toolkits/nature/packages/nature-header/scss/50-components/header-expander.scss
+++ b/toolkits/nature/packages/nature-header/scss/50-components/header-expander.scss
@@ -75,13 +75,21 @@
 .c-header-expander.has-tethered {
 	position: absolute;
 	top: 100%; // bottom of the tether element
-	transform: translateY(8px);
+	transform: translateY(5px);
 	z-index: 1;
 	left: 0;
-	width: auto;
-	min-width: 225px;
+	width: 100%;
 	border-radius: 0 0 2px 2px;
 	border-bottom: 0;
+
+	@include media-query('sm') {
+		transform: translateY(8px);
+		width: auto;
+	}
+
+	@include media-query('md') {
+		min-width: 225px;
+	}
 
 	.c-header-expander__list {
 		display: block;

--- a/toolkits/nature/packages/nature-header/scss/50-components/header.scss
+++ b/toolkits/nature/packages/nature-header/scss/50-components/header.scss
@@ -137,7 +137,9 @@
 }
 
 .c-header__item--dropdown-menu {
-	position: relative;
+	@include media-query('sm') {
+		position: relative;
+	}
 
 	.c-header__link.is-open {
 		svg {

--- a/toolkits/nature/packages/nature-header/scss/50-components/header.scss
+++ b/toolkits/nature/packages/nature-header/scss/50-components/header.scss
@@ -164,3 +164,16 @@
 	}
 }
 
+.c-header__menu--journal .c-header__item--dropdown-menu:last-child {
+	.c-header-expander.has-tethered {
+		@include media-query('sm') {
+			left: auto;
+			right: 0;
+		}
+
+		@include media-query('md') {
+			left: 0;
+			right: auto;
+		}
+	}
+}

--- a/toolkits/nature/packages/nature-header/scss/50-components/header.scss
+++ b/toolkits/nature/packages/nature-header/scss/50-components/header.scss
@@ -69,6 +69,18 @@
 	}
 }
 
+.c-header__menu--journal {
+	font-size: 1.4rem;
+
+	@include media-query('sm') {
+		flex-wrap: nowrap;
+	}
+
+	@include media-query('sm') {
+		font-size: 1.6rem;
+	}
+}
+
 .c-header__menu--tools {
 	@include media-query('lg', 'max') {
 		display: none;
@@ -109,8 +121,12 @@
 	white-space: nowrap;
 
 	> svg {
-		margin-left: spacing(4);
+		margin-left: spacing(2);
 		transition-duration: 0.2s;
+
+		@include media-query('sm') {
+			margin-left: spacing(4);
+		}
 	}
 }
 


### PR DESCRIPTION
* Expander full width at narrow viewports
* Aligned last expander in list of dropdown to right of screen to prevent horizontal scroll
* Reduced font-size and space between chevrons on journal menu items to get all on one line for 320px/'xs' breakpoint and above    


### **Before**
![www nature com_srep_(iPhone 5_SE)](https://user-images.githubusercontent.com/16775735/105373381-8b310b00-5bfe-11eb-9da7-aed5ae3d5b99.png)


### **After**
![local-www nature com_7890_srep(iPhone 5_SE)](https://user-images.githubusercontent.com/16775735/105373412-92581900-5bfe-11eb-98bc-9fb3599603ec.png)

