### PR TITLE
Capitalize links in nature header

### DIFF
--- a/toolkits/nature/packages/nature-header/HISTORY.md
+++ b/toolkits/nature/packages/nature-header/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 4.1.1 (2021-01-26)
+    * Capilatize first letter in links 
+
 ## 4.1.0 (2021-01-21)
     * Expander full width at narrow viewports
     * Aligned last expander in list of dropdown to right of screen to prevent horizontal scroll

--- a/toolkits/nature/packages/nature-header/package.json
+++ b/toolkits/nature/packages/nature-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/nature-header",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "license": "MIT",
   "description": "Publisher level header",
   "keywords": [],

--- a/toolkits/nature/packages/nature-header/scss/50-components/header.scss
+++ b/toolkits/nature/packages/nature-header/scss/50-components/header.scss
@@ -118,6 +118,7 @@
 	padding: spacing(8);
 	display: flex;
 	align-items: center;
+	text-transform: capitalize;
 	white-space: nowrap;
 
 	> svg {


### PR DESCRIPTION
https://jira.springernature.com/browse/PAN-1053

`Explore content` turns to `Content` at narrow widths in header so needed to capitalize link when `Explore` is hidden.
