### PR TITLE
BUG: global-list interface-link only used for Springer

### DIFF
--- a/toolkits/global/packages/global-lists/HISTORY.md
+++ b/toolkits/global/packages/global-lists/HISTORY.md
@@ -1,3 +1,7 @@
+## 1.0.1 (2021-01-29)
+    * BUG: interface-link only available for Springer brand
+	* Only use interface-link styling for Springer brand
+
 ## 1.0.0 (2021-01-26)
     * Initial commit
     * Moves `springer-lists` to the global toolkit

--- a/toolkits/global/packages/global-lists/package.json
+++ b/toolkits/global/packages/global-lists/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-lists",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "description": "Provide different styled lists",
   "keywords": [],

--- a/toolkits/global/packages/global-lists/scss/10-settings/_default.scss
+++ b/toolkits/global/packages/global-lists/scss/10-settings/_default.scss
@@ -17,4 +17,4 @@ $global-list-group--padding-sm: spacing(8) 0;
 $global-list-group--padding-md: spacing(16) 0;
 $global-list-group--padding-lg: spacing(24) 0;
 $global-list-group--line-height: 1.4;
-$global-list-group--is-interface-link: false;
+$global-list-group--is-interface: false;

--- a/toolkits/global/packages/global-lists/scss/10-settings/_default.scss
+++ b/toolkits/global/packages/global-lists/scss/10-settings/_default.scss
@@ -1,17 +1,20 @@
-$global-list-columned--column-gap: 24px;
-$global-list-columned--margin-bottom: 0.25em;
+// Columned list
+$global-list-columned--column-gap: spacing(24);
+$global-list-columned--margin-bottom: 12px;
 
-$global-list-description--wrapper-margin-bottom: 24px;
-$global-list-description--font-weight: $font-weight-bold;
-$global-list-description--font-size: $font-size-sm;
+// Description list
+$global-list-description--wrapper-margin-bottom: spacing(24);
+$global-list-description--font-weight: 700;
+$global-list-description--font-size: 16px;
 $global-list-description--line-height: 1.4;
-$global-list-description--margin-bottom: 0.25em;
-$global-list-description--is-interface-link: false;
+$global-list-description--margin-bottom: 12px;
+$global-list-description--is-interface: false;
 
+// Grouped list
 $global-list-group--border-color: #ccc;
-$global-list-group--padding-xs: 4px 0;
-$global-list-group--padding-sm: 8px 0;
-$global-list-group--padding-md: 16px 0;
-$global-list-group--padding-lg: 24px 0;
+$global-list-group--padding-xs: spacing(4) 0;
+$global-list-group--padding-sm: spacing(8) 0;
+$global-list-group--padding-md: spacing(16) 0;
+$global-list-group--padding-lg: spacing(24) 0;
 $global-list-group--line-height: 1.4;
 $global-list-group--is-interface-link: false;

--- a/toolkits/global/packages/global-lists/scss/10-settings/_default.scss
+++ b/toolkits/global/packages/global-lists/scss/10-settings/_default.scss
@@ -6,7 +6,7 @@ $global-list-description--font-weight: $font-weight-bold;
 $global-list-description--font-size: $font-size-sm;
 $global-list-description--line-height: 1.4;
 $global-list-description--margin-bottom: 0.25em;
-$global-list-description--is-interface-link: true;
+$global-list-description--is-interface-link: false;
 
 $global-list-group--border-color: #ccc;
 $global-list-group--padding-xs: 4px 0;

--- a/toolkits/global/packages/global-lists/scss/10-settings/_springer.scss
+++ b/toolkits/global/packages/global-lists/scss/10-settings/_springer.scss
@@ -7,4 +7,5 @@
 @import 'default';
 
 // Springer overrides
+$global-list-description--is-interface-link: true;
 $global-list-group--is-interface-link: true;

--- a/toolkits/global/packages/global-lists/scss/10-settings/_springer.scss
+++ b/toolkits/global/packages/global-lists/scss/10-settings/_springer.scss
@@ -7,7 +7,7 @@
 @import 'default';
 
 // Springer overrides
-$global-list-group--is-interface-link: true;
+$global-list-group--is-interface: true;
 $global-list-group--border-color: greyscale(80);
 $global-list-group--line-height: $line-height-tight;
 

--- a/toolkits/global/packages/global-lists/scss/10-settings/_springer.scss
+++ b/toolkits/global/packages/global-lists/scss/10-settings/_springer.scss
@@ -7,5 +7,12 @@
 @import 'default';
 
 // Springer overrides
-$global-list-description--is-interface-link: true;
 $global-list-group--is-interface-link: true;
+$global-list-group--border-color: greyscale(80);
+$global-list-group--line-height: $line-height-tight;
+
+$global-list-description--is-interface: true;
+$global-list-description--font-weight: $font-weight-bold;
+$global-list-description--margin-bottom: 0.25em;
+
+$global-list-columned--margin-bottom: 0.25em;

--- a/toolkits/global/packages/global-lists/scss/50-components/_list-description.scss
+++ b/toolkits/global/packages/global-lists/scss/50-components/_list-description.scss
@@ -1,11 +1,16 @@
 .c-list-description {
-	font-size: $global-list-description--font-size;
-	font-family: $font-family-sans;
-	line-height: $global-list-description--line-height;
 	margin-bottom: 0;
 	width: 100%; // fix text breaking layout in IE10
 
-	@if $global-list-description--is-interface-link {
+	@if not $global-list-description--is-interface {
+		font-size: $global-list-description--font-size;
+		font-family: $font-family-sans;
+		line-height: $global-list-description--line-height;
+	}
+
+	@if $global-list-description--is-interface {
+		@include u-text-interface;
+
 		a {
 			@include interface-link;
 		}

--- a/toolkits/global/packages/global-lists/scss/50-components/_list-description.scss
+++ b/toolkits/global/packages/global-lists/scss/50-components/_list-description.scss
@@ -7,7 +7,7 @@
 
 	@if $global-list-description--is-interface-link {
 		a {
-			@include u-link-interface;
+			@include interface-link;
 		}
 	}
 }

--- a/toolkits/global/packages/global-lists/scss/50-components/_list-group.scss
+++ b/toolkits/global/packages/global-lists/scss/50-components/_list-group.scss
@@ -3,7 +3,7 @@
 	line-height: $global-list-group--line-height;
 }
 
-@if $global-list-group--is-interface-link {
+@if $global-list-group--is-interface {
 	.c-list-group__item > a {
 		@include interface-link;
 	}


### PR DESCRIPTION
## Bug
The component uses a mixin for `interface-link` which is only available from the Springer brand of the `brand-context`.

## Fix
This PR uses conditional variables to make sure that this mixin is only used for the Springer branded version of the global component.

## Future
In the future, we are going to add the `interface-link` concept to the default `brand-context` so that it is available to all, and release a new version of this component.