### PR TITLE
Hotfix global lists sass

### DIFF
--- a/toolkits/global/packages/global-lists/HISTORY.md
+++ b/toolkits/global/packages/global-lists/HISTORY.md
@@ -1,3 +1,7 @@
+## 2.0.1 (2021-02-02)
+    * BUG: add comparison on is-interface if condition
+    * Include unconditionally `u-text-interface`
+
 ## 2.0.0 (2021-02-01)
     * Update `brand-context` to v9.0.0
     * Use new versions of mixins

--- a/toolkits/global/packages/global-lists/package.json
+++ b/toolkits/global/packages/global-lists/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-lists",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "description": "Provide different styled lists",
   "keywords": [],

--- a/toolkits/global/packages/global-lists/scss/50-components/_list-description.scss
+++ b/toolkits/global/packages/global-lists/scss/50-components/_list-description.scss
@@ -1,7 +1,7 @@
 .c-list-description {
+	@include u-text-interface;
 	margin-bottom: 0;
 	width: 100%; // fix text breaking layout in IE10
-	@include u-text-interface;
 
 	@if ($global-list-description--is-interface == true) {
 		a {

--- a/toolkits/global/packages/global-lists/scss/50-components/_list-description.scss
+++ b/toolkits/global/packages/global-lists/scss/50-components/_list-description.scss
@@ -1,10 +1,9 @@
 .c-list-description {
 	margin-bottom: 0;
 	width: 100%; // fix text breaking layout in IE10
-	
-	@if $global-list-description--is-interface {
-		@include u-text-interface;
+	@include u-text-interface;
 
+	@if ($global-list-description--is-interface == true) {
 		a {
 			@include u-link-interface;
 		}

--- a/toolkits/global/packages/global-lists/scss/50-components/_list-group.scss
+++ b/toolkits/global/packages/global-lists/scss/50-components/_list-group.scss
@@ -3,7 +3,7 @@
 	line-height: $global-list-group--line-height;
 }
 
-@if $global-list-group--is-interface {
+@if ($global-list-group--is-interface == true) {
 	.c-list-group__item > a {
 		@include u-link-interface;
 	}


### PR DESCRIPTION
- Fix the if `is-interface` condition by adding comparison operator
- Pull `u-text-interface` out of the condition 