### PR TITLE
Update global-expander in components

### DIFF
--- a/toolkits/global/packages/global-article/HISTORY.md
+++ b/toolkits/global/packages/global-article/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 22.1.0 (2021-02-03)
+    * Bump global-expander to 4.0.0
+
 ## 22.0.0 (2021-02-03)
     * Bump `brand-context` version
     * Update context variable references to use `context--` prefix

--- a/toolkits/global/packages/global-article/package.json
+++ b/toolkits/global/packages/global-article/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@springernature/global-article",
-  "version": "22.0.0",
+  "version": "22.1.0",
   "description": "Frontend package for article display",
   "license": "MIT",
   "brandContext": "^9.0.1",
   "dependencies": {
-    "@springernature/global-expander": "~3.0.1",
+    "@springernature/global-expander": "~4.0.0",
     "@springernature/global-popup": "~3.0.0"
   },
   "devDependencies": {

--- a/toolkits/global/packages/global-popup/HISTORY.md
+++ b/toolkits/global/packages/global-popup/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 4.1.0 (2021-02-03)
+    * Bump global-expander to 4.0.0
+
 ## 4.0.0 (2021-02-03)
     * Bump `brand-context` version
     * Update context variable references to use `context--` prefix

--- a/toolkits/global/packages/global-popup/package.json
+++ b/toolkits/global/packages/global-popup/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@springernature/global-popup",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Builds and styles a popup that can be opened and closed",
   "license": "MIT",
   "brandContext": "^9.0.1",
   "dependencies": {
     "@springernature/global-javascript": "^3.0.0",
-    "@springernature/global-expander": "^3.0.1"
+    "@springernature/global-expander": "^4.0.0"
   }
 }

--- a/toolkits/nature/packages/nature-header/HISTORY.md
+++ b/toolkits/nature/packages/nature-header/HISTORY.md
@@ -1,5 +1,10 @@
 # History
 
+## 5.1.0 (2021-02-03)
+    * Remove aria-pressed
+    * Remove aria-expanded and u-js-hide. These are handled in global-expander.
+    * Bump global-expander to 4.0.0
+
 ## 5.0.0 (2021-02-03)
     * Bump `brand-context` version
     * Update context variable references to use `context--` prefix

--- a/toolkits/nature/packages/nature-header/__tests__/enhanced-header.spec.js
+++ b/toolkits/nature/packages/nature-header/__tests__/enhanced-header.spec.js
@@ -50,10 +50,8 @@ describe('enhancedHeader', () => {
 		// Then
 		expect(element.button1.getAttribute('role')).toBe('button');
 		expect(element.button1.getAttribute('aria-expanded')).toBe('false');
-		expect(element.button1.getAttribute('aria-pressed')).toBe('false');
 		expect(element.button2.getAttribute('role')).toBe('button');
 		expect(element.button2.getAttribute('aria-expanded')).toBe('false');
-		expect(element.button2.getAttribute('aria-pressed')).toBe('false');
 	});
 
 	test('should append target after respective triggers', () => {

--- a/toolkits/nature/packages/nature-header/__tests__/enhanced-header.spec.js
+++ b/toolkits/nature/packages/nature-header/__tests__/enhanced-header.spec.js
@@ -34,24 +34,12 @@ describe('enhancedHeader', () => {
 		document.body.innerHTML = '';
 	});
 
-
-	test('should make all targets hidden', () => {
-		// Given
-		enhancedHeader();
-		// Then
-		expect(element.target1.classList.contains('u-js-hide')).toBe(true);
-		expect(element.target2.classList.contains('u-js-hide')).toBe(true);
-
-	});
-
-	test('should set role and aria attributes for buttons', () => {
+	test('should set role for buttons', () => {
 		// Given
 		enhancedHeader();
 		// Then
 		expect(element.button1.getAttribute('role')).toBe('button');
-		expect(element.button1.getAttribute('aria-expanded')).toBe('false');
 		expect(element.button2.getAttribute('role')).toBe('button');
-		expect(element.button2.getAttribute('aria-expanded')).toBe('false');
 	});
 
 	test('should append target after respective triggers', () => {

--- a/toolkits/nature/packages/nature-header/js/enhanced-header.js
+++ b/toolkits/nature/packages/nature-header/js/enhanced-header.js
@@ -22,7 +22,6 @@ const enhancedHeader = () => {
 	const header = document.querySelector(selectors.HEADER);
 	const triggerAttributes = [
 		{attribute: 'role', value: 'button'},
-		{attribute: 'aria-pressed', value: 'false'},
 		{attribute: 'aria-expanded', value: 'false'}
 	];
 

--- a/toolkits/nature/packages/nature-header/js/enhanced-header.js
+++ b/toolkits/nature/packages/nature-header/js/enhanced-header.js
@@ -8,8 +8,7 @@ import {Expander} from '@springernature/global-expander/js/expander';
 const DATA_COMPONENT = 'data-header-expander';
 
 const classNames = {
-	TETHERED: 'has-tethered',
-	JSHIDE: 'u-js-hide'
+	TETHERED: 'has-tethered'
 };
 
 const selectors = {
@@ -21,8 +20,7 @@ const enhancedHeader = () => {
 	const triggers = document.querySelectorAll(selectors.DATA_COMPONENT);
 	const header = document.querySelector(selectors.HEADER);
 	const triggerAttributes = [
-		{attribute: 'role', value: 'button'},
-		{attribute: 'aria-expanded', value: 'false'}
+		{attribute: 'role', value: 'button'}
 	];
 
 	if (triggers.length === 0 || !header) {
@@ -42,7 +40,6 @@ const enhancedHeader = () => {
 		}
 
 		trigger.insertAdjacentElement('afterend', targetElement);
-		targetElement.classList.add(classNames.JSHIDE);
 		targetElement.classList.add(classNames.TETHERED);
 
 		const expander = new Expander(trigger, targetElement);

--- a/toolkits/nature/packages/nature-header/package.json
+++ b/toolkits/nature/packages/nature-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/nature-header",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "license": "MIT",
   "description": "Publisher level header",
   "keywords": [],
@@ -8,6 +8,6 @@
   "brandContext": "^9.0.1",
   "dependencies": {
     "@springernature/global-javascript": "^3.0.0",
-    "@springernature/global-expander": "^3.0.1"
+    "@springernature/global-expander": "^4.0.0"
   }
 }


### PR DESCRIPTION
Update global-expander (to get [4.0.0 changes](https://github.com/springernature/frontend-toolkits/pull/440)) in nature-header, global-popup and global-article.
Removed aria-pressed from nature-header.
Removed aria-hidden and u-js-hide from nature-header. This is handled in global-expander.