### PR TITLE
brand-context: reorder abstract imports

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 9.1.1 (2021-02-05)
+    * Changes the order of abstract imports to ensure dependency settings come first
+      - This fixes a bug where buttons were not using the overriden $context--colors.
+
 ## 9.1.0 (2021-02-05)
     * Adds button-contrast to default context
 

--- a/context/brand-context/default/scss/abstracts.scss
+++ b/context/brand-context/default/scss/abstracts.scss
@@ -4,16 +4,18 @@
  * These files don’t output any CSS when compiled
  */
 
+// These settings must come first, as other settings can reference them
 @import '10-settings/breakpoints';
 @import '10-settings/colors/default';
 @import '10-settings/colors/shared';
 @import '10-settings/spacing';
-@import '10-settings/buttons'; // needs to appear after spacing
-@import '10-settings/container'; // needs to appear after spacing
+@import '10-settings/typography';
+
+@import '10-settings/buttons';
+@import '10-settings/container';
 @import '10-settings/keyframes';
 @import '10-settings/layers';
 @import '10-settings/style';
-@import '10-settings/typography';
 
 @import '20-functions/colors';
 @import '20-functions/helpers';

--- a/context/brand-context/nature/scss/abstracts.scss
+++ b/context/brand-context/nature/scss/abstracts.scss
@@ -4,11 +4,13 @@
  * These files don’t output any CSS when compiled
  */
 
-@import '10-settings/buttons';
+// These settings must come first, as other settings can reference them
 @import '10-settings/colors/default';
+@import '10-settings/typography';
+
+@import '10-settings/buttons';
 @import '10-settings/keyframes';
 @import '10-settings/style';
-@import '10-settings/typography';
 @import '10-settings/global'; // temp, will be removed eventually
 
 @import '30-mixins/typography';

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/springer/scss/abstracts.scss
+++ b/context/brand-context/springer/scss/abstracts.scss
@@ -4,9 +4,11 @@
  * These files don’t output any CSS when compiled
  */
 
+// These settings must come first, as other settings can reference them
 @import '10-settings/colors/default';
 @import '10-settings/typography';
-@import '10-settings/buttons'; // needs to appear after colors & typography
+
+@import '10-settings/buttons';
 
 @import '20-functions/em';
 @import '20-functions/strip-unit';

--- a/context/brand-context/springernature/scss/abstracts.scss
+++ b/context/brand-context/springernature/scss/abstracts.scss
@@ -4,10 +4,12 @@
  * These files don’t output any CSS when compiled
  */
 
+// These settings must come first, as other settings can reference them
 @import '10-settings/breakpoints';
 @import '10-settings/colors/default';
 @import '10-settings/typography';
-@import '10-settings/buttons'; // needs to appear after colors & typography
+
+@import '10-settings/buttons';
 
 // 30-mixins
 @import '30-mixins/typography';


### PR DESCRIPTION
This ensures that the dependency settings always come first.