### PR TITLE
Update default headings to use mixins

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 10.0.3 (2021-02-12)
+    * BUG: all brands except default were using a mixin for headings
+
 ## 10.0.2 (2021-02-12)
     * Fix button box-shadow on hover for Springernature brand
 

--- a/context/brand-context/default/scss/30-mixins/typography.scss
+++ b/context/brand-context/default/scss/30-mixins/typography.scss
@@ -26,3 +26,25 @@
 	font-size: $context--font-size-interface;
 	line-height: $context--line-height-tight;
 }
+
+// Headings
+
+@mixin u-h1() {
+	font-size: $context--font-size-h1;
+	font-weight: $context--font-weight-bold;
+}
+
+@mixin u-h2() {
+	font-size: $context--font-size-h2;
+	font-weight: $context--font-weight-bold;
+}
+
+@mixin u-h3() {
+	font-size: $context--font-size-h3;
+	font-weight: $context--font-weight-bold;
+}
+
+@mixin u-h4() {
+	font-size: $context--font-size-h4;
+	font-weight: $context--font-weight-bold;
+}

--- a/context/brand-context/default/scss/60-utilities/typography.scss
+++ b/context/brand-context/default/scss/60-utilities/typography.scss
@@ -70,17 +70,17 @@
 }
 
 .u-h1 {
-	font-size: $context--font-size-h1;
+	@include u-h1();
 }
 
 .u-h2 {
-	font-size: $context--font-size-h2;
+	@include u-h2();
 }
 
 .u-h3 {
-	font-size: $context--font-size-h3;
+	@include u-h3();
 }
 
 .u-h4 {
-	font-size: $context--font-size-h4;
+	@include u-h4();
 }

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],


### PR DESCRIPTION
All brands except the `default` brand were using a mixin for the heading utility classes e.g `u-h1`. This causes an issue for components that want to reference that mixin.

FIX: all the mixin to the `default` brand level, to be overridden by each imprint brand