### PR TITLE
Increase line-height in global-status-message

### DIFF
--- a/toolkits/global/packages/global-status-message/HISTORY.md
+++ b/toolkits/global/packages/global-status-message/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 2.0.2 (2021-02-16)
+    * Increase line-height from 1.3 to 1.4 using $context--line-height-tight 
+
 ## 2.0.1 (2021-02-03)
     * Bump `brand-context` version
     * Fix reference to old font-size-* variable

--- a/toolkits/global/packages/global-status-message/package.json
+++ b/toolkits/global/packages/global-status-message/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-status-message",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "license": "MIT",
   "description": "Global Status Message component",
   "keywords": [],

--- a/toolkits/global/packages/global-status-message/scss/10-settings/default.scss
+++ b/toolkits/global/packages/global-status-message/scss/10-settings/default.scss
@@ -11,7 +11,7 @@ $status-message--border-radius: 2px;
 $status-message--boxed-border: 4px;
 $status-message--background-color: white;
 $status-message--border: 1px solid greyscale(80);
-$status-message--line-height: 1.3;
+$status-message--line-height: $context--line-height-tight;
 $status-message--gutter: spacing(16);
 $status-message--gutter-icon: spacing(8);
 $status-message--font-weight: $context--font-weight-bold;


### PR DESCRIPTION
Bugbash: https://trello.com/c/rfgoQbIM/37-is-the-line-space-ok-in-this-message-seems-a-bit-tight-compare-to-the-rest-of-the-page-rv

Increase line-height from 1.3 to 1.4 using $context--line-height-tight