### PR TITLE
Button mixin svg fill

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 10.0.4 (2021-02-17)
+    * Make svg fill in button mixin follow currentColor
+
 ## 10.0.3 (2021-02-12)
     * BUG: all brands except default were using a mixin for headings
 

--- a/context/brand-context/default/scss/30-mixins/buttons.scss
+++ b/context/brand-context/default/scss/30-mixins/buttons.scss
@@ -111,6 +111,10 @@
 	box-shadow: map-get($theme, 'boxShadow');
 	font-weight: map-get($theme, 'fontWeight');
 
+	svg {
+		fill: currentColor;
+	}
+
 	&:visited {
 		color: map-get($theme, 'visitedColor');
 	}

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],


### PR DESCRIPTION
This change will make sure that any svg icon included on a button gets the currentColor used by the font.


<img width="270" alt="Screen Shot 2021-02-17 at 14 40 13" src="https://user-images.githubusercontent.com/7041528/108212375-146c2c80-712e-11eb-8c55-def0114f399a.png">

