### PR TITLE
Update global popup to allow for wrapped text

### DIFF
--- a/toolkits/global/packages/global-popup/HISTORY.md
+++ b/toolkits/global/packages/global-popup/HISTORY.md
@@ -3,6 +3,7 @@
 ## 4.2.0 (2021-02-17)
     * Fixes bug so that popup/arrow is positioned above trigger
     * Ensure popup stays within screen width
+
 ## 4.1.1 (2021-02-15)
     * Bump global-expander to 4.0.1
     * Bump global-javascript to 3.0.1 

--- a/toolkits/global/packages/global-popup/HISTORY.md
+++ b/toolkits/global/packages/global-popup/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 4.2.0 (2021-02-17)
+    * Fixes bug so that popup/arrow is positioned above trigger
+    * Ensure popup stays within screen width
 ## 4.1.1 (2021-02-15)
     * Bump global-expander to 4.0.1
     * Bump global-javascript to 3.0.1 

--- a/toolkits/global/packages/global-popup/js/popup.js
+++ b/toolkits/global/packages/global-popup/js/popup.js
@@ -42,7 +42,7 @@ const Popup = class {
 		const pos = this._calcPositioning();
 		this._content.style.top = this._px(pos.top);
 		this._content.style.left = this._px(pos.left);
-		this._content.style.right = this._px(5);
+		this._content.style.right = this._px(pos.right);
 	}
 
 	_close() {
@@ -96,20 +96,21 @@ const Popup = class {
 
 	_calcPositioning() {
 		const distanceScrolled = document.documentElement.scrollTop;
+		const defaultOffset = 5;
 		const triggerMetricsCollection = this._trigger.getClientRects();
 		const triggerMetrics = (triggerMetricsCollection.length > 0) ? triggerMetricsCollection[0] : {top: 0, left: 0};
 		const offset = {
 			top: triggerMetrics.top + distanceScrolled,
-			left: triggerMetrics.left
+			left: triggerMetrics.left,
+			right: defaultOffset
 		};
+		
 		const originalOffsetLeft = offset.left;
-
 		const arrow = this._content.querySelector(`.${this._arrowClass}`);
 		const windowWidth = document.documentElement.clientWidth;
 		const arrowHeight = 12;
 		const arrowWidth = 20;
-		const defaultOffsetLeft = 5;
-		const pagePadding = 32;
+		const pagePadding =  (this._options.PAGE_PADDING) ? this._options.PAGE_PADDING : 32;
 		const mdBreakPoint = 768;
 		const lgBreakPoint = 1024;
 
@@ -123,7 +124,7 @@ const Popup = class {
 		const overrun = offset.left + this._content.offsetWidth - windowWidth + pagePadding;
 		if (overrun > 0) {
 			if (overrun > offset.left) {
-				offset.left = defaultOffsetLeft;
+				offset.left = defaultOffset;
 			} else {
 				offset.left -= overrun;
 			}
@@ -162,8 +163,9 @@ const Popup = class {
 		}
 
 		return {
-			left: (windowWidth < mdBreakPoint) ? defaultOffsetLeft : offset.left,
-			top: top
+			left: (windowWidth < mdBreakPoint) ? defaultOffset : offset.left,
+			top: top,
+			right: defaultOffset
 		};
 	}
 };

--- a/toolkits/global/packages/global-popup/js/popup.js
+++ b/toolkits/global/packages/global-popup/js/popup.js
@@ -104,13 +104,13 @@ const Popup = class {
 			left: triggerMetrics.left,
 			right: defaultOffset
 		};
-		
+
 		const originalOffsetLeft = offset.left;
 		const arrow = this._content.querySelector(`.${this._arrowClass}`);
 		const windowWidth = document.documentElement.clientWidth;
 		const arrowHeight = 12;
 		const arrowWidth = 20;
-		const pagePadding =  (this._options.PAGE_PADDING) ? this._options.PAGE_PADDING : 32;
+		const pagePadding = (this._options.PAGE_PADDING) ? this._options.PAGE_PADDING : 32;
 		const mdBreakPoint = 768;
 		const lgBreakPoint = 1024;
 

--- a/toolkits/global/packages/global-popup/js/popup.js
+++ b/toolkits/global/packages/global-popup/js/popup.js
@@ -96,8 +96,8 @@ const Popup = class {
 
 	_calcPositioning() {
 		const distanceScrolled = document.documentElement.scrollTop;
-		const triggerMetricsArr = this._trigger.getClientRects();
-		const triggerMetrics = (triggerMetricsArr.length) ? triggerMetricsArr[0] : {top: 0, left: 0};
+		const triggerMetricsCollection = this._trigger.getClientRects();
+		const triggerMetrics = (triggerMetricsCollection.length > 0) ? triggerMetricsCollection[0] : {top: 0, left: 0};
 		const offset = {
 			top: triggerMetrics.top + distanceScrolled,
 			left: triggerMetrics.left
@@ -134,7 +134,7 @@ const Popup = class {
 		if (triggerMetrics.length > 1) {
 			wrapped = true;
 			if (windowWidth > lgBreakPoint) {
-				offset.left = triggerMetrics.left - this._content.offsetWidth / 2 + arrowWidth;
+				offset.left = (triggerMetrics.left - (this._content.offsetWidth / 2)) + arrowWidth;
 			}
 		}
 
@@ -153,12 +153,12 @@ const Popup = class {
 		if (windowWidth < mdBreakPoint) {
 			// just position arrow 5px from trigger left
 			arrow.style.left = this._px(originalOffsetLeft + 5);
-		} else if (!wrapped) {
-			arrow.style.left = this._px(Math.max(Math.round(triggerMetrics.width / 2 - arrowWidth / 2) + ((overrun > 0) ? overrun : 0), 5));
-		} else {
+		} else if (wrapped) {
 			// wrapped text add arrow
 			const triggerStartPos = Math.round((offset.left + this._content.offsetWidth) - triggerMetrics.left - arrowWidth);
 			arrow.style.left = this._px(Math.round(this._content.offsetWidth - triggerStartPos));
+		} else {
+			arrow.style.left = this._px(Math.max(Math.round((triggerMetrics.width / 2) - (arrowWidth / 2)) + ((overrun > 0) ? overrun : 0), 5));
 		}
 
 		return {

--- a/toolkits/global/packages/global-popup/js/popup.js
+++ b/toolkits/global/packages/global-popup/js/popup.js
@@ -41,7 +41,8 @@ const Popup = class {
 		}
 		const pos = this._calcPositioning();
 		this._content.style.top = this._px(pos.top);
-		this._content.style.transform = `translateX(${pos.left}px)`;
+		this._content.style.left = this._px(pos.left);
+		this._content.style.right = this._px(5);
 	}
 
 	_close() {
@@ -95,21 +96,47 @@ const Popup = class {
 
 	_calcPositioning() {
 		const distanceScrolled = document.documentElement.scrollTop;
-		const triggerMetrics = this._trigger.getBoundingClientRect();
+		const triggerMetricsArr = this._trigger.getClientRects();
+		const triggerMetrics = (triggerMetricsArr.length) ? triggerMetricsArr[0] : {top: 0, left: 0};
 		const offset = {
 			top: triggerMetrics.top + distanceScrolled,
 			left: triggerMetrics.left
 		};
+		const originalOffsetLeft = offset.left;
+
 		const arrow = this._content.querySelector(`.${this._arrowClass}`);
 		const windowWidth = document.documentElement.clientWidth;
 		const arrowHeight = 12;
 		const arrowWidth = 20;
+		const defaultOffsetLeft = 5;
+		const pagePadding = 32;
+		const mdBreakPoint = 768;
+		const lgBreakPoint = 1024;
 
 		// calc space above trigger
 		const spaceAbove = offset.top - this._content.offsetHeight - arrowHeight;
 
 		const abovePosition = offset.top - this._content.offsetHeight - arrowHeight;
 		const belowPosition = offset.top + triggerMetrics.height + arrowHeight;
+
+		// does the popup and its position overrun the width of the page and its padding
+		const overrun = offset.left + this._content.offsetWidth - windowWidth + pagePadding;
+		if (overrun > 0) {
+			if (overrun > offset.left) {
+				offset.left = defaultOffsetLeft;
+			} else {
+				offset.left -= overrun;
+			}
+		}
+
+		let wrapped = false;
+		// does the popup trigger content wrap onto multiple lines
+		if (triggerMetrics.length > 1) {
+			wrapped = true;
+			if (windowWidth > lgBreakPoint) {
+				offset.left = triggerMetrics.left - this._content.offsetWidth / 2 + arrowWidth;
+			}
+		}
 
 		let top;
 		// if there is not enough room for popup above trigger
@@ -123,16 +150,19 @@ const Popup = class {
 			arrow.classList.add(this._arrowClass + '--above');
 		}
 
-		if (windowWidth < 600) {
+		if (windowWidth < mdBreakPoint) {
 			// just position arrow 5px from trigger left
-			arrow.style.left = this._px(offset.left + 5);
+			arrow.style.left = this._px(originalOffsetLeft + 5);
+		} else if (!wrapped) {
+			arrow.style.left = this._px(Math.max(Math.round(triggerMetrics.width / 2 - arrowWidth / 2) + ((overrun > 0) ? overrun : 0), 5));
 		} else {
-			// position arrow in middle of trigger
-			arrow.style.left = this._px(Math.round((triggerMetrics.width / 2) - arrowWidth));
+			// wrapped text add arrow
+			const triggerStartPos = Math.round((offset.left + this._content.offsetWidth) - triggerMetrics.left - arrowWidth);
+			arrow.style.left = this._px(Math.round(this._content.offsetWidth - triggerStartPos));
 		}
 
 		return {
-			left: (windowWidth < 600) ? 0 : offset.left,
+			left: (windowWidth < mdBreakPoint) ? defaultOffsetLeft : offset.left,
 			top: top
 		};
 	}

--- a/toolkits/global/packages/global-popup/package.json
+++ b/toolkits/global/packages/global-popup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-popup",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "Builds and styles a popup that can be opened and closed",
   "license": "MIT",
   "brandContext": "^9.0.1",


### PR DESCRIPTION
- Positions the popup and arrow to be over the trigger when the trigger is positioned at the "end of line" and wraps.
- Ensures that the popup doesn't go off the screen.
- Ensures the popup appears at the correct size and isn't shrunk or stretched.
- New version number added