### PR TITLE
Default font-sizing bug

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -2,7 +2,7 @@
 
 ## 10.1.2 (2021-03-01)
     * BUG: components reference missing default font-sizes
-	* Add default font sizes 
+    * Add default font sizes 
 
 ## 10.1.1 (2021-02-24)
     * Change font family to serif for SN u-h4,u-h5 

--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 10.1.2 (2021-03-01)
+    * BUG: components reference missing default font-sizes
+	* Add default font sizes 
+
 ## 10.1.1 (2021-02-24)
     * Change font family to serif for SN u-h4,u-h5 
 

--- a/context/brand-context/default/scss/10-settings/typography.scss
+++ b/context/brand-context/default/scss/10-settings/typography.scss
@@ -19,6 +19,10 @@ $context--font-size-base: 1.8em;
 
 $context--font-size-interface: 16px;
 
+$context--font-size-sm: 16px;
+$context--font-size-md: 18px;
+$context--font-size-lg: 24px;
+
 // Headings
 $context--font-size-h1: 3.2rem;
 $context--font-size-h2: 2.4rem;

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "10.1.1",
+  "version": "10.1.2",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],


### PR DESCRIPTION
Adds:
- `$context--font-size-sm`
- `$context--font-size-md`
- `$context--font-size-lg`

These variables exist in all context packages except `default` and are referenced by some global components. This meant that we get SASS compilation errors when trying to use the default brand.