### PR TITLE
global-status-message: Add icon inheritance 

### DIFF
--- a/toolkits/global/packages/global-status-message/HISTORY.md
+++ b/toolkits/global/packages/global-status-message/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 3.0.0 (2021-03-01)
+    * Update to brand-context@10.1.2 which fixes a bug for default branding in previous version
+    * Allow colour inheritance for icons and no need for other components/utilities
+
 ## 2.0.3 (2021-02-18)
     * Fix icons shrink issue
 

--- a/toolkits/global/packages/global-status-message/README.md
+++ b/toolkits/global/packages/global-status-message/README.md
@@ -2,7 +2,7 @@
 
 ## Branding
 
-The `global-status-message` component uses the `DEFAULT` branding across _all_ of our products so that we have consistent styling.
+The `global-status-message` component uses the `DEFAULT` branding across _all_ of our products.
 
 ```scss
 // Include this with your settings

--- a/toolkits/global/packages/global-status-message/README.md
+++ b/toolkits/global/packages/global-status-message/README.md
@@ -2,7 +2,7 @@
 
 ## Branding
 
-The `global-status-message` component currently uses the `DEFAULT` brand only.
+The `global-status-message` component uses the `DEFAULT` branding across _all_ of our products so that we have consistent styling.
 
 ```scss
 // Include this with your settings

--- a/toolkits/global/packages/global-status-message/README.md
+++ b/toolkits/global/packages/global-status-message/README.md
@@ -23,7 +23,7 @@ The `global-status-message` component currently uses the `DEFAULT` brand only.
 
 <!-- With Icon -->
 <div class="c-status-message">
-    <svg class="c-icon c-status-message__icon" width="24" height="24" aria-hidden="true" focusable="false">
+    <svg class="c-status-message__icon" width="24" height="24" aria-hidden="true" focusable="false">
         <use xlink:href="#icon-success"></use>
     </svg>Your text
 </div>
@@ -51,7 +51,7 @@ Sets a border and padding around the status message.
 
 ```html
 <!-- Default -->
-<div class="c-status-message c-status-message--boxed">...</div>
+<div class="c-status-message c-status-message--success">...</div>
 ```
 <p>
     <img width="300" src="https://github.com/springernature/frontend-toolkits/blob/global-status-message/toolkits/global/packages/global-status-message/img/success.png" />

--- a/toolkits/global/packages/global-status-message/package.json
+++ b/toolkits/global/packages/global-status-message/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-status-message",
-  "version": "2.0.3",
+  "version": "3.0.0",
   "license": "MIT",
   "description": "Global Status Message component",
   "keywords": [],

--- a/toolkits/global/packages/global-status-message/package.json
+++ b/toolkits/global/packages/global-status-message/package.json
@@ -5,5 +5,5 @@
   "description": "Global Status Message component",
   "keywords": [],
   "author": "Springer Nature",
-  "brandContext": "^10.1.1"
+  "brandContext": "^10.1.2"
 }

--- a/toolkits/global/packages/global-status-message/package.json
+++ b/toolkits/global/packages/global-status-message/package.json
@@ -5,5 +5,5 @@
   "description": "Global Status Message component",
   "keywords": [],
   "author": "Springer Nature",
-  "brandContext": "^9.0.2"
+  "brandContext": "^10.1.1"
 }

--- a/toolkits/global/packages/global-status-message/scss/10-settings/default.scss
+++ b/toolkits/global/packages/global-status-message/scss/10-settings/default.scss
@@ -1,3 +1,8 @@
+/**
+ * Status Message
+ * Default branding for component
+ */
+
 $status-message-theme: (
 	"info": #003f8d,
 	"error": #c40606,

--- a/toolkits/global/packages/global-status-message/scss/50-components/status-message.scss
+++ b/toolkits/global/packages/global-status-message/scss/50-components/status-message.scss
@@ -28,6 +28,10 @@
 .c-status-message__icon {
 	flex: 0 0 auto;
 	margin-right: $status-message--gutter-icon;
+	fill: currentColor;
+	transform: translate(0, 0); // Hack to allow for subpixel rendering
+	display: inline-block;
+	vertical-align: text-top;
 }
 
 .c-status-message__icon--top {

--- a/toolkits/global/packages/global-status-message/scss/50-components/status-message.scss
+++ b/toolkits/global/packages/global-status-message/scss/50-components/status-message.scss
@@ -26,12 +26,9 @@
 }
 
 .c-status-message__icon {
+	@include u-icon;
 	flex: 0 0 auto;
 	margin-right: $status-message--gutter-icon;
-	fill: currentColor;
-	transform: translate(0, 0); // Hack to allow for subpixel rendering
-	display: inline-block;
-	vertical-align: text-top;
 }
 
 .c-status-message__icon--top {


### PR DESCRIPTION
This PR does the following:
- Update to the latest version of the `brand-context` which fixes a bug where `$context--font-size-sm` was not available for the `default` brand
- Tidy up the README, fixing some text errors
- Add color `fill` inheritance for icons by using the `u-icon` mixin, the readme previously referenced the non-existent `c-icon` component, whilst Oscar was using the `u-icon` class. This decouples the component from any other dependencies (either another component or having to include the utility class)