### PR TITLE
Dont focus input

### DIFF
--- a/toolkits/global/packages/global-autocomplete/HISTORY.md
+++ b/toolkits/global/packages/global-autocomplete/HISTORY.md
@@ -1,6 +1,6 @@
 # History
 
-## 5.0.3 (2020-03-01)
+## 5.0.3 (2021-03-01)
     * Dont focus input when removing suggestion box
 
 ## 5.0.2 (2020-11-19)

--- a/toolkits/global/packages/global-autocomplete/HISTORY.md
+++ b/toolkits/global/packages/global-autocomplete/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 5.0.3 (2020-03-01)
+    * Dont focus input when removing suggestion box
+
 ## 5.0.2 (2020-11-19)
     * Bump to get latest version package-manager with updated post install script
 

--- a/toolkits/global/packages/global-autocomplete/js/index.js
+++ b/toolkits/global/packages/global-autocomplete/js/index.js
@@ -59,7 +59,6 @@ const autoComplete = arguments_ => {
 			container().remove();
 		}
 		document.removeEventListener('click', removeSuggestions);
-		input.focus();
 	};
 
 	const addSuggestionEventListeners = () => {

--- a/toolkits/global/packages/global-autocomplete/package.json
+++ b/toolkits/global/packages/global-autocomplete/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-autocomplete",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "license": "MIT",
   "description": "Autocomplete/suggest component",
   "keywords": [],


### PR DESCRIPTION
This PR removes a line which focuses the autocomplete input when you click outside of it. 
This bit of code is called when you click a suggestion (updates input value and removes suggestions), or when you click outside of the component (removes suggestions) - it probably doesn't need to focus on the input.