### PR TITLE
Add an open method for popups to allow them to be lazily created when…

### DIFF
--- a/toolkits/global/packages/global-popup/HISTORY.md
+++ b/toolkits/global/packages/global-popup/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 4.3.0 (2021-03-03)
+    * Adds an open method to allow lazily creating a popup when the trigger is clicked
+
 ## 4.2.0 (2021-02-17)
     * Fixes bug so that popup/arrow is positioned above trigger
     * Ensure popup stays within screen width

--- a/toolkits/global/packages/global-popup/README.md
+++ b/toolkits/global/packages/global-popup/README.md
@@ -56,3 +56,27 @@ new Popup(trigger, 'popupContent1', { MIN_WIDTH: "100px", MAX_WIDTH: "600px" });
     </div>
 </div>		
 ```
+
+### Lazily
+
+If you wish to lazily create a popup the first time the trigger is clicked - for example if building the html for your popup is an expensive operation that you'd like to defer until needed - you can use this pattern:
+
+
+```javascript
+import {Popup} from 'global-popup/js/popup';
+
+const trigger = document.querySelector('span');
+trigger.addEventListener('click', function() {
+    const popup = new Popup(trigger, 'popupContent1');
+    popup.open();
+}, {capture: false, once: true});
+```
+
+```html
+<div>
+    <span>Popup trigger</span>
+    <div id="popupContent1">
+        <p>Some popup text</p>
+    </div>
+</div>
+```

--- a/toolkits/global/packages/global-popup/__tests__/popup.spec.js
+++ b/toolkits/global/packages/global-popup/__tests__/popup.spec.js
@@ -21,6 +21,28 @@ describe('Global Popup: popup.js', () => {
 		document.getElementsByTagName('html')[0].innerHTML = '';
 	});
 
+	it('should open the popup when the trigger is clicked', () => {
+		const popup = new Popup(trigger, 'popupContent1');
+		const spy = jest.spyOn(popup._expander, 'open');
+
+		expect(spy).not.toHaveBeenCalled();
+
+		trigger.click();
+
+		expect(spy).toHaveBeenCalled();
+	});
+
+	it('should open the popup when the open method id called', () => {
+		const popup = new Popup(trigger, 'popupContent1');
+		const spy = jest.spyOn(popup._expander, 'open');
+
+		expect(spy).not.toHaveBeenCalled();
+
+		popup.open();
+
+		expect(spy).toHaveBeenCalled();
+	});
+
 	it('should build a popup that includes the arrow and close button html', () => {
 		new Popup(trigger, 'popupContent1');
 

--- a/toolkits/global/packages/global-popup/js/popup.js
+++ b/toolkits/global/packages/global-popup/js/popup.js
@@ -21,6 +21,10 @@ const Popup = class {
 		this._bindEvents();
 	}
 
+	open() {
+		this._expander.open();
+	}
+
 	_build() {
 		this._content.insertAdjacentHTML('beforeend', this._closeButton + this._arrow);
 		document.body.appendChild(this._content);

--- a/toolkits/global/packages/global-popup/package.json
+++ b/toolkits/global/packages/global-popup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-popup",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Builds and styles a popup that can be opened and closed",
   "license": "MIT",
   "brandContext": "^9.0.1",


### PR DESCRIPTION
… the trigger is first clicked

Creating the markup for author popups is a relatively expensive operation. We would like to be able to defer this until an author link is actually clicked instead of building them all up front. However if you simply create the popup object in the click event it won't open because it'll be too late for the popup itself to respond to the event. 

This change adds an open method to popup objects so we can programatically open the popup after it has been created. 

e.g.

```javascript
trigger.addEventListener('click', function() {
    const popup = new Popup(trigger, 'popupcontent');
    popup.open();
}, {capture: false, once: true});
```