### PR TITLE
Change h4 to serif in springer context

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 11.0.1 (2021-03-12)
+    * Change h4 to serif in springer context 
+
 ## 11.0.0 (2021-03-12)
     * BREAKING:
         * Remove $save-data variable from typography

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/springer/scss/30-mixins/typography.scss
+++ b/context/brand-context/springer/scss/30-mixins/typography.scss
@@ -56,7 +56,7 @@
 	@include heading-base;
 	font-size: $context--font-size-h4;
 	font-size: unquote('min(max(#{$context--font-size-h4-min}, 2.5vw), #{$context--font-size-h4})');
-	font-family: $context--font-family-sans;
+	font-family: $context--font-family-serif;
 	font-weight: $context--font-weight-bold;
 }
 


### PR DESCRIPTION
Request from James to make h4 serif and consistent with the other headings