### PR TITLE
Add global-card title overrides in nature settings

### DIFF
--- a/toolkits/global/packages/global-card/HISTORY.md
+++ b/toolkits/global/packages/global-card/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 3.1.1 (2021-03-15)
+    * Add title overrides in nature settings
+
 ## 3.1.0 (2021-03-15)
     * Change default card title settings 
     * Bump brand context version

--- a/toolkits/global/packages/global-card/package.json
+++ b/toolkits/global/packages/global-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-card",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "license": "MIT",
   "description": "card component",
   "keywords": [

--- a/toolkits/global/packages/global-card/scss/10-settings/nature.scss
+++ b/toolkits/global/packages/global-card/scss/10-settings/nature.scss
@@ -10,3 +10,5 @@
 $card--padding-x: 0;
 $card--dark-background: #29303c;
 $card--dark-color: #e3e4e5;
+$card--title-font-weight: null;
+$card--title-heading: h3;


### PR DESCRIPTION
This setting was previously in default but got changed in 3.1.0. Adding it back for nature to retain title style. 