### PR TITLE
Small refactor to generate a smaller compiled bundle size

### DIFF
--- a/toolkits/nature/packages/nature-header/HISTORY.md
+++ b/toolkits/nature/packages/nature-header/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 5.1.3 (2021-03-17)
+    * Refactor to generate smaller bundle size
+
 ## 5.1.2 (2021-03-01)
     * Capitalize first letter instead all words in link
     * Update readme

--- a/toolkits/nature/packages/nature-header/js/enhanced-header.js
+++ b/toolkits/nature/packages/nature-header/js/enhanced-header.js
@@ -20,7 +20,7 @@ const enhancedHeader = () => {
 	const triggers = document.querySelectorAll(selectors.DATA_COMPONENT);
 	const header = document.querySelector(selectors.HEADER);
 	const triggerAttributes = [
-		{attribute: 'role', value: 'button'}
+		{name: 'role', value: 'button'}
 	];
 
 	if (triggers.length === 0 || !header) {
@@ -35,9 +35,9 @@ const enhancedHeader = () => {
 			return;
 		}
 
-		for (let {attribute, value} of triggerAttributes) {
-			trigger.setAttribute(attribute, value);
-		}
+		triggerAttributes.forEach(function (attribute) {
+			trigger.setAttribute(attribute.name, attribute.value);
+		});
 
 		trigger.insertAdjacentElement('afterend', targetElement);
 		targetElement.classList.add(classNames.TETHERED);

--- a/toolkits/nature/packages/nature-header/package.json
+++ b/toolkits/nature/packages/nature-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/nature-header",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "license": "MIT",
   "description": "Publisher level header",
   "keywords": [],


### PR DESCRIPTION
This change seems to allow us to remove:

```
import 'core-js/features/dom-collections';
import 'core-js/features/symbol';
import 'regenerator-runtime/runtime';
import 'core-js/stable/object/assign';
```

from header-150.js and would take the resulting bundle size from around 32kb to 7kb. 