### PR TITLE
Fluid typography on titles of nature-hero and global-card

### DIFF
--- a/toolkits/global/packages/global-card/HISTORY.md
+++ b/toolkits/global/packages/global-card/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 3.2.0 (2021-04-19)
+    * Update card title to use fluid typography
+    * Bump brand context version
+
 ## 3.1.1 (2021-03-15)
     * Add title overrides in nature settings
 

--- a/toolkits/global/packages/global-card/package.json
+++ b/toolkits/global/packages/global-card/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@springernature/global-card",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "license": "MIT",
   "description": "card component",
   "keywords": [
     "card"
   ],
   "author": "Springer Nature",
-  "brandContext": "^11.0.1"
+  "brandContext": "^11.1.1"
 }

--- a/toolkits/global/packages/global-card/scss/10-settings/default.scss
+++ b/toolkits/global/packages/global-card/scss/10-settings/default.scss
@@ -17,7 +17,7 @@ $card--title-letter-spacing: normal;
 
 // --major
 $card--major-font-size: 1.6rem;
-$card--major-title-font-size: 2.4rem;
+$card--major-title-heading: h2;
 
 // --dark
 $card--dark-background: slategrey;

--- a/toolkits/global/packages/global-card/scss/10-settings/nature.scss
+++ b/toolkits/global/packages/global-card/scss/10-settings/nature.scss
@@ -12,3 +12,4 @@ $card--dark-background: #29303c;
 $card--dark-color: #e3e4e5;
 $card--title-font-weight: null;
 $card--title-heading: h3;
+$card--title-letter-spacing: -0.01875rem;

--- a/toolkits/global/packages/global-card/scss/50-components/card.scss
+++ b/toolkits/global/packages/global-card/scss/50-components/card.scss
@@ -71,7 +71,7 @@
 	font-size: $card--major-font-size;
 
 	.c-card__title {
-		font-size: $card--major-title-font-size;
+		@include u-heading($card--major-title-heading);
 	}
 }
 

--- a/toolkits/nature/packages/nature-hero/HISTORY.md
+++ b/toolkits/nature/packages/nature-hero/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 1.1.0 (2021-04-19)
+    * Bump brand context version
+    * Adjust hero title to use fluid typography
+
 ## 1.0.0 (2021-03-02)
     * Update to brand-context 10.1.3
 

--- a/toolkits/nature/packages/nature-hero/package.json
+++ b/toolkits/nature/packages/nature-hero/package.json
@@ -1,9 +1,9 @@
 {
     "name": "@springernature/nature-hero",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "license": "MIT",
     "description": "Nature branded hero",
     "keywords": [],
     "author": "Springer Nature",
-    "brandContext": "^10.1.3"
+    "brandContext": "^11.1.1"
 }

--- a/toolkits/nature/packages/nature-hero/scss/10-settings/hero.scss
+++ b/toolkits/nature/packages/nature-hero/scss/10-settings/hero.scss
@@ -8,10 +8,8 @@ $hero--copy-background-color: #29303c;
 $hero--copy-padding: spacing(16);
 $hero--copy-padding-at-lg: spacing(32);
 $hero--copy-max-width: calc(40% + 8px); // Half the global-gutter
-$hero--title-font-weight: bold;
-$hero--title-line-height: 1.2;
-$hero--title-font-size: 2.4rem;
-$hero--title-font-size-at-xl: 3.2rem;
+$hero--title-font-size-at-md: unquote('min(max(#{$context--font-size-h1-min}, 3vw), #{$context--font-size-h1})');
+$hero--title-line-height-at-md: unquote('min(max(#{$context--line-height-h1-min}, 3vw), #{$context--line-height-h1})');
 $hero--title-margin: spacing(16);
 $hero--summary-line-height: 1.4;
 $hero--summary-font-size: 1.4rem;

--- a/toolkits/nature/packages/nature-hero/scss/50-components/hero.scss
+++ b/toolkits/nature/packages/nature-hero/scss/50-components/hero.scss
@@ -65,13 +65,12 @@
 }
 
 .c-hero__title {
-	font-size: $hero--title-font-size;
-	font-weight: $hero--title-font-weight;
-	line-height: $hero--title-line-height;
+	@include u-h1;
 	margin-bottom: $hero--title-margin;
 
-	@include media-query('xl') {
-		font-size: $hero--title-font-size-at-xl;
+	@include media-query('md') {
+		font-size: $hero--title-font-size-at-md;
+		line-height: $hero--title-line-height-at-md;
 	}
 }
 


### PR DESCRIPTION
updates titles on nature-hero and global-card components to use fluid typography set from https://github.com/springernature/frontend-toolkits/pull/497