### PR TITLE
Adds List Header component to Global Lists

### DIFF
--- a/toolkits/global/packages/global-lists/HISTORY.md
+++ b/toolkits/global/packages/global-lists/HISTORY.md
@@ -1,3 +1,6 @@
+## 2.1.0 (2021-05-18)
+    * Adds list header component and settings
+
 ## 2.0.1 (2021-02-02)
     * BUG: add comparison on is-interface if condition
     * Include unconditionally `u-text-interface`

--- a/toolkits/global/packages/global-lists/README.md
+++ b/toolkits/global/packages/global-lists/README.md
@@ -42,3 +42,19 @@ Components for working with lists.
     </li>
 </ul>
 ```
+
+### List Header
+![image](https://i.imgur.com/wHNpnJt.png)
+
+#### HTML
+```html
+<div class="c-list-header">
+    <span><!-- Left aligned content --></span>
+    <button><!-- Right aligned content --></button>
+</div>
+```
+
+#### Example
+
+![image](https://i.imgur.com/g8jZ24b.png)
+

--- a/toolkits/global/packages/global-lists/package.json
+++ b/toolkits/global/packages/global-lists/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-lists",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "license": "MIT",
   "description": "Provide different styled lists",
   "keywords": [],

--- a/toolkits/global/packages/global-lists/scss/10-settings/_default.scss
+++ b/toolkits/global/packages/global-lists/scss/10-settings/_default.scss
@@ -18,3 +18,8 @@ $global-list-group--padding-md: spacing(16) 0;
 $global-list-group--padding-lg: spacing(24) 0;
 $global-list-group--line-height: $context--line-height-tight;
 $global-list-group--is-interface: false;
+
+$global-list-header--keyline-gap: spacing(16);
+$global-list-header--keyline-color: $context--keyline-border-color;
+$global-list-header--font-size: 1.4rem;
+$global-list-header--font-family: $context--font-family-sans;

--- a/toolkits/global/packages/global-lists/scss/50-components/_list-header.scss
+++ b/toolkits/global/packages/global-lists/scss/50-components/_list-header.scss
@@ -1,0 +1,9 @@
+.c-list-header {
+	display: flex;
+	justify-content: space-between;
+	margin-bottom: $global-list-header--keyline-gap;
+	border-bottom: 2px solid $global-list-header--keyline-color;
+	padding-bottom: spacing(4);
+	font-size: $global-list-header--font-size;
+	font-family: $global-list-header--font-family;
+}


### PR DESCRIPTION
See https://github.com/springernature/frontend-toolkits/blob/6c525b43549d2be1e48f8bbb120af8e378d11f94/toolkits/global/packages/global-lists/README.md#list-header

Allows lists such as search results to have a header that includes a keyline divide, and a layout that distributes the list header's content along the horizontal axis evenly