### PR TITLE
Adds Nature toolkit Sort By component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3905,6 +3905,19 @@
         }
       }
     },
+    "@springernature/global-expander": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@springernature/global-expander/-/global-expander-2.1.0.tgz",
+      "integrity": "sha512-69zgIsP+ZtwyM5S47+GCUMv0FpQqo/aumpZwT0n0FGH2aNptxJYDSDn16Msoy+9O414JIZgc8fO/fnU5FqRF6w==",
+      "requires": {
+        "@springernature/global-javascript": "^2.3.0"
+      }
+    },
+    "@springernature/global-javascript": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@springernature/global-javascript/-/global-javascript-2.4.0.tgz",
+      "integrity": "sha512-jKHMSV98koYECmCdsVXDaD0cPFskNmr9sfqviBAbH4TRTXVs3Ggc+haFaU7q8qUDXScATdzQV+uf2vwerQREsw=="
+    },
     "@springernature/sasslint-config": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@springernature/sasslint-config/-/sasslint-config-1.2.1.tgz",
@@ -7473,6 +7486,11 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
       }
+    },
+    "fontfaceobserver": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fontfaceobserver/-/fontfaceobserver-2.1.0.tgz",
+      "integrity": "sha512-ReOsO2F66jUa0jmv2nlM/s1MiutJx/srhAe2+TE8dJCMi02ZZOcCTxTCQFr3Yet+uODUtnr4Mewg+tNQ+4V1Ng=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/toolkits/nature/packages/nature-sort-by/HISTORY.md
+++ b/toolkits/nature/packages/nature-sort-by/HISTORY.md
@@ -1,0 +1,4 @@
+# History
+
+## 1.0.0 (2021-05-19)
+    * Initial commit

--- a/toolkits/nature/packages/nature-sort-by/README.md
+++ b/toolkits/nature/packages/nature-sort-by/README.md
@@ -6,12 +6,12 @@ A sort by dropdown for use on Nature product pages that contain a sortable list 
 
 To configure the component the following html attributes will need to be set:
 
-| Data Attribute          | Description                                                                                 | 
-|-------------------------|---------------------------------------------------------------------------------------------|
-| data-sort-by-trigger    | This should be set on the html element that is clicked in order to open the dropdown menu   |
-| data-sort-by-target     | This should be set on the containing html element of the sort by dropdown menu              |
-| data-sort-by-radio      | This should be set on each list item within the sort by dropdown menu                       |
-| <input value=""         | The value attribute for each radio input should be set with the corresponding url parameter value for page content sorting. For example `value="date_desc"` generates the following url parameter upon page reload: `?ORDER=date_desc`  |
+| Name                    | Description                                                                                 | 
+|------------------------|---------------------------------------------------------------------------------------------|
+| data-sort-by-trigger   | This should be set on the html element that is clicked in order to open the dropdown menu   |
+| data-sort-by-target    | This should be set on the containing html element of the sort by dropdown menu              |
+| data-sort-by-radio     | This should be set on each list item within the sort by dropdown menu                       |
+| <input value=""        | The value attribute for each radio input should be set with the corresponding url parameter value for page content sorting. For example `value="date_desc"` generates the following url parameter upon page reload: `?ORDER=date_desc`  |
 
 This component uses Global Expander. This means you should be aware of the following:
 1. Global Expander will replace the href of the trigger with `javascript:;`. This allows you to put a hash link in for progressive enhancements purposes.

--- a/toolkits/nature/packages/nature-sort-by/README.md
+++ b/toolkits/nature/packages/nature-sort-by/README.md
@@ -1,5 +1,25 @@
 # Nature Sort By
 
-A sort by dropdown for use on pages with a list of articles such as search results pages.
+A sort by dropdown for use on Nature product pages that contain a sortable list of content such as search results pages.
 
 ## Usage
+```html
+<div class="c-sort-by">
+    <a href="#sort-by" class="c-sort-by__button" data-sort-by-trigger role="button" aria-expanded="false">
+        <span>Sort by {{#each facets.sortOrder as |order|}}{{#if order.isChecked}}{{{order.label}}}{{/if}}{{/each}}</span>
+    </a>
+    <div id="sort-by" data-sort-by-target class="c-sort-by__menu u-js-hide">
+        <ul class="c-sort-by__list">
+            {{#each facets.sortOrder as |listElement|}}
+                <li class="c-sort-by__list-item" data-sort-by-radio>
+                    <input name="order" id="order{{listElement.value}}" value="{{listElement.value}}" type="radio"
+                           {{#if listElement.isChecked}}checked="checked"{{/if}}/>
+                    <label for="order-{{listElement.value}}">
+                        <span>{{{listElement.label}}}</span>
+                    </label>
+                </li>
+            {{/each}}
+        </ul>
+    </div>
+</div>
+```

--- a/toolkits/nature/packages/nature-sort-by/README.md
+++ b/toolkits/nature/packages/nature-sort-by/README.md
@@ -18,6 +18,10 @@ sortBy();
 
 ```
 
+If you plan to use utility classnames such as `u-js-hide` as shown in the examples below, ensure you import the relevant toolkit scss. For example:
+```scss
+@import '../../node_modules/@springernature/brand-context/default/scss/60-utilities/hiding';
+```
 
 To configure the component the following html attributes will need to be set:
 

--- a/toolkits/nature/packages/nature-sort-by/README.md
+++ b/toolkits/nature/packages/nature-sort-by/README.md
@@ -4,6 +4,21 @@ A sort by dropdown for use on Nature product pages that contain a sortable list 
 
 ## Usage
 
+Import the js and scss as follows:
+
+```js
+import {sortBy} from '@springernature/nature-sort-by/js/sort-by';
+
+sortBy();
+```
+
+```scss
+@import '../../node_modules/@springernature/nature-sort-by/scss/10-settings/sort-by';
+@import '../../node_modules/@springernature/nature-sort-by/scss/50-components/sort-by';
+
+```
+
+
 To configure the component the following html attributes will need to be set:
 
 | Name                    | Description                                                                                 | 

--- a/toolkits/nature/packages/nature-sort-by/README.md
+++ b/toolkits/nature/packages/nature-sort-by/README.md
@@ -3,10 +3,27 @@
 A sort by dropdown for use on Nature product pages that contain a sortable list of content such as search results pages.
 
 ## Usage
-```html
+
+To configure the component the following html attributes will need to be set:
+
+| Data Attribute          | Description                                                                                 | 
+|-------------------------|---------------------------------------------------------------------------------------------|
+| data-sort-by-trigger    | This should be set on the html element that is clicked in order to open the dropdown menu   |
+| data-sort-by-target     | This should be set on the containing html element of the sort by dropdown menu              |
+| data-sort-by-radio      | This should be set on each list item within the sort by dropdown menu                       |
+| <input value=""         | The value attribute for each radio input should be set with the corresponding url parameter value for page content sorting. For example `value="date_desc"` generates the following url parameter upon page reload: `?ORDER=date_desc`  |
+
+This component uses Global Expander. This means you should be aware of the following:
+1. Global Expander will replace the href of the trigger with `javascript:;`. This allows you to put a hash link in for progressive enhancements purposes.
+2. You can add the classname `u-js-hide` to the target on page render. Global Expander will remove this when the menu is opened. 
+3. Global Expander will add the classname `is-open` to the trigger and `has-tethered` to the target when the menu has been opened. The component's styling utilises these.
+
+Example handlebars template
+```handlebars
 <div class="c-sort-by">
     <a href="#sort-by" class="c-sort-by__button" data-sort-by-trigger role="button" aria-expanded="false">
         <span>Sort by {{#each facets.sortOrder as |order|}}{{#if order.isChecked}}{{{order.label}}}{{/if}}{{/each}}</span>
+        <svg role="img" aria-hidden="true" focusable="false" height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m5.58578644 3-3.29289322-3.29289322c-.39052429-.39052429-.39052429-1.02368927 0-1.41421356s1.02368927-.39052429 1.41421356 0l4 4c.39052429.39052429.39052429 1.02368927 0 1.41421356l-4 4c-.39052429.39052429-1.02368927.39052429-1.41421356 0s-.39052429-1.02368927 0-1.41421356z" transform="matrix(0 1 -1 0 11 3)"></path></svg>
     </a>
     <div id="sort-by" data-sort-by-target class="c-sort-by__menu u-js-hide">
         <ul class="c-sort-by__list">
@@ -19,6 +36,38 @@ A sort by dropdown for use on Nature product pages that contain a sortable list 
                     </label>
                 </li>
             {{/each}}
+        </ul>
+    </div>
+</div>
+```
+
+Example html
+```html
+<div class="c-sort-by">
+    <a href="#sort-by" class="c-sort-by__button is-open" data-sort-by-trigger="" aria-expanded="false" role="button">
+        <span>Sort by Relevance</span>
+        <svg role="img" aria-hidden="true" focusable="false" height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m5.58578644 3-3.29289322-3.29289322c-.39052429-.39052429-.39052429-1.02368927 0-1.41421356s1.02368927-.39052429 1.41421356 0l4 4c.39052429.39052429.39052429 1.02368927 0 1.41421356l-4 4c-.39052429.39052429-1.02368927.39052429-1.41421356 0s-.39052429-1.02368927 0-1.41421356z" transform="matrix(0 1 -1 0 11 3)"></path></svg>
+    </a>
+    <div id="sort-by" data-sort-by-target="" class="c-sort-by__menu u-js-hide">
+        <ul class="c-sort-by__list">
+            <li class="c-sort-by__list-item" data-sort-by-radio="">
+                <input name="order" id="orderrelevance" value="relevance" type="radio" checked="checked">
+                <label for="order-relevance">
+                    <span>Relevance</span>
+                </label>
+            </li>
+            <li class="c-sort-by__list-item" data-sort-by-radio="">
+                <input name="order" id="orderdate_desc" value="date_desc" type="radio">
+                <label for="order-date_desc">
+                    <span>Date — most recent</span>
+                </label>
+            </li>
+            <li class="c-sort-by__list-item" data-sort-by-radio="">
+                <input name="order" id="orderdate_asc" value="date_asc" type="radio">
+                <label for="order-date_asc">
+                    <span>Date — oldest first</span>
+                </label>
+            </li>
         </ul>
     </div>
 </div>

--- a/toolkits/nature/packages/nature-sort-by/README.md
+++ b/toolkits/nature/packages/nature-sort-by/README.md
@@ -1,0 +1,5 @@
+# Nature Sort By
+
+A sort by dropdown for use on pages with a list of articles such as search results pages.
+
+## Usage

--- a/toolkits/nature/packages/nature-sort-by/__tests__/sort-by.spec.js
+++ b/toolkits/nature/packages/nature-sort-by/__tests__/sort-by.spec.js
@@ -6,19 +6,38 @@ describe('sortBy', () => {
 	beforeEach(() => {
 		document.body.innerHTML = `
 			<div>
-				<a href="#sort-by" data-sort-by>
+				<a href="#sort-by" data-sort-by-trigger="">
 					<span>Sort by trigger</span>
 				</a>
 			</div>
 
-			<div id="sort-by">
-				Sort by
-			</div>
+			<div id="sort-by" data-sort-by-target="" class="c-sort-by__menu">
+				<ul class="c-sort-by__list">
+						<li class="c-sort-by__list-item" data-sort-by-radio="">
+							<input name="order" id="orderrelevance" value="relevance" type="radio">
+							<label for="order-relevance">
+								<span>Relevance</span>
+							</label>
+						</li>
+						<li class="c-sort-by__list-item" data-sort-by-radio="">
+							<input name="order" id="orderdate_desc" value="date_desc" type="radio">
+							<label for="order-date_desc">
+								<span>Date — most recent</span>
+							</label>
+						</li>
+						<li class="c-sort-by__list-item" data-sort-by-radio="">
+							<input name="order" id="orderdate_asc" value="date_asc" type="radio" checked="checked">
+							<label for="order-date_asc">
+								<span>Date — oldest first</span>
+							</label>
+						</li>
+				</ul>
+    		</div>
 		`;
 
 		element.target1 = document.querySelector('#sort-by');
 
-		element.button1 = document.querySelector('a[href^="#sort-by"]');
+		element.button1 = document.querySelector('[data-sort-by-trigger]');
 	});
 
 	afterEach(() => {
@@ -32,7 +51,7 @@ describe('sortBy', () => {
 		expect(element.button1.getAttribute('role')).toBe('button');
 	});
 
-	test('should append target after respective triggers', () => {
+	test('should append target after trigger', () => {
 		// Given
 		sortBy();
 		// When

--- a/toolkits/nature/packages/nature-sort-by/__tests__/sort-by.spec.js
+++ b/toolkits/nature/packages/nature-sort-by/__tests__/sort-by.spec.js
@@ -1,0 +1,43 @@
+import {sortBy} from '../js/sort-by';
+
+describe('sortBy', () => {
+	const element = {};
+
+	beforeEach(() => {
+		document.body.innerHTML = `
+			<div>
+				<a href="#sort-by" data-sort-by>
+					<span>Sort by trigger</span>
+				</a>
+			</div>
+
+			<div id="sort-by">
+				Sort by
+			</div>
+		`;
+
+		element.target1 = document.querySelector('#sort-by');
+
+		element.button1 = document.querySelector('a[href^="#sort-by"]');
+	});
+
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	test('should set role for button', () => {
+		// Given
+		sortBy();
+		// Then
+		expect(element.button1.getAttribute('role')).toBe('button');
+	});
+
+	test('should append target after respective triggers', () => {
+		// Given
+		sortBy();
+		// When
+		element.targetAfterButton1 = element.button1.nextSibling
+		// Then
+		expect(element.targetAfterButton1).toBe(element.target1);
+	});
+});

--- a/toolkits/nature/packages/nature-sort-by/js/sort-by.js
+++ b/toolkits/nature/packages/nature-sort-by/js/sort-by.js
@@ -1,12 +1,11 @@
 import {Expander} from '@springernature/global-expander/js/expander';
 import {makeArray} from '@springernature/global-javascript/src/helpers';
 
-
-const generateParams = (value) => {
-	const params = (new URL(document.location)).searchParams;
-	params.set('order', value);
-	return params;
-}
+const generateParameters = value => {
+	const parameters = new URL(document.location).searchParams;
+	parameters.set('order', value);
+	return parameters;
+};
 
 const sortBy = () => {
 	const trigger = document.querySelector('[data-sort-by-trigger]');
@@ -17,14 +16,14 @@ const sortBy = () => {
 		return;
 	}
 
-	radios.forEach((el) => {
-		el.addEventListener('click', (event) => {
+	radios.forEach(element => {
+		element.addEventListener('click', event => {
 			event.preventDefault();
 
-			const value = el.querySelector('input').value;
-			const params = generateParams(value);
-			window.location.replace('/search?' + params);
-		})
+			const value = element.querySelector('input').value;
+			const parameters = generateParameters(value);
+			window.location.replace('/search?' + parameters);
+		});
 	});
 
 	trigger.setAttribute('role', 'button');

--- a/toolkits/nature/packages/nature-sort-by/js/sort-by.js
+++ b/toolkits/nature/packages/nature-sort-by/js/sort-by.js
@@ -1,0 +1,29 @@
+import {Expander} from '@springernature/global-expander/js/expander';
+
+const sortBy = () => {
+	const trigger = document.querySelector('[data-sort-by-trigger]');
+	const targetElement = document.querySelector('[data-sort-by-target]');
+
+	if (!trigger || !targetElement) {
+		return;
+	}
+
+	const triggerAttributes = [
+		{name: 'role', value: 'button'}
+	];
+
+	triggerAttributes.forEach(function (attribute) {
+		trigger.setAttribute(attribute.name, attribute.value);
+	});
+
+	trigger.insertAdjacentElement('afterend', targetElement);
+	targetElement.classList.add('has-tethered');
+
+	const expander = new Expander(trigger, targetElement, {AUTOFOCUS: 'firstTabbable'});
+
+	expander.init();
+
+	return expander;
+};
+
+export {sortBy};

--- a/toolkits/nature/packages/nature-sort-by/js/sort-by.js
+++ b/toolkits/nature/packages/nature-sort-by/js/sort-by.js
@@ -1,25 +1,38 @@
 import {Expander} from '@springernature/global-expander/js/expander';
+import {makeArray} from '@springernature/global-javascript/src/helpers';
+
+
+const generateParams = (value) => {
+	const params = (new URL(document.location)).searchParams;
+	params.set('order', value);
+	return params;
+}
 
 const sortBy = () => {
 	const trigger = document.querySelector('[data-sort-by-trigger]');
 	const targetElement = document.querySelector('[data-sort-by-target]');
+	const radios = makeArray(document.querySelectorAll('[data-sort-by-radio]'));
 
-	if (!trigger || !targetElement) {
+	if (!trigger || !targetElement || !radios) {
 		return;
 	}
 
-	const triggerAttributes = [
-		{name: 'role', value: 'button'}
-	];
+	radios.forEach((el) => {
+		el.addEventListener('click', (event) => {
+			event.preventDefault();
 
-	triggerAttributes.forEach(function (attribute) {
-		trigger.setAttribute(attribute.name, attribute.value);
+			const value = el.querySelector('input').value;
+			const params = generateParams(value);
+			window.location.replace('/search?' + params);
+		})
 	});
+
+	trigger.setAttribute('role', 'button');
 
 	trigger.insertAdjacentElement('afterend', targetElement);
 	targetElement.classList.add('has-tethered');
 
-	const expander = new Expander(trigger, targetElement, {AUTOFOCUS: 'firstTabbable'});
+	const expander = new Expander(trigger, targetElement);
 
 	expander.init();
 

--- a/toolkits/nature/packages/nature-sort-by/package.json
+++ b/toolkits/nature/packages/nature-sort-by/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@springernature/nature-header",
+  "name": "@springernature/nature-sort-by",
   "version": "1.0.0",
   "license": "MIT",
-  "description": "Publisher level header",
+  "description": "Nature sort by ui dropdown",
   "keywords": [],
   "author": "Springer Nature",
   "brandContext": "^11.1.0",

--- a/toolkits/nature/packages/nature-sort-by/package.json
+++ b/toolkits/nature/packages/nature-sort-by/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@springernature/nature-header",
+  "version": "1.0.0",
+  "license": "MIT",
+  "description": "Publisher level header",
+  "keywords": [],
+  "author": "Springer Nature",
+  "brandContext": "^11.1.0",
+  "dependencies": {
+    "@springernature/global-javascript": "^3.0.2",
+    "@springernature/global-expander": "^4.0.2"
+  }
+}

--- a/toolkits/nature/packages/nature-sort-by/scss/10-settings/sort-by.scss
+++ b/toolkits/nature/packages/nature-sort-by/scss/10-settings/sort-by.scss
@@ -1,0 +1,10 @@
+$sort-by--menu-background-colour: #000;
+$sort-by--menu-border-colour: greyscale(5);
+$sort-by--menu-text-colour: greyscale(90);
+$sort-by--menu-padding: spacing(16) 0;
+$sort-by--menu-font-size: 1.4rem;
+$sort-by--menu-line-height: 1.2;
+$sort-by--button-font-weight: 700;
+$sort-by--button-svg-margin: spacing(16);
+$sort-by--button-list-item-spacing: spacing(8) spacing(16);
+$sort-by--menu-min-width: 180px;

--- a/toolkits/nature/packages/nature-sort-by/scss/50-components/sort-by.scss
+++ b/toolkits/nature/packages/nature-sort-by/scss/50-components/sort-by.scss
@@ -23,6 +23,11 @@
 
 	> svg {
 		margin-left: $sort-by--button-svg-margin;
+		transition-duration: .2s;
+	}
+
+	&.is-open > svg {
+		transform: rotate(180deg);
 	}
 }
 

--- a/toolkits/nature/packages/nature-sort-by/scss/50-components/sort-by.scss
+++ b/toolkits/nature/packages/nature-sort-by/scss/50-components/sort-by.scss
@@ -52,7 +52,7 @@
 .c-sort-by__menu.has-tethered {
 	position: absolute;
 	top: 100%; // bottom of the tether element
-	transform: translateY(5px);
+	transform: translateY(4px);
 	z-index: 1;
 	left: 0;
 	width: 100%;
@@ -60,7 +60,6 @@
 	border-bottom: 0;
 
 	@include media-query('sm') {
-		transform: translateY(8px);
 		width: auto;
 	}
 

--- a/toolkits/nature/packages/nature-sort-by/scss/50-components/sort-by.scss
+++ b/toolkits/nature/packages/nature-sort-by/scss/50-components/sort-by.scss
@@ -34,6 +34,11 @@
 
 .c-sort-by__list-item {
 	padding: spacing(8) spacing(16);
+	cursor: pointer;
+
+	& > label {
+		cursor: pointer;
+	}
 }
 
 /**

--- a/toolkits/nature/packages/nature-sort-by/scss/50-components/sort-by.scss
+++ b/toolkits/nature/packages/nature-sort-by/scss/50-components/sort-by.scss
@@ -7,22 +7,22 @@
 }
 
 .c-sort-by__menu {
-	background-color: black;
-	border-bottom: 1px solid greyscale(5); // non-js
-	color: greyscale(90);
-	padding: spacing(16) 0;
-	font-size: 1.4rem;
-	line-height: 1.2;
+	background-color: $sort-by--menu-background-colour;
+	border-bottom: 1px solid $sort-by--menu-border-colour; // non-js
+	color: $sort-by--menu-text-colour;
+	padding: $sort-by--menu-padding;
+	font-size: $sort-by--menu-font-size;
+	line-height: $sort-by--menu-line-height;
 }
 
 .c-sort-by__button {
-	font-weight: 700;
+	font-weight: $sort-by--button-font-weight;
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
 
 	> svg {
-		margin-left: spacing(16);
+		margin-left: $sort-by--button-svg-margin;
 	}
 }
 
@@ -33,8 +33,7 @@
 }
 
 .c-sort-by__list-item {
-	padding: spacing(8) spacing(16);
-	cursor: pointer;
+	padding: $sort-by--button-list-item-spacing;
 
 	& > label {
 		cursor: pointer;
@@ -61,6 +60,6 @@
 	}
 
 	@include media-query('md') {
-		min-width: 180px;
+		min-width: $sort-by--menu-min-width;
 	}
 }

--- a/toolkits/nature/packages/nature-sort-by/scss/50-components/sort-by.scss
+++ b/toolkits/nature/packages/nature-sort-by/scss/50-components/sort-by.scss
@@ -1,0 +1,61 @@
+.c-sort-by {
+	position: relative;
+
+	a {
+		@include u-link-inherit();
+	}
+}
+
+.c-sort-by__menu {
+	background-color: black;
+	border-bottom: 1px solid greyscale(5); // non-js
+	color: greyscale(90);
+	padding: spacing(16) 0;
+	font-size: 1.4rem;
+	line-height: 1.2;
+}
+
+.c-sort-by__button {
+	font-weight: 700;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+
+	> svg {
+		margin-left: spacing(16);
+	}
+}
+
+.c-sort-by__list {
+	@include u-list-reset;
+	padding: 0;
+	margin: 0;
+}
+
+.c-sort-by__list-item {
+	padding: spacing(8) spacing(16);
+}
+
+/**
+ JavaScript Enhancements
+ */
+
+.c-sort-by__menu.has-tethered {
+	position: absolute;
+	top: 100%; // bottom of the tether element
+	transform: translateY(5px);
+	z-index: 1;
+	left: 0;
+	width: 100%;
+	border-radius: 0 0 2px 2px;
+	border-bottom: 0;
+
+	@include media-query('sm') {
+		transform: translateY(8px);
+		width: auto;
+	}
+
+	@include media-query('md') {
+		min-width: 180px;
+	}
+}


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/5796370/118958975-cac3f580-b959-11eb-89e3-c7fd0bac26b8.png)


- Adds a component for use on Nature product pages that displays a sort by ui menu that uses js to reload the page by modifying the url parameter for content order and reloading the page. This was preferred to making a fetch request and dynamically loading content in to the page for performance reasons (less complicated client side js). 

- Progressively enhanced, without javascript a user is able to submit the form and it will recognise the sort by option chosen.

- Uses Global Expander to open and close the menu
