### PR TITLE
Add demo body style + Remove obsolete .c-forms__buttons

### DIFF
--- a/toolkits/springernature/packages/springernature-forms/HISTORY.md
+++ b/toolkits/springernature/packages/springernature-forms/HISTORY.md
@@ -1,5 +1,12 @@
 # History
 
+## 0.1.1 (2021-06-02)
+
+- Add some default inline `body` tag style to uniformize demo rendering in
+  Elements. Needed to override the Springer Nature brand default.
+- Remove non necessary `.c-forms__buttons`.
+- Add a note about form buttons
+
 ## 0.1.0 (2021-06-01)
 
 Inital commit

--- a/toolkits/springernature/packages/springernature-forms/README.md
+++ b/toolkits/springernature/packages/springernature-forms/README.md
@@ -320,8 +320,10 @@ Watch a video about how some [users struggle with selects](https://www.youtube.c
 
 Use this component to help users submit their information.
 
+**Note**: This section exists to show you how a form submit button should be
+marked up. Buttons are not part of this package. They are inherited from the
+brand context utilities.
+
 ```html
-<div class="c-forms__submit">
-	<button type="submit" class="u-button u-button--primary">Submit</button>
-</div>
+<button type="submit" class="u-button u-button--primary">Submit</button>
 ```

--- a/toolkits/springernature/packages/springernature-forms/demo/dist/index.html
+++ b/toolkits/springernature/packages/springernature-forms/demo/dist/index.html
@@ -1692,7 +1692,12 @@ input[type="file"]:focus-within {
 		</style>
 	</head>
 	<body>
-		<div aria-hidden="true" class="u-display-none">
+		<style>
+/* demo page styles */
+body{background-color: white;padding:2%;}
+</style>
+
+<div aria-hidden="true" class="u-display-none">
 	<svg xmlns="http://www.w3.org/2000/svg">
 		<symbol id="icon-warning" viewBox="0 0 18 18"><path fill-rule="evenodd" d="M9 11.75a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zM9.413 4a1 1 0 011 1l-.003.083-.334 4A1 1 0 019.08 10h-.16a1 1 0 01-.996-.917l-.334-4a1 1 0 01.914-1.08l.041-.002zM9 18A9 9 0 119 0a9 9 0 010 18z"/></symbol>
 	</svg>
@@ -1934,11 +1939,7 @@ input[type="file"]:focus-within {
 
 <div class="u-mb-48">
 	<h2 class="u-mb-24" id="form-buttons">Form buttons</h2>
-	<div class="u-mb-16">
-		<div class="c-forms__submit">
-			<button type="submit" class="u-button u-button--primary">Submit</button>
-		</div>
-	</div>
+	<button type="submit" class="u-button u-button--primary">Submit</button>
 </div>
 
 	</body>

--- a/toolkits/springernature/packages/springernature-forms/demo/index.hbs
+++ b/toolkits/springernature/packages/springernature-forms/demo/index.hbs
@@ -1,3 +1,8 @@
+<style>
+/* demo page styles */
+body{background-color: white;padding:2%;}
+</style>
+
 <div aria-hidden="true" class="u-display-none">
 	<svg xmlns="http://www.w3.org/2000/svg">
 		<symbol id="icon-warning" viewBox="0 0 18 18"><path fill-rule="evenodd" d="M9 11.75a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zM9.413 4a1 1 0 011 1l-.003.083-.334 4A1 1 0 019.08 10h-.16a1 1 0 01-.996-.917l-.334-4a1 1 0 01.914-1.08l.041-.002zM9 18A9 9 0 119 0a9 9 0 010 18z"/></symbol>
@@ -240,9 +245,5 @@
 
 <div class="u-mb-48">
 	<h2 class="u-mb-24" id="form-buttons">Form buttons</h2>
-	<div class="u-mb-16">
-		<div class="c-forms__submit">
-			<button type="submit" class="u-button u-button--primary">Submit</button>
-		</div>
-	</div>
+	<button type="submit" class="u-button u-button--primary">Submit</button>
 </div>

--- a/toolkits/springernature/packages/springernature-forms/package.json
+++ b/toolkits/springernature/packages/springernature-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springernature-forms",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "description": "Springer Nature branded styles for text, checkbox, radio button, textarea and select inputs",
   "keywords": [],


### PR DESCRIPTION
- Add some default inline `body` tag style to uniformize demo rendering in
  Elements. Needed to override the Springer Nature brand default.
- Remove non necessary `.c-forms__buttons`.
- Add a note about form buttons