### PR TITLE
Replace for in loop in `makeArray` to iterate safely over a `NodeList`

### DIFF
--- a/toolkits/global/packages/global-javascript/HISTORY.md
+++ b/toolkits/global/packages/global-javascript/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 3.0.3 (2021-06-03)
+    * Replace for .. in loop in `makeArray` to iterate safely over a `NodeList` in old browsers
+
 ## 3.0.2 (2021-04-15)
     * Replace for .. of loop in `makeArray` to generate a smaller transpiled bundle
 

--- a/toolkits/global/packages/global-javascript/package.json
+++ b/toolkits/global/packages/global-javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-javascript",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "license": "MIT",
   "description": "Globally shared JavaScript helpers",
   "keywords": [

--- a/toolkits/global/packages/global-javascript/src/helpers/util/make-array.js
+++ b/toolkits/global/packages/global-javascript/src/helpers/util/make-array.js
@@ -6,7 +6,7 @@ const makeArray = iterable => {
 	}
 
 	Array.prototype.forEach.call(iterable, function (item) {
-		list.push(item)
+		list.push(item);
 	});
 
 	return list;

--- a/toolkits/global/packages/global-javascript/src/helpers/util/make-array.js
+++ b/toolkits/global/packages/global-javascript/src/helpers/util/make-array.js
@@ -5,11 +5,9 @@ const makeArray = iterable => {
 		return list;
 	}
 
-	for (const key in iterable) {
-		if (Object.prototype.hasOwnProperty.call(iterable, key)) {
-			list.push(iterable[key]);
-		}
-	}
+	Array.prototype.forEach.call(iterable, function (item) {
+		list.push(item)
+	});
 
 	return list;
 };


### PR DESCRIPTION
The `for in` loop was generating a non-sense array of elements in old browsers and was causing errors in the page when trying iterating over a list of DOM elements.

<img width="749" alt="Screenshot 2021-06-03 at 12 28 51" src="https://user-images.githubusercontent.com/1053385/120637899-5e6fe880-c467-11eb-9e59-f8ba90d975a8.png">

<img width="755" alt="Screenshot 2021-06-03 at 12 28 30" src="https://user-images.githubusercontent.com/1053385/120637909-616ad900-c467-11eb-9503-983ec807095d.png">

I changed it to a simpler way to ensure it works for all kind of lists.

