### PR TITLE
Fixes for explorer!

### DIFF
--- a/toolkits/global/packages/global-autocomplete/HISTORY.md
+++ b/toolkits/global/packages/global-autocomplete/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 5.0.4 (2021-06-18)
+    * explorer fixes: event key for Escape, and use .removeChild() instead of .remove()
+
 ## 5.0.3 (2021-03-01)
     * Dont focus input when removing suggestion box
 

--- a/toolkits/global/packages/global-autocomplete/js/index.js
+++ b/toolkits/global/packages/global-autocomplete/js/index.js
@@ -31,7 +31,7 @@ const autoComplete = arguments_ => {
 		return Array.from(document.querySelectorAll(`${resultSelector}`));
 	};
 
-	const eventKeys = ['ArrowDown', 'Down', 'ArrowUp', 'Up', 'Escape', 'Enter', 'Tab'];
+	const eventKeys = ['ArrowDown', 'Down', 'ArrowUp', 'Up', 'Escape', 'Esc', 'Enter', 'Tab'];
 
 	let inputTimer = null;
 	let fetchTimer = null;
@@ -56,7 +56,7 @@ const autoComplete = arguments_ => {
 		}
 		input.removeEventListener('keyup', inputEvents);
 		if (container()) {
-			container().remove();
+			container().parentNode.removeChild(container());
 		}
 		document.removeEventListener('click', removeSuggestions);
 	};
@@ -67,7 +67,7 @@ const autoComplete = arguments_ => {
 		}
 
 		container().addEventListener('keydown', event => {
-			if (['Escape', 'ArrowUp', 'Up', 'ArrowDown', 'Down'].includes(event.key)) {
+			if (['Escape', 'Esc', 'ArrowUp', 'Up', 'ArrowDown', 'Down'].includes(event.key)) {
 				event.preventDefault();
 				event.stopPropagation();
 			}
@@ -100,7 +100,7 @@ const autoComplete = arguments_ => {
 						input.value = currentSearchTerm;
 					}
 				}
-			} else if (event.key === 'Escape') {
+			} else if (event.key === 'Escape' || event.key === 'Esc') {
 				removeSuggestions();
 				input.value = currentSearchTerm;
 			}
@@ -196,7 +196,7 @@ const autoComplete = arguments_ => {
 			}
 		}
 
-		if (event.key === 'Escape') {
+		if (event.key === 'Escape' || event.key === 'Esc') {
 			removeSuggestions(event);
 		}
 		if (event.key === 'Enter') {

--- a/toolkits/global/packages/global-autocomplete/package.json
+++ b/toolkits/global/packages/global-autocomplete/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-autocomplete",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "license": "MIT",
   "description": "Autocomplete/suggest component",
   "keywords": [],


### PR DESCRIPTION
Explorer fixes:

Use 'Esc' as well as 'Escape' keycode.
Use .removeChild() rather than .remove().