### PR TITLE
reduce max-width

### DIFF
--- a/toolkits/springernature/packages/springernature-header/HISTORY.md
+++ b/toolkits/springernature/packages/springernature-header/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 2.0.2 (2021-07-28)
+    * Fix max-width for header
+
 ## 2.0.1 (2021-05-13)
     * Use new SN branding URL (for logo)
 

--- a/toolkits/springernature/packages/springernature-header/package.json
+++ b/toolkits/springernature/packages/springernature-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springernature-header",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "license": "MIT",
   "description": "Springer Nature branded header component",
   "keywords": [],

--- a/toolkits/springernature/packages/springernature-header/scss/10-settings/layout.scss
+++ b/toolkits/springernature/packages/springernature-header/scss/10-settings/layout.scss
@@ -1,2 +1,2 @@
 $header--header-height: 40px;
-$header--content-width: 1184px;
+$header--content-width: 1124px;


### PR DESCRIPTION
Reduce max-width of header so that it lines up all nicely with main content.

<img width="1165" alt="Screenshot 2021-07-28 at 15 45 51" src="https://user-images.githubusercontent.com/11961647/127343310-713f3373-1ac7-4895-9401-8ccf25c878db.png">
