### PR TITLE
Correct error - `tablet-wide-width` is not a valid breakpoint name.

### DIFF
--- a/toolkits/springernature/packages/springernature-header/HISTORY.md
+++ b/toolkits/springernature/packages/springernature-header/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 2.0.2 (2021-07-29)
+    * Fix media queries
+
 ## 2.0.1 (2021-05-13)
     * Use new SN branding URL (for logo)
 

--- a/toolkits/springernature/packages/springernature-header/package.json
+++ b/toolkits/springernature/packages/springernature-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springernature-header",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "license": "MIT",
   "description": "Springer Nature branded header component",
   "keywords": [],

--- a/toolkits/springernature/packages/springernature-header/package.json
+++ b/toolkits/springernature/packages/springernature-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springernature-header",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "MIT",
   "description": "Springer Nature branded header component",
   "keywords": [],

--- a/toolkits/springernature/packages/springernature-header/scss/50-components/core.scss
+++ b/toolkits/springernature/packages/springernature-header/scss/50-components/core.scss
@@ -33,11 +33,11 @@
 }
 
 .c-header__journal-title {
-	@include media-query('tablet-wide-width') {
+	@include media-query('md') {
 		font-size: 2.2rem;
 	}
 
-	@include media-query('desktop-width') {
+	@include media-query('lg') {
 		font-size: 2.7rem;
 	}
 

--- a/toolkits/springernature/packages/springernature-header/scss/50-components/enhanced.scss
+++ b/toolkits/springernature/packages/springernature-header/scss/50-components/enhanced.scss
@@ -4,7 +4,7 @@
 		display: flex;
 		justify-content: space-between;
 
-		@include media-query('desktop-width') {
+		@include media-query('lg') {
 			width: calc(100% - 64px);
 			margin-left: 32px;
 		}
@@ -19,7 +19,7 @@
 	}
 
 	.c-header__site-logo.with-journal-logo {
-		@include media-query('tablet-wide-width') {
+		@include media-query('md') {
 			border-right: 2px solid color('black');
 		}
 	}
@@ -34,7 +34,7 @@
 		flex-basis: 60%;
 		flex-wrap: wrap;
 
-		@include media-query('tablet-wide-width') {
+		@include media-query('md') {
 			flex-basis: 70%;
 		}
 	}


### PR DESCRIPTION
Fix errors to do with media queries

```Warning: `tablet-wide-width` is not a valid breakpoint name.
    node_modules/@springernature/brand-context/default/scss/30-mixins/media-query.scss 17:3        -get-breakpoint()
    node_modules/@springernature/brand-context/default/scss/30-mixins/media-query.scss 76:22       media-query()
    node_modules/@springernature/brand-context/springernature/scss/30-mixins/media-query.scss 8:2  from-wide-tablet()
    node_modules/@springernature/springernature-header/scss/50-components/enhanced.scss 37:3       @import
    src/main/sass/main.scss 31:9                                                                   root stylesheet```