### PR TITLE
Imports style 10-settings in to Springer abstracts partial

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 13.1.1 (2021-07-29)
+    * Includes the style 10-settings in Springer abstracts partial
+
 ## 13.1.0 (2021-07-29)
     * Adds keyline utility classnames to nature and springer
     * Refactors keyline mixin; now includes thickness and references spacing from settings

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "13.1.0",
+  "version": "13.1.1",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/springer/scss/abstracts.scss
+++ b/context/brand-context/springer/scss/abstracts.scss
@@ -6,8 +6,8 @@
 
 // These settings must come first, as other settings can reference them
 @import '10-settings/colors/default';
+@import '10-settings/style';
 @import '10-settings/typography';
-
 @import '10-settings/buttons';
 
 @import '20-functions/em';


### PR DESCRIPTION
Forgot to do this on previous PR (yesterday re keyline changes). Needed to ensure Springer brand uses correct greyscale values.