### PR TITLE
Removes bottom margin from list description terms on springer brand

### DIFF
--- a/toolkits/global/packages/global-lists/HISTORY.md
+++ b/toolkits/global/packages/global-lists/HISTORY.md
@@ -1,3 +1,6 @@
+## 3.0.0 (2021-07-29)
+    * Removes bottom margin from description list terms
+
 ## 2.1.0 (2021-05-18)
     * Adds list header component and settings
 

--- a/toolkits/global/packages/global-lists/package.json
+++ b/toolkits/global/packages/global-lists/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-lists",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "license": "MIT",
   "description": "Provide different styled lists",
   "keywords": [],

--- a/toolkits/global/packages/global-lists/scss/10-settings/_springer.scss
+++ b/toolkits/global/packages/global-lists/scss/10-settings/_springer.scss
@@ -11,6 +11,6 @@ $global-list-group--is-interface: true;
 $global-list-group--border-color: greyscale(80);
 
 $global-list-description--is-interface: true;
-$global-list-description--margin-bottom: 0.25em;
+$global-list-description--margin-bottom: 0;
 
 $global-list-columned--margin-bottom: 0.25em;


### PR DESCRIPTION
We use margin-bottom on the default brand of this component. However when used on Springer branded sites it is not needed. I'm not sure who is consuming this global component so I'm cautiously only removing the bottom margin on the Springer brand instead of default.