### PR TITLE
reverts width change

### DIFF
--- a/toolkits/springernature/packages/springernature-header/HISTORY.md
+++ b/toolkits/springernature/packages/springernature-header/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 2.0.4 (2021-07-29)
+    * Revert header width (media query fix below resolved issue)
+
 ## 2.0.3 (2021-07-29)
     * Fix media queries
 

--- a/toolkits/springernature/packages/springernature-header/package.json
+++ b/toolkits/springernature/packages/springernature-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springernature-header",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "license": "MIT",
   "description": "Springer Nature branded header component",
   "keywords": [],

--- a/toolkits/springernature/packages/springernature-header/scss/10-settings/layout.scss
+++ b/toolkits/springernature/packages/springernature-header/scss/10-settings/layout.scss
@@ -1,2 +1,2 @@
 $header--header-height: 40px;
-$header--content-width: 1124px;
+$header--content-width: 1184px;


### PR DESCRIPTION
This commit reverts a change to the header width. A subsequent fix I made to the media queries means that this change is not needed anymore.

![sigh](https://user-images.githubusercontent.com/11961647/127521721-dd346757-459c-45e3-92ed-b024846351f5.gif)
