### PR TITLE
Add parameter for reflow on focus mixin 

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,8 +1,9 @@
 # History
 
-## 13.2.1 (2021-08-12)
-    * Use -webkit-font-smoothing: antialiased instead of -webkit-transform: translateZ(0) to avoid breaking z-index stack but still cause a reflow in Safari
-        - related to 13.1.2 
+## 13.2.1 (2021-08-13)
+    * Add parameter to optionally force reflow on focus for webkit browsers
+        - applied on links as this seems to be where outline appears incorrectly
+        - related to 13.1.2
 
 ## 13.2.0 (2021-08-12)
     * Add mixin for u-focus-outline and default $context--focus-color variable

--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,8 +1,8 @@
 # History
 
-## 13.2.1 (2021-08-13)
-    * Add parameter to optionally force reflow on focus for webkit browsers
-        - applied on links as this seems to be where outline appears incorrectly
+## 13.2.1 (2021-08-23)
+    * Add will-change: tranform reflow on focus mixin
+        - reflow needed to ensure outline styles visible in Safari v13+
         - related to 13.1.2
 
 ## 13.2.0 (2021-08-12)

--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 13.2.1 (2021-08-12)
+    * Use -webkit-font-smoothing: antialiased instead of -webkit-transform: translateZ(0) to avoid breaking z-index stack but still cause a reflow in Safari
+        - related to 13.1.2 
+
 ## 13.2.0 (2021-08-12)
     * Add mixin for u-focus-outline and default $context--focus-color variable
     * Replace the focus style for links in nature to use this new mixin

--- a/context/brand-context/default/scss/30-mixins/focus.scss
+++ b/context/brand-context/default/scss/30-mixins/focus.scss
@@ -1,6 +1,8 @@
-@mixin u-focus-outline {
+@mixin u-focus-outline($reflow: false) {
 	&:focus {
 		outline: 3px solid $context--focus-color;
-		-webkit-font-smoothing: antialiased; // reflow needed to ensure outline styles visible in Safari v13+
+		@if $reflow == true {
+			-webkit-transform: translateZ(0); // reflow needed to ensure outline styles visible in Safari v13+
+		}
 	}
 }

--- a/context/brand-context/default/scss/30-mixins/focus.scss
+++ b/context/brand-context/default/scss/30-mixins/focus.scss
@@ -1,8 +1,6 @@
 @mixin u-focus-outline($reflow: false) {
 	&:focus {
 		outline: 3px solid $context--focus-color;
-		@if $reflow == true {
-			-webkit-transform: translateZ(0); // reflow needed to ensure outline styles visible in Safari v13+
-		}
+		will-change: transform;
 	}
 }

--- a/context/brand-context/default/scss/30-mixins/focus.scss
+++ b/context/brand-context/default/scss/30-mixins/focus.scss
@@ -1,6 +1,6 @@
 @mixin u-focus-outline {
 	&:focus {
 		outline: 3px solid $context--focus-color;
-		-webkit-transform: translateZ(0); // reflow needed to ensure outline styles visible in Safari v13+
+		-webkit-font-smoothing: antialiased; // reflow needed to ensure outline styles visible in Safari v13+
 	}
 }

--- a/context/brand-context/default/scss/30-mixins/focus.scss
+++ b/context/brand-context/default/scss/30-mixins/focus.scss
@@ -1,4 +1,4 @@
-@mixin u-focus-outline($reflow: false) {
+@mixin u-focus-outline() {
 	&:focus {
 		outline: 3px solid $context--focus-color;
 		will-change: transform;

--- a/context/brand-context/nature/scss/40-base/links.scss
+++ b/context/brand-context/nature/scss/40-base/links.scss
@@ -4,7 +4,7 @@
  */
 
 a {
-	@include u-focus-outline();
+	@include u-focus-outline($reflow:true);
 	text-decoration: none;
 	vertical-align: baseline;
 	color: color('blue');

--- a/context/brand-context/nature/scss/40-base/links.scss
+++ b/context/brand-context/nature/scss/40-base/links.scss
@@ -4,6 +4,7 @@
  */
 
 a {
+	@include u-focus-outline();
 	text-decoration: none;
 	vertical-align: baseline;
 	color: color('blue');
@@ -13,10 +14,6 @@ a:hover {
 	text-decoration: underline;
 	-webkit-text-decoration-skip: skip;
 	text-decoration-skip-ink: auto;
-}
-
-a:focus {
-	@include u-focus-outline();
 }
 
 a:active {

--- a/context/brand-context/nature/scss/40-base/links.scss
+++ b/context/brand-context/nature/scss/40-base/links.scss
@@ -4,7 +4,7 @@
  */
 
 a {
-	@include u-focus-outline($reflow:true);
+	@include u-focus-outline();
 	text-decoration: none;
 	vertical-align: baseline;
 	color: color('blue');

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "13.2.0",
+  "version": "13.2.1",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],


### PR DESCRIPTION
* Add parameter for reflow on focus mixin
        - applied on links as this seems to be where outline appears incorrectly
        - related to 13.1.2
        
* Fix `:focus` being applied twice on `a`