### PR TITLE
Remove flex from sm breakpoint

### DIFF
--- a/toolkits/springernature/packages/springernature-submission-header/HISTORY.md
+++ b/toolkits/springernature/packages/springernature-submission-header/HISTORY.md
@@ -1,6 +1,10 @@
 # History
+
 ## 0.4.2 (2021-08-18)
 	* removes flex for sub details at smaller breakpoint
+
+## 0.4.1 (2021-08-12)
+	* Fix typo in readme, remove unneeded styles
 
 ## 0.4.0 (2021-08-10)
 	* incorporate global popup

--- a/toolkits/springernature/packages/springernature-submission-header/HISTORY.md
+++ b/toolkits/springernature/packages/springernature-submission-header/HISTORY.md
@@ -1,6 +1,6 @@
 # History
-## 0.4.1 (2021-08-12)
-	* Fix typo in readme, remove unneeded styles
+## 0.4.2 (2021-08-18)
+	* removes flex for sub details at smaller breakpoint
 
 ## 0.4.0 (2021-08-10)
 	* incorporate global popup

--- a/toolkits/springernature/packages/springernature-submission-header/package.json
+++ b/toolkits/springernature/packages/springernature-submission-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springernature-submission-header",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "license": "MIT",
   "description": "Springer Nature branded submission details component",
   "keywords": [],

--- a/toolkits/springernature/packages/springernature-submission-header/scss/50-components/enhanced.scss
+++ b/toolkits/springernature/packages/springernature-submission-header/scss/50-components/enhanced.scss
@@ -9,9 +9,10 @@
 	border: 1px solid #173643;
 	border-left: 3px solid #173643;
 
-	&__row,
 	&__author-list {
-		@extend .u-display-flex;
+		@include media-query('md') {
+			display: flex;
+		}
 	}
 
 	&__row-item {


### PR DESCRIPTION
Remove flex from authors list at small breakpoint.
Remove it entirely from metadata row at top as they're all inline anyway.

<img width="457" alt="Screenshot 2021-08-18 at 13 26 43" src="https://user-images.githubusercontent.com/11961647/129897905-fe07635d-be8b-480a-90e3-492b37cae478.png">
