### PR TITLE
add springer brand to global-skip-link

### DIFF
--- a/toolkits/global/packages/global-skip-link/HISTORY.md
+++ b/toolkits/global/packages/global-skip-link/HISTORY.md
@@ -1,6 +1,11 @@
 # History
 
+## 0.3.0 (2021-08-24)
+    * Add Springer brand to settings
+    * Bump brand-context
+
 ## 0.2.0 (2021-07-13)
     * Update SN according to new brand context
+
 ## 0.1.0 (2021-06-01)
     * First release

--- a/toolkits/global/packages/global-skip-link/README.md
+++ b/toolkits/global/packages/global-skip-link/README.md
@@ -11,6 +11,7 @@ To include `global-skip-link` in your application, you need to choose **ONE** br
 @import '@springernature/global-skip-link/scss/10-settings/default';
 @import '@springernature/global-skip-link/scss/10-settings/springernature';
 @import '@springernature/global-skip-link/scss/10-settings/nature';
+@import '@springernature/global-skip-link/scss/10-settings/springer';
 
 // Include this with your other components
 @import '@springernature/global-skip-link/scss/50-components/skip-link';

--- a/toolkits/global/packages/global-skip-link/package.json
+++ b/toolkits/global/packages/global-skip-link/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@springernature/global-skip-link",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "description": "Full width link to skip to main content",
   "keywords": [],
   "author": "Springer Nature",
-  "brandContext": "^12.0.0"
+  "brandContext": "^13.2.1"
 }

--- a/toolkits/global/packages/global-skip-link/scss/10-settings/_springer.scss
+++ b/toolkits/global/packages/global-skip-link/scss/10-settings/_springer.scss
@@ -1,0 +1,14 @@
+/**
+ * @springernature/global-skip-link
+ * Springer skin settings
+ *
+ */
+
+// Default setting
+@import 'default';
+
+$skip-link--font-size: 1.4rem;
+$skip-link--color: color('action-base');
+$skip-link--hover-color: color('action-base');
+$skip-link--background-color: color('action-background-light');
+$skip-link--z-index: 9999;


### PR DESCRIPTION
- add springer brand in settings to use for springer and bmc/so
- bump brand-context to the latest