### PR TITLE
Use commas in template rather than scss

### DIFF
--- a/toolkits/springernature/packages/springernature-submission-header/HISTORY.md
+++ b/toolkits/springernature/packages/springernature-submission-header/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 0.6.0 (2021-09-09)
+	* Add commas in template rather than with complicated SCSS
+
 ## 0.5.0 (2021-09-08)
 	* Adjust spacing of author list, only show comma separator for js version
 

--- a/toolkits/springernature/packages/springernature-submission-header/package.json
+++ b/toolkits/springernature/packages/springernature-submission-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springernature-submission-header",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "MIT",
   "description": "Springer Nature branded submission details component",
   "keywords": [],

--- a/toolkits/springernature/packages/springernature-submission-header/scss/50-components/enhanced.scss
+++ b/toolkits/springernature/packages/springernature-submission-header/scss/50-components/enhanced.scss
@@ -1,3 +1,5 @@
+$author-icon-background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23007E99'%3E%3Cpath d='M29 0H13v12h16V0zM17.6 8.2L15.1 11c-.1.1-.3.2-.4.2-.1 0-.3-.1-.4-.2-.2-.2-.2-.6 0-.9l2.5-2.8c.2-.2.6-.2.8 0 .2.3.2.7 0 .9zm3.4-.6c-.1 0-.2 0-.3-.1l-6.3-5.7c-.3-.2-.3-.5-.1-.7.2-.3.5-.3.7-.1l6 5.4L27 1c.2-.2.5-.2.7.1.2.2.2.6-.1.7l-6.2 5.7c-.1.1-.3.1-.4.1zm6.7 3.4c-.1.1-.3.2-.4.2-.1 0-.3-.1-.4-.2l-2.6-2.8c-.2-.2-.2-.6 0-.9.2-.2.6-.2.8 0l2.6 2.8c.2.3.2.7 0 .9z'/%3E%3Crect width='11' height='2' rx='1'/%3E%3Crect x='3' y='4' width='8' height='2' rx='1'/%3E%3Crect x='7' y='8' width='4' height='2' rx='1'/%3E%3C/g%3E%3Cg transform='translate(0 13)' fill='%23183642'%3E%3Cpath d='M29 0H13v12h16V0zM17.6 8.2L15.1 11c-.1.1-.3.2-.4.2-.1 0-.3-.1-.4-.2-.2-.2-.2-.6 0-.9l2.5-2.8c.2-.2.6-.2.8 0 .2.3.2.7 0 .9zm3.4-.6c-.1 0-.2 0-.3-.1l-6.3-5.7c-.3-.2-.3-.5-.1-.7.2-.3.5-.3.7-.1l6 5.4L27 1c.2-.2.5-.2.7.1.2.2.2.6-.1.7l-6.2 5.7c-.1.1-.3.1-.4.1zm6.7 3.4c-.1.1-.3.2-.4.2-.1 0-.3-.1-.4-.2l-2.6-2.8c-.2-.2-.2-.6 0-.9.2-.2.6-.2.8 0l2.6 2.8c.2.3.2.7 0 .9z'/%3E%3Crect width='11' height='2' rx='1'/%3E%3Crect x='3' y='4' width='8' height='2' rx='1'/%3E%3Crect x='7' y='8' width='4' height='2' rx='1'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")  no-repeat;
+
 .c-submission-details-header {
 	font-family: $context--font-family-sans;
 	font-size: 0.75em;
@@ -55,30 +57,22 @@
 		}
 	}
 
-	&__author-item:not(:last-child) {
+	&__author-item {
 		font-size: 0.75rem;
 		list-style-type: none;
 		margin: 0;
 		padding-right: 7px;
 
-		.js & {
+		&.corresponding {
 			&:after {
-				content: ', ';
+				content: ' ';
 				display: inline-block;
-				width: 3px;
-			}
-
-			&.corresponding {
-				&:after {
-					content: ' ,';
-					display: inline-block;
-					background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23007E99'%3E%3Cpath d='M29 0H13v12h16V0zM17.6 8.2L15.1 11c-.1.1-.3.2-.4.2-.1 0-.3-.1-.4-.2-.2-.2-.2-.6 0-.9l2.5-2.8c.2-.2.6-.2.8 0 .2.3.2.7 0 .9zm3.4-.6c-.1 0-.2 0-.3-.1l-6.3-5.7c-.3-.2-.3-.5-.1-.7.2-.3.5-.3.7-.1l6 5.4L27 1c.2-.2.5-.2.7.1.2.2.2.6-.1.7l-6.2 5.7c-.1.1-.3.1-.4.1zm6.7 3.4c-.1.1-.3.2-.4.2-.1 0-.3-.1-.4-.2l-2.6-2.8c-.2-.2-.2-.6 0-.9.2-.2.6-.2.8 0l2.6 2.8c.2.3.2.7 0 .9z'/%3E%3Crect width='11' height='2' rx='1'/%3E%3Crect x='3' y='4' width='8' height='2' rx='1'/%3E%3Crect x='7' y='8' width='4' height='2' rx='1'/%3E%3C/g%3E%3Cg transform='translate(0 13)' fill='%23183642'%3E%3Cpath d='M29 0H13v12h16V0zM17.6 8.2L15.1 11c-.1.1-.3.2-.4.2-.1 0-.3-.1-.4-.2-.2-.2-.2-.6 0-.9l2.5-2.8c.2-.2.6-.2.8 0 .2.3.2.7 0 .9zm3.4-.6c-.1 0-.2 0-.3-.1l-6.3-5.7c-.3-.2-.3-.5-.1-.7.2-.3.5-.3.7-.1l6 5.4L27 1c.2-.2.5-.2.7.1.2.2.2.6-.1.7l-6.2 5.7c-.1.1-.3.1-.4.1zm6.7 3.4c-.1.1-.3.2-.4.2-.1 0-.3-.1-.4-.2l-2.6-2.8c-.2-.2-.2-.6 0-.9.2-.2.6-.2.8 0l2.6 2.8c.2.3.2.7 0 .9z'/%3E%3Crect width='11' height='2' rx='1'/%3E%3Crect x='3' y='4' width='8' height='2' rx='1'/%3E%3Crect x='7' y='8' width='4' height='2' rx='1'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")  no-repeat;
-					background-position: -11px 3px;
-					background-size: 30px;
-					padding-left: 20px;
-					height: 16px;
-					margin-left: 3px;
-				}
+				background: $author-icon-background;
+				background-position: -11px 3px;
+				background-size: 30px;
+				padding-left: 20px;
+				height: 16px;
+				margin-left: 3px;
 			}
 		}
 	}
@@ -90,9 +84,9 @@
 			&:after {
 				content: '';
 				display: inline-block;
-				background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23007E99'%3E%3Cpath d='M29 0H13v12h16V0zM17.6 8.2L15.1 11c-.1.1-.3.2-.4.2-.1 0-.3-.1-.4-.2-.2-.2-.2-.6 0-.9l2.5-2.8c.2-.2.6-.2.8 0 .2.3.2.7 0 .9zm3.4-.6c-.1 0-.2 0-.3-.1l-6.3-5.7c-.3-.2-.3-.5-.1-.7.2-.3.5-.3.7-.1l6 5.4L27 1c.2-.2.5-.2.7.1.2.2.2.6-.1.7l-6.2 5.7c-.1.1-.3.1-.4.1zm6.7 3.4c-.1.1-.3.2-.4.2-.1 0-.3-.1-.4-.2l-2.6-2.8c-.2-.2-.2-.6 0-.9.2-.2.6-.2.8 0l2.6 2.8c.2.3.2.7 0 .9z'/%3E%3Crect width='11' height='2' rx='1'/%3E%3Crect x='3' y='4' width='8' height='2' rx='1'/%3E%3Crect x='7' y='8' width='4' height='2' rx='1'/%3E%3C/g%3E%3Cg transform='translate(0 13)' fill='%23183642'%3E%3Cpath d='M29 0H13v12h16V0zM17.6 8.2L15.1 11c-.1.1-.3.2-.4.2-.1 0-.3-.1-.4-.2-.2-.2-.2-.6 0-.9l2.5-2.8c.2-.2.6-.2.8 0 .2.3.2.7 0 .9zm3.4-.6c-.1 0-.2 0-.3-.1l-6.3-5.7c-.3-.2-.3-.5-.1-.7.2-.3.5-.3.7-.1l6 5.4L27 1c.2-.2.5-.2.7.1.2.2.2.6-.1.7l-6.2 5.7c-.1.1-.3.1-.4.1zm6.7 3.4c-.1.1-.3.2-.4.2-.1 0-.3-.1-.4-.2l-2.6-2.8c-.2-.2-.2-.6 0-.9.2-.2.6-.2.8 0l2.6 2.8c.2.3.2.7 0 .9z'/%3E%3Crect width='11' height='2' rx='1'/%3E%3Crect x='3' y='4' width='8' height='2' rx='1'/%3E%3Crect x='7' y='8' width='4' height='2' rx='1'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")  no-repeat;
-				background-position: -190% -16%;
-				background-size: 25px;
+				background: $author-icon-background;
+				background-position: 1px 1px;
+				background-size: cover;
 				padding-left: 30px;
 				height: 12px;
 				margin-left: 3px;

--- a/toolkits/springernature/packages/springernature-submission-header/view/header.hbs
+++ b/toolkits/springernature/packages/springernature-submission-header/view/header.hbs
@@ -23,7 +23,7 @@
                         {{#if affiliation}}<p class="u-font-14 u-font-daytona" data-test="submission-author-{{@index}}-affiliation">{{affiliation.institutionName}}, {{affiliation.countryName}}</p>{{/if}}
                         <a href="mailto:{{emailAddress}}" class="c-submission-details-header__authors-email {{#if corresponding}}corresponding{{/if}}" data-test="submission-author-email-address">{{emailAddress}}</a>
                     </div>
-                    <button data-test="submission-author-name{{@index}}" data-component-author-popup-trigger data-popup data-popup-target="author-popup{{@index}}" class="c-submission-details-header__author{{#if corresponding}} corresponding{{/if}}">{{givenName}} {{familyName}}</button>
+                    <button data-test="submission-author-name{{@index}}" data-component-author-popup-trigger data-popup data-popup-target="author-popup{{@index}}" class="c-submission-details-header__author{{#if corresponding}} corresponding{{/if}}">{{givenName}} {{familyName}}{{#unless @last}},{{/unless}}</button>
                 </li>
             {{/each}}
         </ul>


### PR DESCRIPTION
Remove the slightly complicated addition of comma separators in the SCSS. Add them in the template instead.
And move the author background to a variable.

<img width="256" alt="Screenshot 2021-09-09 at 11 32 15" src="https://user-images.githubusercontent.com/11961647/132670629-38aeb8b1-a26e-491a-9712-c668c1b94891.png">
