### PR TITLE
Increase max width of journal logo

### DIFF
--- a/toolkits/springernature/packages/springernature-header/HISTORY.md
+++ b/toolkits/springernature/packages/springernature-header/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 2.1.0 (2021-09-15)
+    * Allow journal header to take a little more room
+
 ## 2.0.4 (2021-07-29)
     * Revert header width (media query fix below resolved issue)
 

--- a/toolkits/springernature/packages/springernature-header/package.json
+++ b/toolkits/springernature/packages/springernature-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springernature-header",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "license": "MIT",
   "description": "Springer Nature branded header component",
   "keywords": [],

--- a/toolkits/springernature/packages/springernature-header/scss/50-components/enhanced.scss
+++ b/toolkits/springernature/packages/springernature-header/scss/50-components/enhanced.scss
@@ -18,6 +18,10 @@
 		max-width: 209px;
 	}
 
+	.c-header__journal-logo {
+		max-width: 300px;
+	}
+
 	.c-header__site-logo.with-journal-logo {
 		@include media-query('md') {
 			border-right: 2px solid color('black');


### PR DESCRIPTION
Some new journals with larger logo images were getting squished.

<img width="864" alt="Screenshot 2021-09-15 at 09 53 16" src="https://user-images.githubusercontent.com/11961647/133402862-0623c961-a53c-4ab8-a1a5-60c74957f7e4.png">

<img width="863" alt="Screenshot 2021-09-15 at 09 52 59" src="https://user-images.githubusercontent.com/11961647/133402989-0e671332-52ee-45ce-8945-2bbd483fe266.png">

