### PR TITLE
Positioning of author icon

### DIFF
--- a/toolkits/springernature/packages/springernature-submission-header/HISTORY.md
+++ b/toolkits/springernature/packages/springernature-submission-header/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 0.6.1 (2021-09-15)
+	* Adjustment of icon position to line up with text
+
 ## 0.6.0 (2021-09-09)
 	* Add commas in template rather than with complicated SCSS
 

--- a/toolkits/springernature/packages/springernature-submission-header/package.json
+++ b/toolkits/springernature/packages/springernature-submission-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springernature-submission-header",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "MIT",
   "description": "Springer Nature branded submission details component",
   "keywords": [],

--- a/toolkits/springernature/packages/springernature-submission-header/scss/50-components/enhanced.scss
+++ b/toolkits/springernature/packages/springernature-submission-header/scss/50-components/enhanced.scss
@@ -67,11 +67,12 @@ $author-icon-background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org
 			&:after {
 				content: ' ';
 				display: inline-block;
+				position: absolute;
 				background: $author-icon-background;
-				background-position: -11px 3px;
+				background-position: -11px 4px;
 				background-size: 30px;
 				padding-left: 20px;
-				height: 16px;
+				height: 17px;
 				margin-left: 3px;
 			}
 		}


### PR DESCRIPTION
Smol smol vertical position tweak

Move it down  pixel to line up nicely. Make it absolute so it doesn't push down the text (which it is only doing when it is the last item??)


<img width="324" alt="Screenshot 2021-09-15 at 12 47 50" src="https://user-images.githubusercontent.com/11961647/133427947-16cd8a17-96b1-449e-9a03-0fd439778bd5.png">

-->

<img width="385" alt="Screenshot 2021-09-15 at 12 48 48" src="https://user-images.githubusercontent.com/11961647/133427964-a9660f18-be09-4b51-bd0a-412c821b67df.png">
