### PR TITLE
Accommodate diff sized logos at breakpoints

### DIFF
--- a/toolkits/springernature/packages/springernature-header/HISTORY.md
+++ b/toolkits/springernature/packages/springernature-header/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 2.2.0 (2021-09-21)
+    * Try to accommodate for different sized journal logos at different breakpoints
+
 ## 2.1.0 (2021-09-15)
     * Allow journal header to take a little more room
 

--- a/toolkits/springernature/packages/springernature-header/package.json
+++ b/toolkits/springernature/packages/springernature-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springernature-header",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": "MIT",
   "description": "Springer Nature branded header component",
   "keywords": [],

--- a/toolkits/springernature/packages/springernature-header/scss/50-components/enhanced.scss
+++ b/toolkits/springernature/packages/springernature-header/scss/50-components/enhanced.scss
@@ -23,6 +23,7 @@
 
 	.c-header__journal-logo {
 		max-width: 100%;
+		height: 24px;
 
 		@include media-query('md') {
 			max-width: 65%;
@@ -44,6 +45,7 @@
 		display: flex;
 		flex-basis: 100%;
 		flex-wrap: wrap;
+		align-items: center;
 
 		@include media-query('sm') {
 			flex-basis: 75%;

--- a/toolkits/springernature/packages/springernature-header/scss/50-components/enhanced.scss
+++ b/toolkits/springernature/packages/springernature-header/scss/50-components/enhanced.scss
@@ -1,8 +1,11 @@
 .js {
 	.c-header__content {
 		position: relative;
-		display: flex;
-		justify-content: space-between;
+
+		@include media-query('sm') {
+			display: flex;
+			justify-content: space-between;
+		}
 
 		@include media-query('lg') {
 			width: calc(100% - 64px);
@@ -19,7 +22,11 @@
 	}
 
 	.c-header__journal-logo {
-		max-width: 300px;
+		max-width: 100%;
+
+		@include media-query('md') {
+			max-width: 65%;
+		}
 	}
 
 	.c-header__site-logo.with-journal-logo {
@@ -35,11 +42,15 @@
 
 	.c-header__logo-link {
 		display: flex;
-		flex-basis: 60%;
+		flex-basis: 100%;
 		flex-wrap: wrap;
 
+		@include media-query('sm') {
+			flex-basis: 75%;
+		}
+
 		@include media-query('md') {
-			flex-basis: 70%;
+			flex-basis: 85%;
 		}
 	}
 }


### PR DESCRIPTION
We try to accommodate different sized logos at different breakpoints. One logo in particular with a lot of whitespace at the end has illustrated a bit of a problem whereby it gets shrunk quite small at smaller breakpoints. 
Below you can see the green-bordered SVG which seems to have been set to have ~40% whitespace?

<img width="1089" alt="Screenshot 2021-09-21 at 11 57 51" src="https://user-images.githubusercontent.com/11961647/134159060-7a0899b1-4b08-4870-86fe-052c7083d740.png">

--->

<img width="873" alt="Screenshot 2021-09-21 at 11 44 32" src="https://user-images.githubusercontent.com/11961647/134158517-bc7e02d7-6db2-4157-aaca-e66275cddac1.png">

<img width="431" alt="Screenshot 2021-09-21 at 11 44 19" src="https://user-images.githubusercontent.com/11961647/134158524-de802b3a-e349-41cd-b9af-e75b39974aeb.png">

