### PR TITLE
Improve logo sizing for non-js view

### DIFF
--- a/toolkits/springernature/packages/springernature-header/HISTORY.md
+++ b/toolkits/springernature/packages/springernature-header/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 2.2.1 (2021-09-23)
+    * Improve logo sizing for no-js view
+
 ## 2.2.0 (2021-09-21)
     * Try to accommodate for different sized journal logos at different breakpoints
 

--- a/toolkits/springernature/packages/springernature-header/package.json
+++ b/toolkits/springernature/packages/springernature-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springernature-header",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "license": "MIT",
   "description": "Springer Nature branded header component",
   "keywords": [],

--- a/toolkits/springernature/packages/springernature-header/scss/50-components/enhanced.scss
+++ b/toolkits/springernature/packages/springernature-header/scss/50-components/enhanced.scss
@@ -1,58 +1,64 @@
-.js {
-	.c-header__content {
-		position: relative;
+.c-header__content {
+	position: relative;
 
-		@include media-query('sm') {
-			display: flex;
-			justify-content: space-between;
-		}
-
-		@include media-query('lg') {
-			width: calc(100% - 64px);
-			margin-left: 32px;
-		}
-	}
-
-	.c-header__site-logo,
-	.c-header__journal-logo {
-		width: auto;
-		height: auto;
-		min-width: 130px;
-		max-width: 209px;
-	}
-
-	.c-header__journal-logo {
-		max-width: 100%;
-		height: 24px;
-
-		@include media-query('md') {
-			max-width: 65%;
-		}
-	}
-
-	.c-header__site-logo.with-journal-logo {
-		@include media-query('md') {
-			border-right: 2px solid color('black');
-		}
-	}
-
-	.c-header__content-block {
+	@include media-query('sm') {
 		display: flex;
-		flex-wrap: wrap;
+		justify-content: space-between;
 	}
 
-	.c-header__logo-link {
-		display: flex;
-		flex-basis: 100%;
-		flex-wrap: wrap;
-		align-items: center;
+	@include media-query('lg') {
+		width: calc(100% - 64px);
+		margin-left: 32px;
+	}
+}
 
+.c-header__site-logo,
+.c-header__journal-logo {
+	width: auto;
+	height: auto;
+	min-width: 130px;
+	max-width: 209px;
+}
+
+.c-header__site-logo {
+	padding-right: 20px;
+}
+
+.c-header__journal-logo {
+	max-width: 100%;
+	height: 24px;
+
+	@include media-query('md') {
+		max-width: 65%;
+	}
+}
+
+.c-header__site-logo.with-journal-logo {
+	@include media-query('md') {
+		border-right: 2px solid color('black');
+	}
+}
+
+.c-header__content-block {
+	display: flex;
+	flex-wrap: wrap;
+}
+
+.c-header__logo-link {
+	display: flex;
+	flex-basis: 100%;
+	flex-grow: 1;
+	flex-wrap: wrap;
+	align-items: center;
+	flex-basis: 55%;
+
+	@include media-query('sm') {
+		flex-basis: 65%;
+	}
+
+	.js & {
 		@include media-query('sm') {
 			flex-basis: 75%;
-		}
-
-		@include media-query('md') {
-			flex-basis: 85%;
 		}
 	}
 }

--- a/toolkits/springernature/packages/springernature-header/scss/50-components/enhanced.scss
+++ b/toolkits/springernature/packages/springernature-header/scss/50-components/enhanced.scss
@@ -46,7 +46,6 @@
 
 .c-header__logo-link {
 	display: flex;
-	flex-basis: 100%;
 	flex-grow: 1;
 	flex-wrap: wrap;
 	align-items: center;


### PR DESCRIPTION
After fixing the logo sizing in a previous commit, I noticed it was still a bit squiffy when js disabled.
This fix basically adjust the widths/floating for non-js.