### PR TITLE
URL prop prefixes

### DIFF
--- a/toolkits/global/packages/global-breadcrumbs/HISTORY.md
+++ b/toolkits/global/packages/global-breadcrumbs/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 3.1.1 (2021-10-23)
+    * Safer prop name for url
+
 ## 3.1.0 (2021-09-20)
     * Demo created with consumable handlebars template
 

--- a/toolkits/global/packages/global-breadcrumbs/demo/context.json
+++ b/toolkits/global/packages/global-breadcrumbs/demo/context.json
@@ -2,11 +2,11 @@
 	"crumbs": [
 		{
 			"label": "Crumb 1",
-			"url": "/path/to/crumb/1"
+			"crumbUrl": "/path/to/crumb/1"
 		},
 		{
 			"label": "Crumb 2",
-			"url": "/path/to/crumb/2"
+			"crumbUrl": "/path/to/crumb/2"
 		}
 	],
 	"current": {

--- a/toolkits/global/packages/global-breadcrumbs/demo/index.hbs
+++ b/toolkits/global/packages/global-breadcrumbs/demo/index.hbs
@@ -1,7 +1,7 @@
 <ul class="c-breadcrumbs">
 	{{#each crumbs}}
 		<li class="c-breadcrumbs__item">
-			<a href="{{url}}">{{label}}</a>
+			<a href="{{crumbUrl}}">{{label}}</a>
 			<svg class="c-breadcrumbs__chevron" width="12" height="12" aria-hidden="true" focusable="false">
 				<use xlink:href="{{../chevronURL}}"></use>
 			</svg>

--- a/toolkits/global/packages/global-breadcrumbs/package.json
+++ b/toolkits/global/packages/global-breadcrumbs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@springernature/global-breadcrumbs",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "license": "MIT",
     "description": "breadcrumbs",
     "keywords": [],

--- a/toolkits/global/packages/global-pill/HISTORY.md
+++ b/toolkits/global/packages/global-pill/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 1.3.1 (2021-10-23)
+    * Safer prop name for url
+
 ## 1.3.0 (2021-09-20)
     * Demo created with consumable handlebars template
 

--- a/toolkits/global/packages/global-pill/demo/context.json
+++ b/toolkits/global/packages/global-pill/demo/context.json
@@ -2,15 +2,15 @@
 	"pills": [
 		{
 			"label": "Pill 1",
-			"url": "/path/to/1"
+			"pillUrl": "/path/to/1"
 		},
 		{
 			"label": "Pill 2",
-			"url": "/path/to/2"
+			"pillUrl": "/path/to/2"
 		},
 		{
 			"label": "Pill 3",
-			"url": "/path/to/3"
+			"pillUrl": "/path/to/3"
 		}
 	]
 }

--- a/toolkits/global/packages/global-pill/demo/index.hbs
+++ b/toolkits/global/packages/global-pill/demo/index.hbs
@@ -1,7 +1,7 @@
 <ul>
 	{{#each pills}}
     <li>
-        <a href="{{url}}" class="c-pill">{{label}}</a>
+        <a href="{{pillUrl}}" class="c-pill">{{label}}</a>
     </li>
 	{{/each}}
 </ul>

--- a/toolkits/global/packages/global-pill/package.json
+++ b/toolkits/global/packages/global-pill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-pill",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "description": "A pill shape container with background",
   "keywords": [],

--- a/toolkits/springer/packages/springer-header/HISTORY.md
+++ b/toolkits/springer/packages/springer-header/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 5.1.1 (2021-10-23)
+    * Safer prop name for url
+
 ## 5.1.0 (2021-09-10)
     * Demo, including consumable handlebars template
 

--- a/toolkits/springer/packages/springer-header/demo/context.json
+++ b/toolkits/springer/packages/springer-header/demo/context.json
@@ -5,17 +5,17 @@
 		"linkUrl": "/"
 	},
 	"search": {
-		"url": "#",
+		"searchUrl": "#",
 		"iconUrl": "../../images/search.svg"
 	},
 	"menu": [
 		{
 			"label": "Menu option 1",
-			"url": "/path/to/1"
+			"optionUrl": "/path/to/1"
 		},
 		{
 			"label": "Menu option 2",
-			"url": "/path/to/2"
+			"optionUrl": "/path/to/2"
 		}
 	]
 }

--- a/toolkits/springer/packages/springer-header/demo/index.hbs
+++ b/toolkits/springer/packages/springer-header/demo/index.hbs
@@ -9,7 +9,7 @@
 		{{/with}}
 		<div class="c-header__navigation">
 			{{#with search}}
-			<a href="{{url}}" class="c-header__link c-header__link--search">
+			<a href="{{searchUrl}}" class="c-header__link c-header__link--search">
 				<span class="u-flex u-align-items-center">
 					Search
 					<svg class="u-icon u-ml-4" width="22" height="22" aria-hidden="true" focusable="false">
@@ -24,7 +24,7 @@
 				<ul class="c-header__menu">
 					{{#each menu}}
 					<li class="c-header__item">
-						<a class="c-header__link" href="{{url}}">{{label}}</a>
+						<a class="c-header__link" href="{{optionUrl}}">{{label}}</a>
 					</li>
 					{{/each}}
 				</ul>

--- a/toolkits/springer/packages/springer-header/package.json
+++ b/toolkits/springer/packages/springer-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-header",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "license": "MIT",
   "description": "Publisher level header",
   "keywords": [],

--- a/toolkits/springer/packages/springer-header/view/index.hbs
+++ b/toolkits/springer/packages/springer-header/view/index.hbs
@@ -8,7 +8,7 @@
 		</div>
 		{{/with}}
 		<div class="c-header__navigation">
-			{{#if searchUrl}}
+			{{#if search}}
 			<a href="{{searchUrl}}" class="c-header__link c-header__link--search">
 				<span class="u-flex u-flex-align-center">
 					Search
@@ -24,7 +24,7 @@
 				<ul class="c-header__menu">
 					{{#each menu}}
 					<li class="c-header__item">
-						<a class="c-header__link" href="{{url}}">{{label}}</a>
+						<a class="c-header__link" href="{{optionUrl}}">{{label}}</a>
 					</li>
 					{{/each}}
 				</ul>

--- a/toolkits/springer/packages/springer-media/HISTORY.md
+++ b/toolkits/springer/packages/springer-media/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 4.1.1 (2021-10-23)
+    * Safer prop name for url
+
 ## 4.1.0 (2021-09-10)
     * Demo, including consumable handlebars template
 

--- a/toolkits/springer/packages/springer-media/demo/context.json
+++ b/toolkits/springer/packages/springer-media/demo/context.json
@@ -4,7 +4,7 @@
 		"alt": "Descriptive alternative txt for image"
 	},
 	"title": "Example title",
-	"url": "/path/from/teaser",
+	"mediaUrl": "/path/from/teaser",
 	"level": "2",
 	"text": "Lorem ipsum dolor sit amet."
 }

--- a/toolkits/springer/packages/springer-media/demo/index.hbs
+++ b/toolkits/springer/packages/springer-media/demo/index.hbs
@@ -4,7 +4,7 @@
 	{{/with}}
 	<div class="c-media__body">
 		<h4 class="c-media__title u-text-lg" aria-level="{{level}}">
-			<a href="{{url}}">{{title}}</a>
+			<a href="{{mediaUrl}}">{{title}}</a>
 		</h4>
 		{{#if text}}
 		<p>{{text}}</p>

--- a/toolkits/springer/packages/springer-media/package.json
+++ b/toolkits/springer/packages/springer-media/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-media",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "license": "MIT",
   "description": "A media component catering for an image, title and body text. Styles have also been included to add a play button for things like videos.",
   "keywords": [],

--- a/toolkits/springer/packages/springer-user-metadata/HISTORY.md
+++ b/toolkits/springer/packages/springer-user-metadata/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 5.1.1 (2021-10-23)
+    * Safer prop name for url
+
 ## 5.1.0 (2021-09-10)
     * Demo, including consumable handlebars template
 

--- a/toolkits/springer/packages/springer-user-metadata/demo/context.json
+++ b/toolkits/springer/packages/springer-user-metadata/demo/context.json
@@ -8,7 +8,7 @@
 		},
 		{
 			"text": "沪ICP备15051854号-3",
-			"url": "http://www.miibeian.gov.cn",
+			"dataUrl": "http://www.miibeian.gov.cn",
 			"lang": "zh-Hans"
 		}
 	]

--- a/toolkits/springer/packages/springer-user-metadata/demo/index.hbs
+++ b/toolkits/springer/packages/springer-user-metadata/demo/index.hbs
@@ -12,7 +12,7 @@
 	{{/if}}
 	{{#each data}}
 	<p class="c-user-metadata__item" {{#if lang}}lang="{{lang}}" {{/if}}>
-		{{#if url}}<a href="{{url}}" class="u-link-inherit">{{/if}}
+		{{#if dataUrl}}<a href="{{dataUrl}}" class="u-link-inherit">{{/if}}
 			{{text}}
 			{{#if url}}</a>{{/if}}
 	</p>

--- a/toolkits/springer/packages/springer-user-metadata/package.json
+++ b/toolkits/springer/packages/springer-user-metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-user-metadata",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "license": "MIT",
   "description": "Meta data for user such as login status, ip address, business partner associations and chinese icp licence status",
   "keywords": [],


### PR DESCRIPTION
I've created https://github.com/springernature/springercom-toolkits-demo to test toolkit package integration for springer.com (and beyond).

Unfortunately, the use of `{{url}}` in templates results in handlebars errors with Eleventy. Since "url" is rather too generic a term anyway, I've prefixed each instance accordingly. With this merged, I will be able to dynamically import toolkits `/demo` templates and render HTML. This is a first step to using toolkits packages directly as dependencies.