### PR TITLE
Correct wording for buttonExpandedText

### DIFF
--- a/toolkits/global/packages/global-author-list/HISTORY.md
+++ b/toolkits/global/packages/global-author-list/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 4.0.2 (2021-10-29)
+    * Update default text for buttonExpandedText config
+
 ## 4.0.1 (2021-10-20)
     * Update readme file with the hasButtonIcon config
 

--- a/toolkits/global/packages/global-author-list/README.md
+++ b/toolkits/global/packages/global-author-list/README.md
@@ -111,7 +111,7 @@ authorList(myAuthorListContainer/*, options*/).init();
 | listModifierClass   | String  | null                         | CSS class to add on initialisation                |
 | buttonClassList     | String  | null                         | List of CSS classes to style the toggle button                           |
 | buttonCollapsedText | String  | Show all authors             | The text the button has when the list is collapsed.                      |
-| buttonExpandedText  | String  | Show less authors            | The text the button has when the list is expanded.                       |
+| buttonExpandedText  | String  | Show fewer authors           | The text the button has when the list is expanded.                       |
 | hasButtonIcon       | Boolean | true                         | A boolean indicating if a button icon should be included                 |
 
 The data attribute options are the same, but are lowercase and hyphenated:

--- a/toolkits/global/packages/global-author-list/js/__tests__/author-list.spec.js
+++ b/toolkits/global/packages/global-author-list/js/__tests__/author-list.spec.js
@@ -253,7 +253,7 @@ function isExpanded(authorListContainer) {
 	const icon = button.querySelector('svg');
 
 	expect(heading.textContent).toBe('Authors');
-	expect(button.textContent).toContain('Show less authors');
+	expect(button.textContent).toContain('Show fewer authors');
 	expect(button.getAttribute('aria-expanded')).toBe('true');
 	expect(icon.innerHTML).toContain('#icon-minus');
 

--- a/toolkits/global/packages/global-author-list/js/author-list.js
+++ b/toolkits/global/packages/global-author-list/js/author-list.js
@@ -36,7 +36,7 @@ function authorList(container, config = {}) {
 	authorHideClass = authorHideClass || 'c-author-list__hide';
 	truncatedClass = truncatedClass || 'c-author-list--truncated';
 	buttonCollapsedText = buttonCollapsedText || 'Show all authors';
-	buttonExpandedText = buttonExpandedText || 'Show less authors';
+	buttonExpandedText = buttonExpandedText || 'Show fewer authors';
 	if (hasButtonIcon !== false) {
 		hasButtonIcon = true;
 	}

--- a/toolkits/global/packages/global-author-list/package.json
+++ b/toolkits/global/packages/global-author-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-author-list",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "license": "MIT",
   "description": "Display a styled list of authors with comma separation. The list can be truncated and then accompanied with a toggle to be expanded/truncated",
   "keywords": [],


### PR DESCRIPTION
We change the default val for the config param buttonExpandedText from 'Show less authors' to 'Show fewer authors' which is 100% good english!