### PR TITLE
Footer landmark

### DIFF
--- a/toolkits/global/packages/global-corporate-footer/README.md
+++ b/toolkits/global/packages/global-corporate-footer/README.md
@@ -25,3 +25,5 @@ To include `global-corporate-footer` in your application, you need to choose **O
     </div>
 </div>
 ```
+
+Note that a `<footer>` region/landmark is not included. This allows you to combine this component with—for example—`springer-publisher-footer` inside a common `<footer>`.

--- a/toolkits/springer/packages/springer-publisher-footer/HISTORY.md
+++ b/toolkits/springer/packages/springer-publisher-footer/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 5.0.0 (2021-11-05)
+    * Removed `<footer>` wrapper so it can be combined with global-corporate-footer
+
 ## 4.1.0 (2021-09-10)
     * Demo, including consumable handlebars template
 

--- a/toolkits/springer/packages/springer-publisher-footer/README.md
+++ b/toolkits/springer/packages/springer-publisher-footer/README.md
@@ -122,4 +122,4 @@ Springer branded site footer
 
 ## Template
 
-The `./demo/index.hbs` template is designed to be consumable by your renderer. See `./demo/context.json` for the expected model / data schema.
+The `./demo/index.hbs` template is designed to be consumable by your renderer. See `./demo/context.json` for the expected model / data schema. Note that `./demo/index.hbs` does not include the `<footer>` wrapper. This allows you to combine this footer with the `global-corporate-footer` inside a common `<footer>` landmark/region.

--- a/toolkits/springer/packages/springer-publisher-footer/demo/index.hbs
+++ b/toolkits/springer/packages/springer-publisher-footer/demo/index.hbs
@@ -1,30 +1,28 @@
-<footer>
-	<div class="c-publisher-footer">
-		{{#with logo}}
-		<div class="c-publisher-footer__section c-publisher-footer__section--compact">
-			<div class="c-publisher-footer__container">
-				<img src="{{src}}" alt="{{alt}}" itemprop="logo" width="112" height="30" role="img">
-			</div>
+<div class="c-publisher-footer">
+	{{#with logo}}
+	<div class="c-publisher-footer__section c-publisher-footer__section--compact">
+		<div class="c-publisher-footer__container">
+			<img src="{{src}}" alt="{{alt}}" itemprop="logo" width="112" height="30" role="img">
 		</div>
-		{{/with}}
-		<div class="c-publisher-footer__section">
-			<div class="c-publisher-footer__container">
-				<div class="c-publisher-footer__menu">
-					{{#each categories}}
-					<div class="c-publisher-footer__menu-group">
-						<dl class="c-publisher-footer__list">
-							<dt class="c-publisher-footer__heading">{{title}}</dt>
-							{{#each links}}
-							<dd class="c-publisher-footer__item">
-								<a class="c-publisher-footer__link {{#if class}}{{class}}{{/if}}"
-									href="{{href}}">{{label}}</a>
-							</dd>
-							{{/each}}
-						</dl>
-					</div>
-					{{/each}}
+	</div>
+	{{/with}}
+	<div class="c-publisher-footer__section">
+		<div class="c-publisher-footer__container">
+			<div class="c-publisher-footer__menu">
+				{{#each categories}}
+				<div class="c-publisher-footer__menu-group">
+					<dl class="c-publisher-footer__list">
+						<dt class="c-publisher-footer__heading">{{title}}</dt>
+						{{#each links}}
+						<dd class="c-publisher-footer__item">
+							<a class="c-publisher-footer__link {{#if class}}{{class}}{{/if}}"
+								href="{{href}}">{{label}}</a>
+						</dd>
+						{{/each}}
+					</dl>
 				</div>
+				{{/each}}
 			</div>
 		</div>
 	</div>
-</footer>
+</div>

--- a/toolkits/springer/packages/springer-publisher-footer/package.json
+++ b/toolkits/springer/packages/springer-publisher-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-publisher-footer",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "license": "MIT",
   "description": "Springer branded site footer",
   "keywords": [],


### PR DESCRIPTION
Removes `<footer>` from the `springer-publisher-footer` template to avoid nested footers when combined with `global-corporate-footer`.