### PR TITLE
Remove references to functions in settings file

### DIFF
--- a/context/brand-context/springernature/scss/10-settings/links.scss
+++ b/context/brand-context/springernature/scss/10-settings/links.scss
@@ -1,7 +1,7 @@
-$context--link-color: color('medium-blue');
-$context--link-hover-color: color('universal-blue');
-$context--link-visited-color: color('purple');
-$context--link-active-color: color('black');
+$context--link-color: map-get($context--colors, medium-blue);
+$context--link-hover-color: map-get($context--colors, universal-blue);
+$context--link-visited-color: map-get($context--colors, purple);
+$context--link-active-color: map-get($context--colors, black);
 
 $context--link-text-font-sizes: (
 	'medium': $context--font-size-md,


### PR DESCRIPTION
Functions are loaded after settings, so some of these variables were not working. I suppose we should not be using functions/mixins in settings files?
