### PR TITLE
Added settings for nature and springer

### DIFF
--- a/toolkits/global/packages/global-layout-with-sidebar/HISTORY.md
+++ b/toolkits/global/packages/global-layout-with-sidebar/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 0.1.2 (2021-11-10)
+    * Add springer settings
+    * Add nature settings
+
 ## 0.0.2 (2021-11-08)
 	* Sidebar elements should not have margin
 

--- a/toolkits/global/packages/global-layout-with-sidebar/HISTORY.md
+++ b/toolkits/global/packages/global-layout-with-sidebar/HISTORY.md
@@ -1,6 +1,6 @@
 # History
 
-## 0.1.2 (2021-11-10)
+## 0.1.0 (2021-11-12)
     * Add springer settings
     * Add nature settings
 

--- a/toolkits/global/packages/global-layout-with-sidebar/package.json
+++ b/toolkits/global/packages/global-layout-with-sidebar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-layout-with-sidebar",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "license": "MIT",
   "description": "A two column layout with one column as a sidebar",
   "keywords": [],

--- a/toolkits/global/packages/global-layout-with-sidebar/scss/10-settings/nature.scss
+++ b/toolkits/global/packages/global-layout-with-sidebar/scss/10-settings/nature.scss
@@ -1,0 +1,11 @@
+/**
+ * @springernature/global-layout-with-sidebar
+ * Nature skin settings
+ */
+
+// Default setting
+@import 'default';
+
+$with-sidebar--gap: 64px;
+$with-sidebar--min: 53%;
+$with-sidebar--basis: 454px;

--- a/toolkits/global/packages/global-layout-with-sidebar/scss/10-settings/springer.scss
+++ b/toolkits/global/packages/global-layout-with-sidebar/scss/10-settings/springer.scss
@@ -1,0 +1,11 @@
+/**
+ * @springernature/global-layout-with-sidebar
+ * Springer skin settings
+ */
+
+// Default setting
+@import 'default';
+
+$with-sidebar--gap: 64px;
+$with-sidebar--min: 53%;
+$with-sidebar--basis: 454px;


### PR DESCRIPTION
We're going to start using this toolkit for the layout in the articles, chapter and book pages in Springerlink and nature. So I added the settings for them.