### PR TITLE
add icon size settings for global-status-message 

### DIFF
--- a/toolkits/global/packages/global-status-message/HISTORY.md
+++ b/toolkits/global/packages/global-status-message/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 3.2.0 (2021-11-12)
+    * Add settings for height and width on icon 
+    * Bump brand-context version to 17.1.1
+
 ## 3.1.0 (2021-09-20)
     * Demo created with consumable handlebars template
 

--- a/toolkits/global/packages/global-status-message/HISTORY.md
+++ b/toolkits/global/packages/global-status-message/HISTORY.md
@@ -2,7 +2,7 @@
 
 ## 3.2.0 (2021-11-12)
     * Add settings for height and width on icon 
-    * Bump brand-context version to 17.1.1
+    * Bump brand-context version to 17.2.0
 
 ## 3.1.0 (2021-09-20)
     * Demo created with consumable handlebars template

--- a/toolkits/global/packages/global-status-message/demo/dist/index.html
+++ b/toolkits/global/packages/global-status-message/demo/dist/index.html
@@ -669,12 +669,10 @@ body {
 	transform: translate(0, 0);
 	display: inline-block;
 	vertical-align: text-top;
-	width: 1em;
-	height: 1em;
+	width: 1.5em;
+	height: 1.5em;
 	flex: 0 0 auto;
 	margin-right: 8px;
-	height: 1.5em;
-	width: 1.5em;
 }
 
 .c-status-message__icon--top {

--- a/toolkits/global/packages/global-status-message/demo/dist/index.html
+++ b/toolkits/global/packages/global-status-message/demo/dist/index.html
@@ -669,8 +669,12 @@ body {
 	transform: translate(0, 0);
 	display: inline-block;
 	vertical-align: text-top;
+	width: 1em;
+	height: 1em;
 	flex: 0 0 auto;
 	margin-right: 8px;
+	height: 1.5em;
+	width: 1.5em;
 }
 
 .c-status-message__icon--top {
@@ -712,7 +716,7 @@ body {
 		</style>
 	</head>
 	<body style="padding:2%">
-		<div class="c-status-message c-status-message--boxed c-status-message--">
+		<div class="c-status-message c-status-message--boxed c-status-message--warning">
     <svg class="c-status-message__icon" width="24" height="24" aria-hidden="true" focusable="false">
         <use xlink:href="../../img/warning.svg#warning"></use>
     </svg>

--- a/toolkits/global/packages/global-status-message/package.json
+++ b/toolkits/global/packages/global-status-message/package.json
@@ -5,5 +5,5 @@
   "description": "Global Status Message component",
   "keywords": [],
   "author": "Springer Nature",
-  "brandContext": "^17.1.1"
+  "brandContext": "^17.2.0"
 }

--- a/toolkits/global/packages/global-status-message/package.json
+++ b/toolkits/global/packages/global-status-message/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@springernature/global-status-message",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "license": "MIT",
   "description": "Global Status Message component",
   "keywords": [],
   "author": "Springer Nature",
-  "brandContext": "^10.1.2"
+  "brandContext": "^17.1.1"
 }

--- a/toolkits/global/packages/global-status-message/scss/10-settings/default.scss
+++ b/toolkits/global/packages/global-status-message/scss/10-settings/default.scss
@@ -19,6 +19,5 @@ $status-message--border: 1px solid greyscale(80);
 $status-message--line-height: $context--line-height-tight;
 $status-message--gutter: spacing(16);
 $status-message--gutter-icon: spacing(8);
-$status-message--icon-height: 1.5em;
-$status-message--icon-width: 1.5em;
+$status-message--icon-size: 1.5em;
 $status-message--font-weight: $context--font-weight-bold;

--- a/toolkits/global/packages/global-status-message/scss/10-settings/default.scss
+++ b/toolkits/global/packages/global-status-message/scss/10-settings/default.scss
@@ -19,4 +19,6 @@ $status-message--border: 1px solid greyscale(80);
 $status-message--line-height: $context--line-height-tight;
 $status-message--gutter: spacing(16);
 $status-message--gutter-icon: spacing(8);
+$status-message--icon-height: 1.5em;
+$status-message--icon-width: 1.5em;
 $status-message--font-weight: $context--font-weight-bold;

--- a/toolkits/global/packages/global-status-message/scss/50-components/status-message.scss
+++ b/toolkits/global/packages/global-status-message/scss/50-components/status-message.scss
@@ -30,8 +30,8 @@
 	@include u-icon;
 	flex: 0 0 auto;
 	margin-right: $status-message--gutter-icon;
-	height: $status-message--icon-height;
-	width: $status-message--icon-width;
+	height: $status-message--icon-size;
+	width: $status-message--icon-size;
 }
 
 .c-status-message__icon--top {

--- a/toolkits/global/packages/global-status-message/scss/50-components/status-message.scss
+++ b/toolkits/global/packages/global-status-message/scss/50-components/status-message.scss
@@ -30,6 +30,8 @@
 	@include u-icon;
 	flex: 0 0 auto;
 	margin-right: $status-message--gutter-icon;
+	height: $status-message--icon-height;
+	width: $status-message--icon-width;
 }
 
 .c-status-message__icon--top {

--- a/toolkits/global/packages/global-status-message/scss/50-components/status-message.scss
+++ b/toolkits/global/packages/global-status-message/scss/50-components/status-message.scss
@@ -27,11 +27,9 @@
 }
 
 .c-status-message__icon {
-	@include u-icon;
+	@include u-icon($status-message--icon-size, $status-message--icon-size);
 	flex: 0 0 auto;
 	margin-right: $status-message--gutter-icon;
-	height: $status-message--icon-size;
-	width: $status-message--icon-size;
 }
 
 .c-status-message__icon--top {


### PR DESCRIPTION
override sizes from `u-icon` which made the status icon a bit smaller than the original design