### PR TITLE
Add optional width and height to set for u-icon mixin

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 17.2.0 (2021-11-12)
+    * Add optional width and height to set for `u-icon` mixin 
+
 ## 17.1.1 (2021-11-08)
     * Remove margin on `p:last-child`
 

--- a/context/brand-context/default/scss/30-mixins/icons.scss
+++ b/context/brand-context/default/scss/30-mixins/icons.scss
@@ -1,8 +1,8 @@
-@mixin u-icon {
+@mixin u-icon ($width: 1em, $height: 1em) {
 	fill: currentColor;
 	transform: translate(0, 0); // Hack to allow for subpixel rendering
 	display: inline-block;
 	vertical-align: text-top;
-	width: 1em; // Fit icons to surrounding text
-	height: 1em; // (continued)
+	width: $width; // Fit icons to surrounding text
+	height: $height; // (continued)
 }

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "17.1.1",
+  "version": "17.2.0",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],


### PR DESCRIPTION
Adding the option to change size as the default `1em` made some existing icons smaller than before.