### PR TITLE
Allow default tab behaviour

### DIFF
--- a/toolkits/global/packages/global-autocomplete/HISTORY.md
+++ b/toolkits/global/packages/global-autocomplete/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 5.1.1 (2021-11-18)
+    * Tab keypress should trigger default behaviour, i.e. move to next action on page rather than nav through suggestions
+
 ## 5.1.0 (2021-06-21)
     * Ensures aria-expanded is set correctly when search results are generated and removed
 

--- a/toolkits/global/packages/global-autocomplete/__tests__/index.js
+++ b/toolkits/global/packages/global-autocomplete/__tests__/index.js
@@ -1,219 +1,253 @@
 'use strict';
 import autoComplete from '../js/index.js';
 
+const showResults = results => {
+	const resultsContainer = document.createElement('div');
+	resultsContainer.className = 'c-results-container';
+	if (results) {
+		results.forEach(datum => {
+			const result = document.createElement('div');
+			result.textContent = datum;
+			result.tabIndex = '0';
+			result.className = 'c-results-container__result';
+			resultsContainer.appendChild(result);
+		});
+	}
+	document.querySelector('.c-autocomplete').insertAdjacentHTML('afterend', resultsContainer.outerHTML);
+};
+
 describe('Autocomplete', () => {
-		const url = 'https://www.something.com/autocomplete?q=';
-		const expectedResults = ['albatrossman', 'angry beaker', 'alturistic flappyman'];
-		const headers = {
-			Accept: 'application/json; version=2'
-		};
-		const mockSelectCallback = jest.fn();
-		const mockErrorCallback = jest.fn();
-		const mockResultsCallback = jest.fn();
-		const expectedResponse = {ok: true, status: 200, json: () => { return expectedResults }};
-		const setMockFetch = response => {
-			global.fetch = () => { return Promise.resolve(response) };
-		};
-		const page = {
-			create: () => {
-				let template = `<div><input type='text' class="c-autocomplete" autocomplete="off" placeholder="trowel handed swan"/></div>`;
-				document.body.innerHTML = template;
-			}
-		};
-		const waitFor = time => new Promise(resolve => setTimeout(resolve, time));
+	const url = 'https://www.something.com/autocomplete?q=';
+	const expectedResults = ['albatrossman', 'angry beaker', 'alturistic flappyman'];
+	const headers = {
+		Accept: 'application/json; version=2'
+	};
+	const mockSelectCallback = jest.fn();
+	const mockErrorCallback = jest.fn();
+	const mockResultsCallback = jest.fn();
+	const expectedResponse = {ok: true, status: 200, json: () => { return expectedResults }};
+	const waitFor = time => new Promise(resolve => setTimeout(resolve, time));
+	const resultsContainerSelector = '.c-results-container';
+	let fetchSpy;
+	let input;
+	
+	const resultsContainer = () => {
+		return document.querySelector(`${resultsContainerSelector}`);
+	};
 
-		const args = {
-				selector: '.c-autocomplete',
-				onSelect: mockSelectCallback,
-				searchError: mockErrorCallback,
-				resultsContainerSelector: '.c-results-container',
-				resultSelector: '.c-results-container__result',
-				resultsCallBack: mockResultsCallback,
-				endpoint: url,
-				minCars: 1,
-				inputDelay: 0,
-				headers: headers
-		};
-		let fetchSpy;
-		let input;
+	const args = {
+			selector: '.c-autocomplete',
+			onSelect: mockSelectCallback,
+			searchError: mockErrorCallback,
+			resultsContainerSelector,
+			resultSelector: '.c-results-container__result',
+			resultsCallBack: mockResultsCallback,
+			endpoint: url,
+			minCars: 1,
+			inputDelay: 0,
+			headers: headers
+	};
 
-		beforeAll(() => {
-			setMockFetch(expectedResponse);
+	const setMockFetch = response => {
+		global.fetch = () => { return Promise.resolve(response) };
+	};
+	const page = {
+		create: () => {
+			let template = `<div><input type='text' class="c-autocomplete" autocomplete="off" placeholder="trowel handed swan"/><button>a button</button></div>`;
+			document.body.innerHTML = template;
+		}
+	};
+
+	beforeAll(() => {
+		setMockFetch(expectedResponse);
+	});
+
+	beforeEach(() => {
+		page.create();
+		input = document.querySelector('.c-autocomplete');
+		fetchSpy = jest.spyOn(global, 'fetch');
+	});
+
+	afterEach(() => {
+		document.body.innerHTML = '';
+		for (let mock of [fetchSpy, mockSelectCallback, mockResultsCallback]) {
+			mock.mockRestore();
+		}
+	});
+
+	describe('Typing into the text input', () => {
+		test('Should by default send a GET request to the configured endpoint', async () => {
+			let auto = autoComplete(args);
+			auto.enable();
+			input.value = 'burdmen';
+			input.dispatchEvent(new Event('keyup'));
+
+			await waitFor(2);
+			expect(fetchSpy).toHaveBeenCalledWith(url + 'burdmen', {"content-type": "application/json", "headers": headers, "method": 'GET'});
+
 		});
 
-		beforeEach(() => {
-			page.create();
-			input = document.querySelector('.c-autocomplete');
-
-			fetchSpy = jest.spyOn(global, 'fetch');
-		});
-
-		afterEach(() => {
-			document.body.innerHTML = '';
-			fetchSpy.mockReset();
-			fetchSpy.mockRestore();
-			mockSelectCallback.mockReset();
-			mockSelectCallback.mockRestore();
-			mockResultsCallback.mockReset();
-			mockResultsCallback.mockRestore();
-		});
-
-		describe('Typing into the text input', () => {
-			test('Should by default send a GET request to the configured endpoint', async () => {
-				let auto = autoComplete(args);
-				auto.enable();
-				input.value = 'burdmen';
-				input.dispatchEvent(new Event('keyup'));
-
-				await waitFor(2);
-				expect(fetchSpy).toHaveBeenCalledWith(url + 'burdmen', {"content-type": "application/json", "headers": headers, "method": 'GET'});
-
-			});
-
-			test('Should send a request using the configured HTTP method and bodyTemplate', async () => {
-				const bodyTemplate = term => {
-					return {
-						text: term,
-						size: 20
-					};
+		test('Should send a request using the configured HTTP method and bodyTemplate', async () => {
+			const bodyTemplate = term => {
+				return {
+					text: term,
+					size: 20
 				};
-				let auto = autoComplete({
-					...args,
-					httpMethod: 'POST',
-					bodyTemplate,
-				});
-				auto.enable();
-				input.value = 'burdmen';
-				input.dispatchEvent(new Event('keyup'));
-
-				await waitFor(2);
-				expect(fetchSpy).toHaveBeenCalledWith(url, {"content-type": "application/json", "headers": headers, "method": "POST", "body": JSON.stringify(bodyTemplate('burdmen'))});
-
-			});
-			test('Or use provided data', async () => {
-				let newArgs = Object.assign({
-					endpoint: null,
-					staticResultsData: [{"name":"Jason","type":"Honey-Beaked Salmon Hunter","id":"1234"},{"name":"Morpor","type":"Shoelace Heron","id":"34566"}]
-				}, args);
-				let auto = autoComplete(newArgs);
-				auto.enable();
-
-				input.value = 'IntrepidTrouser';
-				input.dispatchEvent(new Event('keyup'));
-
-				await waitFor(2);
-				expect(fetchSpy).not.toHaveBeenCalled();
-				expect(mockResultsCallback.mock.calls.length).toBe(1);
-			});
-
-			test('Should invoke callback function from config', async () => {
-				let auto = autoComplete(args);
-				auto.enable();
-				input.value = 'Pain Hawk';
-				input.dispatchEvent(new Event('keyup'));
-
-				await waitFor(2);
-				expect(mockResultsCallback.mock.calls.length).toBe(1);
-				expect(mockResultsCallback).toHaveBeenCalledWith(expectedResults);
-			});
-		});
-
-		describe('Browsing the suggestions', () => {
-			const showResults = results => {
-				// Update UI with results returned from server, e.g.
-
-				const resultsContainer = document.createElement('div');
-				resultsContainer.className = 'c-results-container';
-
-				results.forEach(datum => {
-					const result = document.createElement('div');
-					result.textContent = datum;
-					result.tabIndex = '0'; // So you can focus/tab through the results
-					result.className = 'c-results-container__result';
-					resultsContainer.appendChild(result);
-				});
-				document.querySelector('.c-autocomplete').insertAdjacentHTML('afterend', resultsContainer.outerHTML);
 			};
-
-			test('Update the text input if selectOnSuggestionBrowsing is true', async () => {
-				let auto = autoComplete({
-					...args,
-					endpoint: null,
-					staticResultsData: ['Wallaby', 'Walrus', 'Warbler'],
-					resultsCallBack: showResults
-				});
-
-				auto.enable();
-
-				input.value = 'Wa';
-				input.dispatchEvent(new KeyboardEvent('keyup'));
-
-				await waitFor(2);
-
-				expect(input.getAttribute('aria-expanded')).toBe("true");
-
-				input.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowDown' }));
-				expect(input.value).toBe('Wallaby');
-
-				document.querySelector('.c-results-container').dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
-				expect(input.value).toBe('Walrus');
-
-				document.querySelector('.c-results-container').dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
-				expect(input.value).toBe('Wallaby');
+			let auto = autoComplete({
+				...args,
+				httpMethod: 'POST',
+				bodyTemplate,
 			});
+			auto.enable();
+			input.value = 'burdmen';
+			input.dispatchEvent(new Event('keyup'));
 
-			test('Do not update the text input if selectOnSuggestionBrowsing is false', async () => {
-				let auto = autoComplete({
-					...args,
-					endpoint: null,
-					staticResultsData: ['Wallaby', 'Walrus', 'Warbler'],
-					resultsCallBack: showResults,
-					selectOnSuggestionBrowsing: false
-				});
+			await waitFor(2);
+			expect(fetchSpy).toHaveBeenCalledWith(url, {"content-type": "application/json", "headers": headers, "method": "POST", "body": JSON.stringify(bodyTemplate('burdmen'))});
 
-				auto.enable();
+		});
+		test('Or use provided data', async () => {
+			let newArgs = Object.assign({
+				endpoint: null,
+				staticResultsData: [{"name":"Jason","type":"Honey-Beaked Salmon Hunter","id":"1234"},{"name":"Morpor","type":"Shoelace Heron","id":"34566"}]
+			}, args);
+			let auto = autoComplete(newArgs);
+			auto.enable();
 
-				input.value = 'Wa';
-				input.dispatchEvent(new KeyboardEvent('keyup'));
+			input.value = 'IntrepidTrouser';
+			input.dispatchEvent(new Event('keyup'));
 
-				await waitFor(2);
-
-				input.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowDown' }));
-				expect(input.value).toBe('Wa');
-
-				document.querySelector('.c-results-container').dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
-				expect(input.value).toBe('Wa');
-
-				document.querySelector('.c-results-container').dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
-				expect(input.value).toBe('Wa');
-			});
+			await waitFor(2);
+			expect(fetchSpy).not.toHaveBeenCalled();
+			expect(mockResultsCallback.mock.calls.length).toBe(1);
 		});
 
-		describe('A bad response', () => {
-			test('Should call the error function provided in the config', async () => {
-				let auto = autoComplete(args);
-				auto.enable();
+		test('Should invoke callback function from config', async () => {
+			let auto = autoComplete(args);
+			auto.enable();
+			input.value = 'Pain Hawk';
+			input.dispatchEvent(new Event('keyup'));
 
-				setMockFetch({ok: false, status: 404 });
-				input.value = 'Death Kestrel';
-				input.dispatchEvent(new Event('keyup'));
+			await waitFor(2);
+			expect(mockResultsCallback.mock.calls.length).toBe(1);
+			expect(mockResultsCallback).toHaveBeenCalledWith(expectedResults);
+		});
+	});
 
-				await waitFor(2);
-				expect(mockErrorCallback.mock.calls.length).toBe(1);
+	describe('Browsing the suggestions', () => {
+		test('Update the text input if selectOnSuggestionBrowsing is true', async () => {
+			let auto = autoComplete({
+				...args,
+				endpoint: null,
+				staticResultsData: ['Wallaby', 'Walrus', 'Warbler'],
+				resultsCallBack: showResults
 			});
+
+			auto.enable();
+
+			input.value = 'Wa';
+			input.dispatchEvent(new KeyboardEvent('keyup'));
+
+			await waitFor(2);
+
+			expect(input.getAttribute('aria-expanded')).toBe("true");
+
+			input.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowDown' }));
+			expect(input.value).toBe('Wallaby');
+
+			document.querySelector('.c-results-container').dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+			expect(input.value).toBe('Walrus');
+
+			document.querySelector('.c-results-container').dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+			expect(input.value).toBe('Wallaby');
 		});
 
-		describe('A response with zero suggestions', () => {
-			test('Should not error out because the "no results" situation is the job of the resultsCallBack', async () => {
-				let auto = autoComplete(args);
-				auto.enable();
-
-				setMockFetch({ok: true, status: 200, json: () => { return []; }});
-				input.value = 'bur';
-				input.dispatchEvent(new Event('keyup'));
-
-				await waitFor(2);
-				expect(mockResultsCallback).toHaveBeenCalledWith([]);
+		test('Do not update the text input if selectOnSuggestionBrowsing is false', async () => {
+			let auto = autoComplete({
+				...args,
+				endpoint: null,
+				staticResultsData: ['Wallaby', 'Walrus', 'Warbler'],
+				resultsCallBack: showResults,
+				selectOnSuggestionBrowsing: false
 			});
+
+			auto.enable();
+
+			input.value = 'Wa';
+			input.dispatchEvent(new KeyboardEvent('keyup'));
+
+			await waitFor(2);
+
+			input.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowDown' }));
+			expect(input.value).toBe('Wa');
+
+			document.querySelector('.c-results-container').dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+			expect(input.value).toBe('Wa');
+
+			document.querySelector('.c-results-container').dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+			expect(input.value).toBe('Wa');
 		});
+	});
+
+	describe('Keyboard events', () => {
+		beforeEach(async () => {
+			let auto = autoComplete({
+				...args,
+				endpoint: null,
+				staticResultsData: ['Wallaby', 'Walrus', 'Warbler'],
+				resultsCallBack: showResults
+			});
+			auto.enable();
+
+			input.value = 'Wa';
+			input.dispatchEvent(new KeyboardEvent('keyup'));
+			await waitFor(2);
+			expect(input.getAttribute('aria-expanded')).toBe("true");
+			expect(document.querySelector('.c-results-container').children).toHaveLength(3);
+		});
+		
+		test('Tabbing from the input removes the results dropdown', async () => {
+			// Removing the results enables the expected tab behaviour which is to move to the next focussable element, rather than nav through the results
+			input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+
+			expect(input.getAttribute('aria-expanded')).not.toBe("true");
+			expect(document.querySelector('.c-results-container')).toBe(null);
+		});
+
+		test('Tabbing from the results container removes the results dropdown', async () => {
+			resultsContainer().dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+
+			expect(input.getAttribute('aria-expanded')).not.toBe("true");
+			expect(document.querySelector('.c-results-container')).toBe(null);
+		});
+	});
+
+	describe('A bad response', () => {
+		test('Should call the error function provided in the config', async () => {
+			let auto = autoComplete(args);
+			auto.enable();
+
+			setMockFetch({ok: false, status: 404 });
+			input.value = 'Death Kestrel';
+			input.dispatchEvent(new Event('keyup'));
+
+			await waitFor(2);
+			expect(mockErrorCallback.mock.calls.length).toBe(1);
+		});
+	});
+
+	describe('A response with zero suggestions', () => {
+		test('Should not error out because the "no results" situation is the job of the resultsCallBack', async () => {
+			let auto = autoComplete(args);
+			auto.enable();
+
+			setMockFetch({ok: true, status: 200, json: () => { return []; }});
+			input.value = 'bur';
+			input.dispatchEvent(new Event('keyup'));
+
+			await waitFor(2);
+			expect(mockResultsCallback).toHaveBeenCalledWith([]);
+		});
+	});
 });

--- a/toolkits/global/packages/global-autocomplete/js/index.js
+++ b/toolkits/global/packages/global-autocomplete/js/index.js
@@ -57,7 +57,7 @@ const autoComplete = arguments_ => {
 		input.removeEventListener('keyup', inputEvents);
 		const resultsContainer = getContainer();
 		if (resultsContainer) {
-			resultsContainer.parentNode.removeChild(resultsContainer);
+			resultsContainer.remove();
 		}
 		document.removeEventListener('click', removeSuggestions);
 		input.setAttribute('aria-expanded', false);

--- a/toolkits/global/packages/global-autocomplete/js/index.js
+++ b/toolkits/global/packages/global-autocomplete/js/index.js
@@ -24,7 +24,7 @@ const autoComplete = arguments_ => {
 	}
 
 	const input = document.querySelector(selector);
-	const container = () => {
+	const getContainer = () => {
 		return document.querySelector(`${resultsContainerSelector}`);
 	};
 	const suggestions = () => {
@@ -55,19 +55,21 @@ const autoComplete = arguments_ => {
 			return;
 		}
 		input.removeEventListener('keyup', inputEvents);
-		if (container()) {
-			container().parentNode.removeChild(container());
+		const resultsContainer = getContainer();
+		if (resultsContainer) {
+			resultsContainer.parentNode.removeChild(resultsContainer);
 		}
 		document.removeEventListener('click', removeSuggestions);
 		input.setAttribute('aria-expanded', false);
 	};
 
 	const addSuggestionEventListeners = () => {
-		if (container() === null) {
+		const resultsContainer = getContainer();
+		if (resultsContainer === null) {
 			return;
 		}
 
-		container().addEventListener('keydown', event => {
+		resultsContainer.addEventListener('keydown', event => {
 			if (['Escape', 'Esc', 'ArrowUp', 'Up', 'ArrowDown', 'Down'].includes(event.key)) {
 				event.preventDefault();
 				event.stopPropagation();
@@ -131,8 +133,9 @@ const autoComplete = arguments_ => {
 		input.addEventListener('keyup', inputEvents);
 		resultsCallBack.call(this, data);
 		addSuggestionEventListeners();
-		if (container()) {
-			container().addEventListener('keydown', ev => {
+		const container = getContainer();
+		if (container) {
+			container.addEventListener('keydown', ev => {
 				if (ev.key === 'Tab') {
 					removeSuggestions();
 				}

--- a/toolkits/global/packages/global-autocomplete/js/index.js
+++ b/toolkits/global/packages/global-autocomplete/js/index.js
@@ -131,6 +131,14 @@ const autoComplete = arguments_ => {
 		input.addEventListener('keyup', inputEvents);
 		resultsCallBack.call(this, data);
 		addSuggestionEventListeners();
+		if (container()) {
+			container().addEventListener('keydown', ev => {
+				if (ev.key === 'Tab') {
+					removeSuggestions();
+				}
+			});
+		}
+
 		input.setAttribute('aria-expanded', true);
 	};
 
@@ -205,6 +213,12 @@ const autoComplete = arguments_ => {
 			event.preventDefault();
 		}
 	};
+
+	input.addEventListener('keydown', ev => {
+		if (ev.key === 'Tab') {
+			removeSuggestions();
+		}
+	});
 
 	const enable = () => {
 		if (input) {

--- a/toolkits/global/packages/global-autocomplete/package.json
+++ b/toolkits/global/packages/global-autocomplete/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-autocomplete",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "license": "MIT",
   "description": "Autocomplete/suggest component",
   "keywords": [],


### PR DESCRIPTION
This fix allows the default expected behaviour from the Tab keypress, i.e move focus to next focussable element, rather than scroll through the results list.
