### PR TITLE
Add keyframes to springer brand context

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 17.3.0 (2021-11-30)
+    * Add keyframes settings to springer brand
+
 ## 17.2.0 (2021-11-12)
     * Add optional width and height to set for `u-icon` mixin 
 

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "17.2.0",
+  "version": "17.3.0",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/springer/scss/10-settings/keyframes.scss
+++ b/context/brand-context/springer/scss/10-settings/keyframes.scss
@@ -1,0 +1,16 @@
+$context--keyframes: (
+	transparent-to-yellow: (
+		0%: (
+			background: transparent
+		),
+		25%: (
+			background: color('yellow')
+		),
+		75%: (
+			background: color('yellow')
+		),
+		100%: (
+			background: transparent
+		)
+	)
+);

--- a/context/brand-context/springer/scss/abstracts.scss
+++ b/context/brand-context/springer/scss/abstracts.scss
@@ -9,6 +9,7 @@
 @import '10-settings/style';
 @import '10-settings/typography';
 @import '10-settings/buttons';
+@import '10-settings/keyframes';
 
 @import '20-functions/em';
 @import '20-functions/strip-unit';


### PR DESCRIPTION
Adding keyframes to the springer brand it can then be removed from multiple scss files it sits within across oscar article stylesheets