### PR TITLE
Fix page elements bleeding through springernature-modal

### DIFF
--- a/toolkits/springernature/packages/springernature-modal/HISTORY.md
+++ b/toolkits/springernature/packages/springernature-modal/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 3.0.1 (2021-12-02)
+    * Bump brand-context
+    * Fix bug where elements on the page that have a z-index bleed through the modal.
+
 ## 3.0.0 (2021-02-08)
     * BREAKING: switch to use new `brand-context` dependency
     * Update colours keys

--- a/toolkits/springernature/packages/springernature-modal/package.json
+++ b/toolkits/springernature/packages/springernature-modal/package.json
@@ -8,5 +8,5 @@
     "pop-up"
   ],
   "author": "Springer Nature",
-  "brandContext": "^10.0.0"
+  "brandContext": "^17.0.0"
 }

--- a/toolkits/springernature/packages/springernature-modal/package.json
+++ b/toolkits/springernature/packages/springernature-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springernature-modal",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "license": "MIT",
   "description": "Springer Nature branded modal pop-up window",
   "keywords": [

--- a/toolkits/springernature/packages/springernature-modal/scss/50-components/enhanced.scss
+++ b/toolkits/springernature/packages/springernature-modal/scss/50-components/enhanced.scss
@@ -28,7 +28,7 @@
 	&--open {
 		align-items: flex-start;
 		background-color: rgba(0, 0, 0, 0.4);
-		content: '';
+		content: "";
 		display: flex;
 		justify-content: center;
 		overflow-y: scroll;
@@ -37,6 +37,7 @@
 		position: fixed;
 		top: 0;
 		width: 100%;
+		z-index: 99999;
 	}
 
 	&__trigger {


### PR DESCRIPTION
I came across an issue where I had some elements on the page that had
an z-index and these were bleeding through the modal. To overcome this,
I added a z-index to the modal when its in open state and increased the
index to a stupidly high number so its less likely other elements on
the page may ever bleed through again.

![image](https://user-images.githubusercontent.com/3441519/144500889-5b7905f5-8eaf-4313-ad09-68ab8d1ff585.png)

