### PR TITLE
the one that updates version of global-meta brand context version required

### DIFF
--- a/toolkits/global/packages/global-meta/HISTORY.md
+++ b/toolkits/global/packages/global-meta/HISTORY.md
@@ -1,6 +1,8 @@
 # History
 
-## 6.0.02
+## 6.0.02 (2021-12-09)
+    * BUG: Updates the version of the brand context in the package.json file to latest.
+## 6.0.02 (2021-12-09)
     * BUG: Temporary fix for the issue with strip-unit.
 ## 6.0.1 (2021-12-07)
     * BUG: Fixes font sizes that were incorrectly calculated

--- a/toolkits/global/packages/global-meta/HISTORY.md
+++ b/toolkits/global/packages/global-meta/HISTORY.md
@@ -2,7 +2,7 @@
 
 ## 6.0.3 (2021-12-09)
     * BUG: Updates the version of the brand context in the package.json file to latest.
-## 6.0.02 (2021-12-09)
+## 6.0.2 (2021-12-09)
     * BUG: Temporary fix for the issue with strip-unit.
 ## 6.0.1 (2021-12-07)
     * BUG: Fixes font sizes that were incorrectly calculated

--- a/toolkits/global/packages/global-meta/HISTORY.md
+++ b/toolkits/global/packages/global-meta/HISTORY.md
@@ -1,6 +1,6 @@
 # History
 
-## 6.0.02 (2021-12-09)
+## 6.0.3 (2021-12-09)
     * BUG: Updates the version of the brand context in the package.json file to latest.
 ## 6.0.02 (2021-12-09)
     * BUG: Temporary fix for the issue with strip-unit.

--- a/toolkits/global/packages/global-meta/package.json
+++ b/toolkits/global/packages/global-meta/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@springernature/global-meta",
-  "version": "6.0.2",
+  "version": "6.0.1",
   "license": "MIT",
   "description": "Brief information about the content",
   "keywords": [],
   "author": "Springer Nature",
-  "brandContext": "17.0.0"
+  "brandContext": "^18.1.1"
 }

--- a/toolkits/global/packages/global-meta/package.json
+++ b/toolkits/global/packages/global-meta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-meta",
-  "version": "6.0.1",
+  "version": "6.0.3",
   "license": "MIT",
   "description": "Brief information about the content",
   "keywords": [],


### PR DESCRIPTION
We move the version of the `global-meta` component to use an older version of the `brandContext` so that it we could get Travis to pass the tests.

Now we've done that, this PR just updates the version of the Brand Context that should be used to the latest - `18.1.1` 