### PR TITLE
the final? fix for font-sizing

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 18.1.2 (2021-12-10)
+    * BUG
+        * fixes font size set in em, not rem and also thinking root size was 62.5%
+
 ## 18.1.1
     * FEATURE
         * copies the strip-unit function into the default brand context.

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "18.1.1",
+  "version": "18.1.2",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/springer/scss/40-base/layout.scss
+++ b/context/brand-context/springer/scss/40-base/layout.scss
@@ -25,7 +25,7 @@ body {
 	max-width: 100%;
 	min-height: 100%;
 	background: $context--page-background;
-	font-size: 1.8em; /* fixes chrome rems bug - http://stackoverflow.com/questions/20099844/chrome-not-respecting-rem-font-size-on-body-tag */
+	font-size: 1.125rem; /* fixes chrome rems bug - http://stackoverflow.com/questions/20099844/chrome-not-respecting-rem-font-size-on-body-tag */
 }
 
 figure {


### PR DESCRIPTION
Fixes an `em` value that still thinks the root font-size is `62.5%` to a `rem` unit knowing the root font-size is `100%`.

I was so preoccupied with wether or not I had changed all the `rem` values, I didn't stop to think about `em`s. 

![Ian Malcom, from Jurassic Park, gesticulating and saying 'well, there it is.'](https://media.giphy.com/media/11FiDF2fuOujPG/giphy.gif)