### PR TITLE
Block new component packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 > Frontend Component Toolkits for the Elements Design System
 
+**Warning**: Publication of _new_ component packages is currently blocked. Updates to existing components are still permitted.
+
 * [Installation](#installation)
 	* [Using the correct `node` & `npm` versions](#using-the-correct-node--npm-versions)
 	* [Using the correct `sass` version](#using-the-correct-sass-version)

--- a/toolkits/package-manager.json
+++ b/toolkits/package-manager.json
@@ -1,6 +1,6 @@
 {
   "scope": "springernature",
-  "blockNewPackages": false,
+  "blockNewPackages": true,
   "folders": {
     "scss": [
       "scss",


### PR DESCRIPTION
Turn on the option to block the publication of new component packages.
Only updates to existing packages are permitted at this time.