### PR TITLE
Fix styling for non-js

### DIFF
--- a/toolkits/springernature/packages/springernature-user-details/HISTORY.md
+++ b/toolkits/springernature/packages/springernature-user-details/HISTORY.md
@@ -1,5 +1,7 @@
 # History
 
+## 4.0.1 (2022-02-03)
+	* BUG fix - change non-js styling - remove hover color of logout link
 ## 4.0.0 (2021-12-03)
     * BREAKING:
         * Changes all typographic values to accomodate the root font size change.

--- a/toolkits/springernature/packages/springernature-user-details/package.json
+++ b/toolkits/springernature/packages/springernature-user-details/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springernature-user-details",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "license": "MIT",
   "description": "Springer Nature branded logged-in user details component",
   "keywords": [],

--- a/toolkits/springernature/packages/springernature-user-details/scss/50-components/core.scss
+++ b/toolkits/springernature/packages/springernature-user-details/scss/50-components/core.scss
@@ -23,8 +23,6 @@
 	&__links {
 		list-style-type: none;
 		margin: 0;
-		padding: 5px 0 0 0;
-		border-top: 1px solid $separator-color;
 		color: #666;
 	}
 
@@ -33,15 +31,7 @@
 		color: #222;
 	}
 
-	&__last-name {
-		padding-right: 10px;
-	}
-
 	&__logout {
-		&:hover {
-			color: #fff;
-		}
-
 		display: block;
 		font-size: $small-font-size;
 	}

--- a/toolkits/springernature/packages/springernature-user-details/scss/50-components/enhanced.scss
+++ b/toolkits/springernature/packages/springernature-user-details/scss/50-components/enhanced.scss
@@ -24,7 +24,7 @@
 
 	&__content-item {
 		padding: 0 12px;
-		font-size: 12px;
+		font-size: .75rem;
 	}
 
 	&__link {

--- a/toolkits/springernature/packages/springernature-user-details/scss/50-components/enhanced.scss
+++ b/toolkits/springernature/packages/springernature-user-details/scss/50-components/enhanced.scss
@@ -1,40 +1,47 @@
-.c-user-details {
-	.js & {
-		height: 30px;
+.js .c-user-details {
+	height: 30px;
 
-		&__open {
-			@include arrow(map-get($context--colors, medium-blue), down, 4px);
+	&__open {
+		@include arrow(map-get($context--colors, medium-blue), down, 4px);
 
-			margin-left: 10px;
-			right: 0;
-			color: map-get($context--colors, medium-blue);
+		margin-left: 10px;
+		right: 0;
+		color: map-get($context--colors, medium-blue);
 
-			&.open {
-				@include arrow(map-get($context--colors, medium-blue), up, 4px);
-			}
+		&.open {
+			@include arrow(map-get($context--colors, medium-blue), up, 4px);
 		}
+	}
 
-		&__content {
-			position: absolute;
-			z-index: $zindex-level-highest;
-			height: auto;
-			padding: 5px 0;
-			text-align: left;
-			box-shadow: 1px 2px 1px 1px rgba(0, 0, 0, 0.3);
+	&__content {
+		position: absolute;
+		z-index: $zindex-level-highest;
+		height: auto;
+		padding: 5px 0;
+		text-align: left;
+		box-shadow: 1px 2px 1px 1px rgba(0, 0, 0, 0.3);
+	}
+
+	&__content-item {
+		padding: 0 12px;
+		font-size: 12px;
+	}
+
+	&__link {
+		padding: 7px 12px;
+
+		&:hover {
+			background-color: map-get($context--colors, universal-blue);
+			color: map-get($context--colors, white);
 		}
+	}
 
-		&__content-item {
-			padding: 0 12px;
-			font-size: .75rem;
-		}
+	&__links {
+		border-top: 1px solid $separator-color;
+		padding: 5px 0 0 0;
+	}
 
-		&__link {
-			padding: 7px 12px;
-
-			&:hover {
-				background-color: map-get($context--colors, universal-blue);
-				color: map-get($context--colors, white);
-			}
-		}
+	&__last-name {
+		padding-right: 10px;
 	}
 }


### PR DESCRIPTION
For non-js environment, the logout link was the same colour as the background on hover. This style should be in the .js version, as one or two others.

no JS
<img width="140" alt="Screenshot 2022-02-03 at 10 20 32" src="https://user-images.githubusercontent.com/11961647/152325933-e4a4aad3-337c-4e8b-a03d-0500aebb4e74.png">

JS
<img width="323" alt="Screenshot 2022-02-03 at 10 25 03" src="https://user-images.githubusercontent.com/11961647/152325974-de118119-b510-4c1f-b243-1145b98e7008.png">

