### PR TITLE
Font and focus state improvements for SpringerNature-User-Details

### DIFF
--- a/toolkits/springernature/packages/springernature-user-details/HISTORY.md
+++ b/toolkits/springernature/packages/springernature-user-details/HISTORY.md
@@ -1,5 +1,7 @@
 # History
 
+## 4.1.0 (2022-02-08)
+    * Improve button focus state to match other elements that could be focused
 ## 4.0.1 (2022-02-03)
 	* BUG fix - change non-js styling - remove hover color of logout link
 ## 4.0.0 (2021-12-03)

--- a/toolkits/springernature/packages/springernature-user-details/HISTORY.md
+++ b/toolkits/springernature/packages/springernature-user-details/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## 4.1.0 (2022-02-08)
     * Improve button focus state to match other elements that could be focused
+    * Add font family to the component
 ## 4.0.1 (2022-02-03)
 	* BUG fix - change non-js styling - remove hover color of logout link
 ## 4.0.0 (2021-12-03)

--- a/toolkits/springernature/packages/springernature-user-details/README.md
+++ b/toolkits/springernature/packages/springernature-user-details/README.md
@@ -42,6 +42,7 @@ Import the core styles into your main stylesheet
 ```scss
 // core.scss
 @import '@springernature/brand-context/springernature/scss/10-settings/colors/default';
+@import '@springernature/brand-context/default/scss/30-mixins/focus';
 @import '@springernature/springernature-user-details/scss/10-settings/colours';
 @import '@springernature/springernature-user-details/scss/10-settings/typography';
 @import '@springernature/springernature-user-details/scss/50-components/core';

--- a/toolkits/springernature/packages/springernature-user-details/package.json
+++ b/toolkits/springernature/packages/springernature-user-details/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springernature-user-details",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "license": "MIT",
   "description": "Springer Nature branded logged-in user details component",
   "keywords": [],

--- a/toolkits/springernature/packages/springernature-user-details/scss/50-components/core.scss
+++ b/toolkits/springernature/packages/springernature-user-details/scss/50-components/core.scss
@@ -10,6 +10,7 @@
 	}
 
 	&__open {
+		@include u-focus-outline;
 		text-decoration: none;
 		vertical-align: baseline;
 		background: none;

--- a/toolkits/springernature/packages/springernature-user-details/scss/50-components/enhanced.scss
+++ b/toolkits/springernature/packages/springernature-user-details/scss/50-components/enhanced.scss
@@ -1,5 +1,6 @@
 .js .c-user-details {
 	height: 30px;
+	font-family: $context--font-family-sans;
 
 	&__open {
 		@include arrow(map-get($context--colors, medium-blue), down, 4px);


### PR DESCRIPTION
While implementing this component to a few services in OASiS, I came across these two issues with this component.
Firstly there was no focus state on the "button" that the user users to trigger the dropdown. The default focus state being used looks jagged and doesn't match other elements on the page that might be using yellow focus state. 

Another issue related to relying on outside influences to control font family being used for this component. A component should have complete control over how it looks and behaves.

## Before
<img width="606" alt="Screenshot 2022-02-08 at 21 54 31" src="https://user-images.githubusercontent.com/3441519/153082843-8dffd7cd-f1cc-4a9c-a41e-0208349c044d.png">


## After 
<img width="606" alt="Screenshot 2022-02-08 at 21 54 13" src="https://user-images.githubusercontent.com/3441519/153082863-aad1081c-980a-464f-bcb5-19b2cf829924.png">



- Fixes issue with focus state for SpringerNature-User-Details component
- Sets the font family needed for SpringerNature-User-Details component