### PR TITLE
Add missing functions and mixins to default brand abstracts

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 20.0.1 (2022-02-09)
+    * BUG
+        * Add missing functions and mixins to default branding abstracts  
 ## 20.0.0 (2022-01-14)
     * BREAKING
         * Switch SASS compiler from Node Sass to Dart Sass

--- a/context/brand-context/default/scss/abstracts.scss
+++ b/context/brand-context/default/scss/abstracts.scss
@@ -22,7 +22,9 @@
 @import '20-functions/layers';
 @import '20-functions/spacing';
 @import '20-functions/strip-unit';
+@import '20-functions/url-encode';
 
+@import '30-mixins/arrow';
 @import '30-mixins/buttons';
 @import '30-mixins/clearfix';
 @import '30-mixins/container';

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "20.0.0",
+  "version": "20.0.1",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],


### PR DESCRIPTION
While implementing SpringerNature brand-context to OASiS I discovered
that some functions and mixins where not being included in the abstract
mean that a developer would have to manually import these functions.