### PR TITLE
global-grid: update bourbon-neat v2 to v4

### DIFF
--- a/toolkits/global/packages/global-grid/HISTORY.md
+++ b/toolkits/global/packages/global-grid/HISTORY.md
@@ -1,5 +1,6 @@
 # History
-
+## 2.0.0 (2022-02-17)
+    * Update bourbon-neat peerDependency version from min v2 to v4
 ## 1.0.0 (2019-02-05)
 	* Make bourbon-neat a peerDependency
 	* Use relative sass imports

--- a/toolkits/global/packages/global-grid/README.md
+++ b/toolkits/global/packages/global-grid/README.md
@@ -2,12 +2,12 @@
 
 This module makes available tools for building a classic grid system (note: nothing to do with the CSS Grid spec, for now).
 
-You need to install `bourbon-neat` version `2.0.0` or higher at the same level as this component e.g.
+You need to install `bourbon-neat` version `4.0.0` or higher at the same level as this component e.g.
 
 ```json
 "devDependencies": {
-  "@springernature/global-grid": "^1.0.0",
-  "bourbon-neat": "^2.0.0"
+  "@springernature/global-grid": "^2.0.0",
+  "bourbon-neat": "^4.0.0"
 }
 ```
 

--- a/toolkits/global/packages/global-grid/package.json
+++ b/toolkits/global/packages/global-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-grid",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "license": "MIT",
   "description": "css layout pattern",
   "keywords": [
@@ -10,6 +10,6 @@
   ],
   "author": "Charlie Owen",
   "peerDependencies": {
-    "bourbon-neat": "^2.0.0"
+    "bourbon-neat": "^4.0.0"
   }
 }


### PR DESCRIPTION
v2 causes an issue when used with dart-sass as there is a [syntax error with one of the @warns](https://github.com/thoughtbot/neat/blob/2bde983e693a05edce1acc128ebb278e9058c7dc/core/neat/mixins/_grid-container.scss#L22-L23)

This issue was fixed in [v3](https://github.com/thoughtbot/neat/blob/2bde983e693a05edce1acc128ebb278e9058c7dc/core/neat/mixins/_grid-container.scss#L22-L23).

Seeing as bourbon-neat hasn't been updated for years it seems practical to use the last latest release