### PR TITLE
Springernature: remove `post-install` step from `package.json`

### DIFF
--- a/toolkits/springernature/packages/springernature-forms/HISTORY.md
+++ b/toolkits/springernature/packages/springernature-forms/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 1.0.1 (2022-02-18)
+    * Remove post install step that was causing issues with CI
+
 ## 1.0.0 (2021-12-03)
     * BREAKING:
         * Changes all typographic values to accomodate the root font size change.

--- a/toolkits/springernature/packages/springernature-forms/package.json
+++ b/toolkits/springernature/packages/springernature-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springernature-forms",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "description": "Springer Nature branded styles for text, checkbox, radio button, textarea and select inputs",
   "keywords": [],

--- a/toolkits/springernature/packages/springernature-header/HISTORY.md
+++ b/toolkits/springernature/packages/springernature-header/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 3.0.2 (2022-02-18)
+    * Remove post install step that was causing issues with CI
+
 ## 3.0.1 (2021-12-10)
     * BUG:
       * Updates line-height rem value to be correct for root font-size changes in v18 of Brand Context

--- a/toolkits/springernature/packages/springernature-header/package.json
+++ b/toolkits/springernature/packages/springernature-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springernature-header",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "license": "MIT",
   "description": "Springer Nature branded header component",
   "keywords": [],

--- a/toolkits/springernature/packages/springernature-modal/HISTORY.md
+++ b/toolkits/springernature/packages/springernature-modal/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 4.0.1 (2022-02-18)
+    * Remove post install step that was causing issues with CI
+
 ## 4.0.0 (2021-12-03)
     * BREAKING:
         * Changes all typographic values to accomodate the root font size change.

--- a/toolkits/springernature/packages/springernature-modal/package.json
+++ b/toolkits/springernature/packages/springernature-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springernature-modal",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "license": "MIT",
   "description": "Springer Nature branded modal pop-up window",
   "keywords": [

--- a/toolkits/springernature/packages/springernature-submission-header/HISTORY.md
+++ b/toolkits/springernature/packages/springernature-submission-header/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 1.1.1 (2022-02-18)
+    * Remove post install step that was causing issues with CI
+
 ## 1.1.0 (2022-19-01)
 	* Adds some styling for invalid email addresses
 

--- a/toolkits/springernature/packages/springernature-submission-header/package.json
+++ b/toolkits/springernature/packages/springernature-submission-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springernature-submission-header",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "description": "Springer Nature branded submission details component",
   "keywords": [],

--- a/toolkits/springernature/packages/springernature-user-details/HISTORY.md
+++ b/toolkits/springernature/packages/springernature-user-details/HISTORY.md
@@ -1,13 +1,19 @@
 # History
 
+## 4.1.1 (2022-02-18)
+    * Remove post install step that was causing issues with CI
+
 ## 4.1.0 (2022-02-08)
     * Improve button focus state to match other elements that could be focused
     * Add font family to the component
+
 ## 4.0.1 (2022-02-03)
 	* BUG fix - change non-js styling - remove hover color of logout link
+
 ## 4.0.0 (2021-12-03)
     * BREAKING:
         * Changes all typographic values to accomodate the root font size change.
+
 ## 3.0.0 (2021-07-28)
     * BREAKING: switch to use newer version `brand-context`, and use updated colours
 

--- a/toolkits/springernature/packages/springernature-user-details/package.json
+++ b/toolkits/springernature/packages/springernature-user-details/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springernature-user-details",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "license": "MIT",
   "description": "Springer Nature branded logged-in user details component",
   "keywords": [],


### PR DESCRIPTION
During the publication of packages, we previously added a `post-install` step to provide messaging around the use of the `brand-context` package. This functionality has [now been removed](https://github.com/springernature/frontend-package-manager/pull/81) due to causing issues in our CI environments.

In order to remove this from published packages, we need to publish new versions of each package - no code changes are needed as the `post-install` was added via the `frontend-package-manager`, and a new version will now just miss out that step.

This PR bumps the version for each package in the Springer Nature toolkit.