### PR TITLE
Springer: remove `post-install` step from `package.json`

### DIFF
--- a/toolkits/springer/packages/springer-dropdown/HISTORY.md
+++ b/toolkits/springer/packages/springer-dropdown/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 6.1.1 (2022-02-18)
+    * Remove post install step that was causing issues with CI
+
 ## 6.1.0 (2021-09-10)
     * Demo, including consumable handlebars template
 

--- a/toolkits/springer/packages/springer-dropdown/package.json
+++ b/toolkits/springer/packages/springer-dropdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-dropdown",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "license": "MIT",
   "description": "Display a contextual list of links controlled by a toggle",
   "keywords": [],

--- a/toolkits/springer/packages/springer-header/HISTORY.md
+++ b/toolkits/springer/packages/springer-header/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 7.0.1 (2022-02-18)
+    * Remove post install step that was causing issues with CI
+
 ## 7.0.0 (2021-01-12)
     * Optional search form and corresponding menu link
 

--- a/toolkits/springer/packages/springer-header/package.json
+++ b/toolkits/springer/packages/springer-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-header",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "license": "MIT",
   "description": "Publisher level header",
   "keywords": [],

--- a/toolkits/springer/packages/springer-hero/HISTORY.md
+++ b/toolkits/springer/packages/springer-hero/HISTORY.md
@@ -1,4 +1,7 @@
 # History
 
+## 0.1.1 (2022-02-18)
+    * Remove post install step that was causing issues with CI
+
 ## 0.1.0 (2021-12-07)
     * Added new Springer hero component

--- a/toolkits/springer/packages/springer-hero/package.json
+++ b/toolkits/springer/packages/springer-hero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-hero",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "description": "A hero component, principally for subject/discipline pages",
   "keywords": [],

--- a/toolkits/springer/packages/springer-listing/HISTORY.md
+++ b/toolkits/springer/packages/springer-listing/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 5.0.2 (2022-02-18)
+    * Remove post install step that was causing issues with CI
+
 ## 5.0.1 (2021-01-11)
     * Demo icon to `currentColor`
 

--- a/toolkits/springer/packages/springer-listing/package.json
+++ b/toolkits/springer/packages/springer-listing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-listing",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "license": "MIT",
   "description": "Display of scannable content typically within a list",
   "keywords": [],

--- a/toolkits/springer/packages/springer-media/HISTORY.md
+++ b/toolkits/springer/packages/springer-media/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 6.0.2 (2022-02-18)
+    * Remove post install step that was causing issues with CI
+
 ## 6.0.1 (2022-02-16)
     * Revisit README.md to meet latest guideline    
     * Enhance demo with more examples

--- a/toolkits/springer/packages/springer-media/package.json
+++ b/toolkits/springer/packages/springer-media/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-media",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "license": "MIT",
   "description": "A media component catering for an image, title and body text. Styles have also been included to add a play button for things like videos.",
   "keywords": [],

--- a/toolkits/springer/packages/springer-product-header/HISTORY.md
+++ b/toolkits/springer/packages/springer-product-header/HISTORY.md
@@ -1,3 +1,8 @@
+# History
+
+## 2.0.1 (2022-02-18)
+    * Remove post install step that was causing issues with CI
+
 ## 2.0.0 (2021-12-10)
     * BREAKING:
       * Bumps Brand Context depdendency to v18 which changes root font-size

--- a/toolkits/springer/packages/springer-product-header/package.json
+++ b/toolkits/springer/packages/springer-product-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-product-header",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "description": "Springer Product Header",
   "keywords": [],

--- a/toolkits/springer/packages/springer-publisher-footer/HISTORY.md
+++ b/toolkits/springer/packages/springer-publisher-footer/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 5.0.2 (2022-02-18)
+    * Remove post install step that was causing issues with CI
+
 ## 5.0.1 (2021-11-30)
     * BUG: images not rendering in demo
 

--- a/toolkits/springer/packages/springer-publisher-footer/package.json
+++ b/toolkits/springer/packages/springer-publisher-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-publisher-footer",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "license": "MIT",
   "description": "Springer branded site footer",
   "keywords": [],

--- a/toolkits/springer/packages/springer-user-metadata/HISTORY.md
+++ b/toolkits/springer/packages/springer-user-metadata/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 5.1.2 (2022-02-18)
+    * Remove post install step that was causing issues with CI
+
 ## 5.1.1 (2021-10-23)
     * Safer prop name for url
 

--- a/toolkits/springer/packages/springer-user-metadata/package.json
+++ b/toolkits/springer/packages/springer-user-metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-user-metadata",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "license": "MIT",
   "description": "Meta data for user such as login status, ip address, business partner associations and chinese icp licence status",
   "keywords": [],

--- a/toolkits/springer/packages/springer-webfonts/HISTORY.md
+++ b/toolkits/springer/packages/springer-webfonts/HISTORY.md
@@ -1,3 +1,8 @@
+# History
+
+## 1.0.3 (2022-02-18)
+    * Remove post install step that was causing issues with CI
+
 ## 1.0.2 (2020-03-04)
 	* Changes where we catch font face observer load rejected promises as needs to be caught on obersver.load() calls
 

--- a/toolkits/springer/packages/springer-webfonts/package.json
+++ b/toolkits/springer/packages/springer-webfonts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-webfonts",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "MIT",
   "description": "For loading webfonts",
   "keywords": [],


### PR DESCRIPTION
During the publication of packages, we previously added a `post-install` step to provide messaging around the use of the `brand-context` package. This functionality has [now been removed](https://github.com/springernature/frontend-package-manager/pull/81) due to causing issues in our CI environments.

In order to remove this from published packages, we need to publish new versions of each package - no code changes are needed as the `post-install` was added via the `frontend-package-manager`, and a new version will now just miss out that step.

This PR bumps the version for each package in the **Springer** toolkit.