### PR TITLE
Put back --flush modifier to reset padding in the card__body

### DIFF
--- a/toolkits/global/packages/global-card/HISTORY.md
+++ b/toolkits/global/packages/global-card/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 8.1.1 (2022-02-18)
+    * Add back modifier .c-card--flush to reset padding
+
 ## 8.1.0 (2022-02-09)
     * Option not to have images
     * Removed universal color from default since it is not available universally yet
@@ -13,6 +16,7 @@
 
 ## 7.0.1
     * wraps the aspect ratio variable declarion with Sass interpolation to work with Dart Sass
+
 ## 7.0.0 (2021-12-29)
     * BREAKING:
         * Template moved to `/view`

--- a/toolkits/global/packages/global-card/package.json
+++ b/toolkits/global/packages/global-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-card",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "license": "MIT",
   "description": "card component",
   "keywords": [

--- a/toolkits/global/packages/global-card/package.json
+++ b/toolkits/global/packages/global-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-card",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "license": "MIT",
   "description": "card component",
   "keywords": [

--- a/toolkits/global/packages/global-card/scss/50-components/card.scss
+++ b/toolkits/global/packages/global-card/scss/50-components/card.scss
@@ -101,6 +101,12 @@
 // modifiers
 // ---------
 
+.c-card--flush {
+	.c-card__body {
+		padding: 0;
+	}
+}
+
 // --major
 .c-card--major {
 	font-size: $card--major-font-size;


### PR DESCRIPTION
I found out this class is hugely used across different nature pages so we need it to put it back. 