### PR TITLE
Fix focus of autocomplete items for NVDA with Firefox (Windows)

### DIFF
--- a/toolkits/global/packages/global-autocomplete/HISTORY.md
+++ b/toolkits/global/packages/global-autocomplete/HISTORY.md
@@ -1,5 +1,11 @@
 # History
 
+## 5.1.4 (2022-02-25)
+    * BUG: unable to move focus to select autocomplete items when using NVDA with Firefox (Windows) 
+        * add role="listbox" to parent container of autocomplete items
+        * add role="option" to each autocomplete item  
+    * Change tabIndex value from string to integer
+
 ## 5.1.3 (2022-02-18)
     * Remove post install step that was causing issues with CI
 

--- a/toolkits/global/packages/global-autocomplete/demo/dist/index.html
+++ b/toolkits/global/packages/global-autocomplete/demo/dist/index.html
@@ -236,6 +236,7 @@ const showResults = results => {
 
 	const resultsContainer = document.createElement('div');
 	resultsContainer.className = 'c-results-container';
+	resultsContainer.setAttribute('role', 'listbox');
 
 	// Assuming results is an array
 	if(results.length === 0) {
@@ -244,8 +245,9 @@ const showResults = results => {
 	results.forEach(datum => {
 		const result = document.createElement('div');
 		result.textContent = datum;
-		result.tabIndex = '0'; // So you can focus/tab through the results
+		result.tabIndex = 0; // So you can focus/tab through the results
 		result.className = 'c-results-container__result';
+		result.setAttribute('role', 'option');
 		resultsContainer.appendChild(result);
 	});
 	document.querySelector('[data-component-autocomplete]').insertAdjacentElement('afterend', resultsContainer);

--- a/toolkits/global/packages/global-autocomplete/demo/main.js
+++ b/toolkits/global/packages/global-autocomplete/demo/main.js
@@ -8,6 +8,7 @@ const showResults = results => {
 
 	const resultsContainer = document.createElement('div');
 	resultsContainer.className = 'c-results-container';
+	resultsContainer.setAttribute('role', 'listbox');
 
 	// Assuming results is an array
 	if(results.length === 0) {
@@ -16,8 +17,9 @@ const showResults = results => {
 	results.forEach(datum => {
 		const result = document.createElement('div');
 		result.textContent = datum;
-		result.tabIndex = '0'; // So you can focus/tab through the results
+		result.tabIndex = 0; // So you can focus/tab through the results
 		result.className = 'c-results-container__result';
+		result.setAttribute('role', 'option');
 		resultsContainer.appendChild(result);
 	});
 	document.querySelector('[data-component-autocomplete]').insertAdjacentElement('afterend', resultsContainer);

--- a/toolkits/global/packages/global-autocomplete/package.json
+++ b/toolkits/global/packages/global-autocomplete/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-autocomplete",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "license": "MIT",
   "description": "Autocomplete/suggest component",
   "keywords": [],


### PR DESCRIPTION
  * BUG: unable to move focus to select autocomplete items when using NVDA with Firefox (Windows) 
      * add role="listbox" to parent container of autocomplete items
      * add role="option" to each autocomplete item  
  * Change tabIndex value from string to integer