### PR TITLE
Updates nature components to ensure no post-install step

### DIFF
--- a/toolkits/nature/packages/nature-footer/HISTORY.md
+++ b/toolkits/nature/packages/nature-footer/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 2.1.1 (2022-03-10)
+    * Remove post install step that was causing issues with CI
+
 ## 2.1.0 (2022-02-02)
     * FEATURE: add view template and demo
 

--- a/toolkits/nature/packages/nature-footer/package.json
+++ b/toolkits/nature/packages/nature-footer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@springernature/nature-footer",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "license": "MIT",
     "description": "Nature branded footer",
     "keywords": [],

--- a/toolkits/nature/packages/nature-header/HISTORY.md
+++ b/toolkits/nature/packages/nature-header/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 7.1.3 (2022-03-10)
+    * Remove post install step that was causing issues with CI
+
 ## 7.1.2 (2022-02-23)
     * Remove screenshots from README
 

--- a/toolkits/nature/packages/nature-header/package.json
+++ b/toolkits/nature/packages/nature-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/nature-header",
-  "version": "7.1.2",
+  "version": "7.1.3",
   "license": "MIT",
   "description": "Publisher level header",
   "keywords": [],

--- a/toolkits/nature/packages/nature-hero/HISTORY.md
+++ b/toolkits/nature/packages/nature-hero/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 2.1.3 (2022-03-10)
+    * Remove post install step that was causing issues with CI
+
 ## 2.1.2 (2022-02-10)
     * BUG: Image not displaying on demo
 

--- a/toolkits/nature/packages/nature-hero/package.json
+++ b/toolkits/nature/packages/nature-hero/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@springernature/nature-hero",
-    "version": "2.1.2",
+    "version": "2.1.3",
     "license": "MIT",
     "description": "The Nature Hero component appears at the top of the page on all Nature journal sites.",
     "keywords": [],

--- a/toolkits/nature/packages/nature-section-heading/HISTORY.md
+++ b/toolkits/nature/packages/nature-section-heading/HISTORY.md
@@ -1,7 +1,10 @@
 # History
 
+## 1.1.3 (2022-03-10)
+    * Remove post install step that was causing issues with CI
+
 ## 1.1.2 (2022-02-23)
-Remove screenshots from README
+    * Remove screenshots from README
 
 ## 1.1.1 (2022-02-07)
     * Update images in section heading README

--- a/toolkits/nature/packages/nature-section-heading/package.json
+++ b/toolkits/nature/packages/nature-section-heading/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/nature-section-heading",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "license": "MIT",
   "description": "Nature Section Heading",
   "keywords": [],

--- a/toolkits/nature/packages/nature-sort-by/HISTORY.md
+++ b/toolkits/nature/packages/nature-sort-by/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 3.0.1 (2022-03-10)
+    * Remove post install step that was causing issues with CI
+
 ## 3.0.0 (2022-02-14)
     * BREAKING: Performs a complete rewrite of the component. Component no longer is a dropdown, now simpler implementation with radio buttons in a form.
 

--- a/toolkits/nature/packages/nature-sort-by/package.json
+++ b/toolkits/nature/packages/nature-sort-by/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/nature-sort-by",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "license": "MIT",
   "description": "Nature sort by ui dropdown",
   "keywords": [],


### PR DESCRIPTION
This is needed to remove the post-install step during package publication, as npx commands for `@springernature/util-context-warning` cause issues in CI