### PR TITLE
Share Springer Nature Corporate colours globally

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 20.0.3 (2022-03-11)
+    * PATCH: share SN corporate colours via the default context. Non-destructive.
+
 ## 20.0.2 (2022-02-16)
     * Updates strip unit function and triangle mixin in brand context to use Dart Sass syntax for math
 

--- a/context/brand-context/default/scss/10-settings/colors/shared.scss
+++ b/context/brand-context/default/scss/10-settings/colors/shared.scss
@@ -6,3 +6,8 @@
 
 // Open Access
 $context--open-access-color: #b74616;
+
+// Springer Nature Corporate colours
+$context--universal-blue: #01324b;
+$context--grey-blue-light1: #ebf1f5;
+$context--grey-blue-light2: #cedbe0;

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "20.0.2",
+  "version": "20.0.3",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/springernature/scss/10-settings/colors/default.scss
+++ b/context/brand-context/springernature/scss/10-settings/colors/default.scss
@@ -29,9 +29,9 @@ $context--colors: (
 	'research-orange': #c75301,
 
 	// SN Corporate colours
-	'universal-blue': #01324b,
-	'grey-blue-light1': #ebf1f5,
-	'grey-blue-light2': #cedbe0
+	'universal-blue': $context--universal-blue,
+	'grey-blue-light1': $context--grey-blue-light1,
+	'grey-blue-light2': $context--grey-blue-light2
 );
 
 $context--page-background-color: color('grey-light1');


### PR DESCRIPTION
The Springer Nature Corporate colours used to live in the `springernature` brand context. For the new `global-corporate-footer` they need to be available to all brands.

This PR moves the colours to `colors/shared.scss` in the default brand context, then references them directly in the `springernature` brand context so as to make this a non-destructive change.