### PR TITLE
Fix SpringerNature breakpoints so theres no conflict between Default and SpringerNature components

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,4 +1,7 @@
 # History
+## 22.0.0 (2022-05-24)
+    * BREAKING
+      * Updates SpringerNature brand-context breakpoints keys to match default brand-context 
 ## 21.1.1 (2022-05-23)
     * Left aligns basic lists in the springer context
 ## 21.1.0 (2022-05-10)
@@ -46,7 +49,6 @@
     * FEATURE: adds javascript helpers for use in components
         * Includes helpers that used to live in `global-javascript`
         * Includes code that used to live in `global-expander`
-
 ## 20.0.3 (2022-03-11)
     * PATCH: share SN corporate colours via the default context. Non-destructive.
 

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "21.1.1",
+  "version": "22.0.0",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/springernature/scss/10-settings/breakpoints.scss
+++ b/context/brand-context/springernature/scss/10-settings/breakpoints.scss
@@ -4,8 +4,9 @@
  */
 
 $context--breakpoints: (
-	'tablet-width': 480px,
-	'tablet-wide-width': 768px,
-	'wide-layout': 876px,
-	'desktop-width': 1024px
+	'xs': 480px, // formly  'tablet-width'
+	'sm': 768px, // formly 'tablet-wide-width'
+	'md': 876px, // formly 'wide-layout'
+	'lg': 1024px, // formly 'desktop-width'
+	'xl': 1220px
 );


### PR DESCRIPTION
Related to https://github.com/springernature/frontend-open-space/issues/307

This open space issue was discussed 17/03/2022. 

Any thoughts about this change? Is it something we could merge?


