### PR TITLE
Move shared javascript into the brand-context

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,7 +1,7 @@
 # History
 
 ## 20.1.0 (2022-03-25)
-    * FEATURE: new javascript helpers for use in components
+    * FEATURE: adds javascript helpers for use in components
         * Includes helpers that used to live in `global-javascript`
         * Includes code that used to live in `global-expander`
 

--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,5 +1,10 @@
 # History
 
+## 20.1.0 (2022-03-25)
+    * FEATURE: new javascript helpers for use in components
+        * Includes helpers that used to live in `global-javascript`
+        * Includes code that used to live in `global-expander`
+
 ## 20.0.3 (2022-03-11)
     * PATCH: share SN corporate colours via the default context. Non-destructive.
 

--- a/context/brand-context/default/README.md
+++ b/context/brand-context/default/README.md
@@ -10,6 +10,7 @@ Use this context configuration in your product to skin components with the `defa
 - [Buttons](#buttons)
 - [Layers](#layers)
 - [Icons](#icons)
+- [Javascript](#javascript)
 
 ## Breakpoints
 
@@ -319,3 +320,6 @@ There is a recommendation that [SVG sprites](https://css-tricks.com/svg-sprites-
 For further information on the various implementation methods, please read this article https://css-tricks.com/pretty-good-svg-icon-system/
 
 The Icons have been optimised, you should not need to optimise them further.
+
+## Javascript
+The `brand-context` comes with a number of [Javascript helpers](https://github.com/springernature/frontend-toolkits/tree/master/context/brand-context/default/js/README.md) that can be used within your product.

--- a/context/brand-context/default/__tests__/unit/dom/expander/expander.spec.js
+++ b/context/brand-context/default/__tests__/unit/dom/expander/expander.spec.js
@@ -1,0 +1,606 @@
+import {Expander} from '../../../../js/helpers/dom/expander/_expander';
+
+/**
+ * Constants
+ */
+
+const className = {
+	HIDE: 'u-js-hide',
+	OPEN: 'is-open'
+};
+
+const createKeydownEvent = key => {
+	const event = new Event('keydown', {
+		bubbles: true
+	});
+
+	switch (key) {
+		case 'Enter':
+			event.key = 'Enter';
+			break;
+		case 'Space':
+			event.key = ' ';
+			break;
+		case 'Spacebar':
+			event.key = 'Spacebar';
+			break;
+		case 'Escape':
+			event.key = 'Escape';
+			break;
+		case 'TabShift':
+			event.key = 'Tab';
+			event.shiftKey = true;
+			break;
+		case 'Tab':
+			event.key = 'Tab';
+			event.shiftKey = false;
+			break;
+		default:
+			throw new Error('key should be "Enter", " " (Space), "Spacebar", "Escape" or "Tab"');
+	}
+
+	return event;
+};
+
+describe('Expander', () => {
+	const element = {};
+
+	beforeEach(() => {
+		document.body.innerHTML = `
+			<button data-expander data-expander-target="#unique">Expander</button>
+			<div id="unique" class=${className.HIDE} hidden>
+				<a href="#">First tabbable element</a>
+				<a href="#">Last tabbable element</a>
+			</div>
+		`;
+
+		element.BUTTON = document.querySelector('button');
+		element.TARGET = document.querySelector('div');
+		element.TABBABLES = document.querySelector('#unique').children;
+		element.FIRSTTABBABLE = element.TABBABLES[0];
+		element.LASTTABBABLE = element.TABBABLES[element.TABBABLES.length - 1];
+	});
+
+	describe('Expander Class Definition', () => {
+		/**
+		 * Helpers
+		 */
+		const clickButtonTwice = () => {
+			for (let i = 0; i < 2; i++) {
+				element.BUTTON.click();
+			}
+		};
+
+		const pressEnterKeyTwice = () => {
+			for (let i = 0; i < 2; i++) {
+				const keydownEnterEvent = createKeydownEvent('Enter');
+				element.BUTTON.dispatchEvent(keydownEnterEvent);
+			}
+		};
+
+		const pressSpaceKeyTwice = () => {
+			for (let i = 0; i < 2; i++) {
+				const keydownSpaceEvent = createKeydownEvent('Space');
+				element.BUTTON.dispatchEvent(keydownSpaceEvent);
+			}
+		};
+
+		let linkButtonElement = document.createElement('a');
+		linkButtonElement.setAttribute('role', 'button');
+		linkButtonElement.setAttribute('href', '#anchor');
+		linkButtonElement.textContent = 'link anchor button';
+
+		test('Should open when button is clicked', () => {
+			// Given
+			const expander = new Expander(element.BUTTON, element.TARGET);
+			expander.init();
+			// When
+			element.BUTTON.click();
+			// Then
+			expect(element.BUTTON.classList.contains(className.OPEN)).toBe(true);
+			expect(element.TARGET.classList.contains(className.HIDE)).toBe(false);
+			expect(element.TARGET.hasAttribute('hidden')).toBe(false);
+		});
+
+		test('Should open when enter key is pressed', () => {
+			// Given
+			const expander = new Expander(element.BUTTON, element.TARGET);
+			expander.init();
+			// When
+			const keydownEnterEvent = createKeydownEvent('Enter');
+			element.BUTTON.dispatchEvent(keydownEnterEvent);
+			// Then
+			expect(element.BUTTON.classList.contains(className.OPEN)).toBe(true);
+			expect(element.TARGET.classList.contains(className.HIDE)).toBe(false);
+			expect(element.TARGET.hasAttribute('hidden')).toBe(false);
+		});
+
+		test('Should open when space key is pressed on native button', () => {
+			// Given
+			const expander = new Expander(element.BUTTON, element.TARGET);
+			expander.init();
+			// When
+			const keydownSpaceEvent = createKeydownEvent('Space');
+			element.BUTTON.dispatchEvent(keydownSpaceEvent);
+			// Then
+			expect(element.BUTTON.classList.contains(className.OPEN)).toBe(true);
+			expect(element.TARGET.classList.contains(className.HIDE)).toBe(false);
+			expect(element.TARGET.hasAttribute('hidden')).toBe(false);
+		});
+
+		test('Should open when space key is pressed on anchor link button', () => {
+			// Given
+			element.BUTTON.outerHTML = linkButtonElement;
+			const expander = new Expander(element.BUTTON, element.TARGET);
+			expander.init();
+			// When
+			const keydownSpaceEvent = createKeydownEvent('Space');
+			element.BUTTON.dispatchEvent(keydownSpaceEvent);
+			// Then
+			expect(element.BUTTON.classList.contains(className.OPEN)).toBe(true);
+			expect(element.TARGET.classList.contains(className.HIDE)).toBe(false);
+			expect(element.TARGET.hasAttribute('hidden')).toBe(false);
+		});
+
+		test('Should open when spacebar key is pressed on anchor link button', () => {
+			// Given
+			element.BUTTON.outerHTML = linkButtonElement;
+			const expander = new Expander(element.BUTTON, element.TARGET);
+			expander.init();
+			// When
+			const keydownSpaceEvent = createKeydownEvent('Spacebar');
+			element.BUTTON.dispatchEvent(keydownSpaceEvent);
+			// Then
+			expect(element.BUTTON.classList.contains(className.OPEN)).toBe(true);
+			expect(element.TARGET.classList.contains(className.HIDE)).toBe(false);
+			expect(element.TARGET.hasAttribute('hidden')).toBe(false);
+		});
+
+		test('Should close when button is clicked a second time', () => {
+			// Given
+			const expander = new Expander(element.BUTTON, element.TARGET);
+			expander.init();
+			// When
+			clickButtonTwice();
+			// Then
+			expect(element.BUTTON.classList.contains(className.OPEN)).toBe(false);
+			expect(element.TARGET.classList.contains(className.HIDE)).toBe(true);
+			expect(element.TARGET.hasAttribute('hidden')).toBe(true);
+		});
+
+		test('Should close when enter key is pressed a second time', () => {
+			// Given
+			const expander = new Expander(element.BUTTON, element.TARGET);
+			expander.init();
+			// When
+			pressEnterKeyTwice();
+			// Then
+			expect(element.BUTTON.classList.contains(className.OPEN)).toBe(false);
+			expect(element.TARGET.classList.contains(className.HIDE)).toBe(true);
+			expect(element.TARGET.hasAttribute('hidden')).toBe(true);
+		});
+
+		test('Should close when space key is pressed a second time', () => {
+			// Given
+			const expander = new Expander(element.BUTTON, element.TARGET);
+			expander.init();
+			// When
+			pressSpaceKeyTwice();
+			// Then
+			expect(element.BUTTON.classList.contains(className.OPEN)).toBe(false);
+			expect(element.TARGET.classList.contains(className.HIDE)).toBe(true);
+			expect(element.TARGET.hasAttribute('hidden')).toBe(true);
+		});
+
+		test('Should close when space key is pressed a second time on anchor link button', () => {
+			// Given
+			element.BUTTON.outerHTML = linkButtonElement;
+			const expander = new Expander(element.BUTTON, element.TARGET);
+			expander.init();
+			// When
+			pressSpaceKeyTwice();
+			// Then
+			expect(element.BUTTON.classList.contains(className.OPEN)).toBe(false);
+			expect(element.TARGET.classList.contains(className.HIDE)).toBe(true);
+			expect(element.TARGET.hasAttribute('hidden')).toBe(true);
+		});
+
+		test('Should set href attribute on anchor link button', () => {
+			// Given
+			element.BUTTON = linkButtonElement;
+			const expander = new Expander(element.BUTTON, element.TARGET);
+			// When
+			expander.init();
+			// Then
+			expect(element.BUTTON.getAttribute('href')).toBe('javascript:;');
+		});
+
+		test('Should not set href attribute on native button', () => {
+			// Given
+			const expander = new Expander(element.BUTTON, element.TARGET);
+			// When
+			expander.init();
+			// Then
+			expect(element.BUTTON.hasAttribute('href')).toBe(false);
+		});
+
+		test('Should set aria attributes when button is clicked', () => {
+			// Given
+			const expander = new Expander(element.BUTTON, element.TARGET);
+			expander.init();
+			element.BUTTON.setAttribute('aria-expanded', 'false');
+			// When
+			element.BUTTON.click();
+			// Then
+			expect(element.BUTTON.getAttribute('aria-expanded')).toBe('true');
+		});
+
+		test('Should set aria attributes when enter key is pressed', () => {
+			// Given
+			const expander = new Expander(element.BUTTON, element.TARGET);
+			expander.init();
+			element.BUTTON.setAttribute('aria-expanded', 'false');
+			// When
+			const keydownEnterEvent = createKeydownEvent('Enter');
+			element.BUTTON.dispatchEvent(keydownEnterEvent);
+			// Then
+			expect(element.BUTTON.getAttribute('aria-expanded')).toBe('true');
+		});
+
+		test('Should set aria attributes when space key is pressed on anchor link button', () => {
+			// Given
+			element.BUTTON.outerHTML = linkButtonElement;
+			const expander = new Expander(element.BUTTON, element.TARGET);
+			expander.init();
+			element.BUTTON.setAttribute('aria-expanded', 'false');
+			// When
+			const keydownEnterEvent = createKeydownEvent('Enter');
+			element.BUTTON.dispatchEvent(keydownEnterEvent);
+			// Then
+			expect(element.BUTTON.getAttribute('aria-expanded')).toBe('true');
+		});
+
+		test('Should unset aria attributes when button is clicked a second time', () => {
+			// Given
+			const expander = new Expander(element.BUTTON, element.TARGET);
+			expander.init();
+			element.BUTTON.setAttribute('aria-expanded', 'false');
+			// When
+			clickButtonTwice();
+			// Then
+			expect(element.BUTTON.getAttribute('aria-expanded')).toBe('false');
+		});
+
+		test('Should unset aria attributes when enter key is pressed a second time', () => {
+			// Given
+			const expander = new Expander(element.BUTTON, element.TARGET);
+			expander.init();
+			element.BUTTON.setAttribute('aria-expanded', 'false');
+			// When
+			pressEnterKeyTwice();
+			// Then
+			expect(element.BUTTON.getAttribute('aria-expanded')).toBe('false');
+		});
+
+		test('Should unset aria attributes when space key is pressed a second time', () => {
+			// Given
+			const expander = new Expander(element.BUTTON, element.TARGET);
+			expander.init();
+			element.BUTTON.setAttribute('aria-expanded', 'false');
+			// When
+			pressSpaceKeyTwice();
+			// Then
+			expect(element.BUTTON.getAttribute('aria-expanded')).toBe('false');
+		});
+
+		test('Should make target element focusable and focus on it when button is clicked and AUTOFOCUS: target', () => {
+			// Given
+			const expander = new Expander(element.BUTTON, element.TARGET, {
+				AUTOFOCUS: 'target'
+			});
+			expander.init();
+			// When
+			element.BUTTON.click();
+			// Then
+			expect(element.TARGET).toEqual(document.activeElement);
+		});
+
+		test('Should make target element focusable and focus on it when enter key is pressed and AUTOFOCUS: target', () => {
+			// Given
+			const expander = new Expander(element.BUTTON, element.TARGET, {
+				AUTOFOCUS: 'target'
+			});
+			expander.init();
+			// When
+			const keydownEnterEvent = createKeydownEvent('Enter');
+			element.BUTTON.dispatchEvent(keydownEnterEvent);
+			// Then
+			expect(element.TARGET).toEqual(document.activeElement);
+		});
+
+		test('Should make target element focusable and focus on it when space key is pressed and AUTOFOCUS: target', () => {
+			// Given
+			const expander = new Expander(element.BUTTON, element.TARGET, {
+				AUTOFOCUS: 'target'
+			});
+			expander.init();
+			// When
+			const keydownSpaceEvent = createKeydownEvent('Space');
+			element.BUTTON.dispatchEvent(keydownSpaceEvent);
+			// Then
+			expect(element.TARGET).toEqual(document.activeElement);
+		});
+
+		test('Should close when click off the target', () => {
+			// Given
+			const outsideElement = document.createElement('div');
+			element.TARGET.parentNode.insertBefore(outsideElement, element.TARGET.nextSibling);
+			const expander = new Expander(element.BUTTON, element.TARGET);
+			expander.init();
+			element.BUTTON.click();
+			// When
+			outsideElement.click();
+			// Then
+			expect(element.BUTTON.classList.contains(className.OPEN)).toBe(false);
+			expect(element.TARGET.classList.contains(className.HIDE)).toBe(true);
+			expect(element.TARGET.hasAttribute('hidden')).toBe(true);
+		});
+
+		test('Should close when tab from last visible tabbable item', done => {
+			// Given
+			const expander = new Expander(element.BUTTON, element.TARGET, {AUTOFOCUS: 'target'});
+			expander.init();
+			element.LASTTABBABLE.style.visibility = 'hidden';
+			element.BUTTON.click();
+			// When
+			const keydownTabEvent = createKeydownEvent('Tab');
+			element.FIRSTTABBABLE.dispatchEvent(keydownTabEvent);
+			// Then
+			window.requestAnimationFrame(() => {
+				expect(element.BUTTON.classList.contains(className.OPEN)).toBe(false);
+				expect(element.TARGET.classList.contains(className.HIDE)).toBe(true);
+				expect(element.TARGET.hasAttribute('hidden')).toBe(true);
+				done();
+			});
+		});
+
+		test('Should close and set focus on trigger when tab out of the target', done => {
+			// Given
+			const expander = new Expander(element.BUTTON, element.TARGET);
+			expander.init();
+			element.BUTTON.click();
+			// When
+			const keydownTabEvent = createKeydownEvent('Tab');
+			element.LASTTABBABLE.dispatchEvent(keydownTabEvent);
+			// Then
+			window.requestAnimationFrame(() => {
+				expect(element.BUTTON.classList.contains(className.OPEN)).toBe(false);
+				expect(element.TARGET.classList.contains(className.HIDE)).toBe(true);
+				expect(element.TARGET.hasAttribute('hidden')).toBe(true);
+				done();
+			});
+		});
+
+		test('Should close and set focus on trigger when tab out backwards of the target', done => {
+			// Given
+			const expander = new Expander(element.BUTTON, element.TARGET, {AUTOFOCUS: 'target'});
+			expander.init();
+			element.BUTTON.click();
+			// When
+			const keydownTabShiftEvent = createKeydownEvent('TabShift');
+			element.FIRSTTABBABLE.dispatchEvent(keydownTabShiftEvent);
+			// Then
+			window.requestAnimationFrame(() => {
+				expect(element.BUTTON.classList.contains(className.OPEN)).toBe(false);
+				expect(element.TARGET.classList.contains(className.HIDE)).toBe(true);
+				expect(element.TARGET.hasAttribute('hidden')).toBe(true);
+				done();
+			});
+		});
+
+		test('Should not close when tab backwards from last tabbable element', done => {
+			// Given
+			const expander = new Expander(element.BUTTON, element.TARGET, {AUTOFOCUS: 'target'});
+			expander.init();
+			element.BUTTON.click();
+			// When
+			const keydownTabShiftEvent = createKeydownEvent('TabShift');
+			element.LASTTABBABLE.dispatchEvent(keydownTabShiftEvent);
+			// Then
+			window.requestAnimationFrame(() => {
+				expect(element.BUTTON.classList.contains(className.OPEN)).toBe(true);
+				expect(element.TARGET.classList.contains(className.HIDE)).toBe(false);
+				expect(element.TARGET.hasAttribute('hidden')).toBe(false);
+				done();
+			});
+		});
+
+		test('Should not close when click on the open target', () => {
+			// Given
+			const expander = new Expander(element.BUTTON, element.TARGET);
+			expander.init();
+			element.BUTTON.click();
+			// When
+			element.TARGET.click();
+			// Then
+			expect(element.BUTTON.classList.contains(className.OPEN)).toBe(true);
+			expect(element.TARGET.classList.contains(className.HIDE)).toBe(false);
+			expect(element.TARGET.hasAttribute('hidden')).toBe(false);
+		});
+
+		test('Should not close when click on a child of the open target', () => {
+			// Given
+			const targetChild = document.createElement('div');
+			element.TARGET.appendChild(targetChild);
+			const expander = new Expander(element.BUTTON, element.TARGET);
+			expander.init();
+			element.BUTTON.click();
+			// When
+			targetChild.click();
+			// Then
+			expect(element.BUTTON.classList.contains(className.OPEN)).toBe(true);
+			expect(element.TARGET.classList.contains(className.HIDE)).toBe(false);
+			expect(element.TARGET.hasAttribute('hidden')).toBe(false);
+		});
+
+		test('Should use TARGET_HIDE_CLASS option if it is passed to constructor', () => {
+			// Given
+			const targetHideClassOption = 'new-target-hide-class';
+			element.TARGET.className = targetHideClassOption;
+			const expander = new Expander(element.BUTTON, element.TARGET, {
+				TARGET_HIDE_CLASS: targetHideClassOption
+			});
+			expander.init();
+			// When
+			element.BUTTON.click();
+			// Then
+			expect(element.TARGET.classList.contains(targetHideClassOption)).toBe(false);
+		});
+
+		test('Should use TRIGGER_OPEN_CLASS option if it is passed to constructor', () => {
+			// Given
+			const triggerOpenClassOption = 'new-trigger-open-class';
+			const expander = new Expander(element.BUTTON, element.TARGET, {
+				TRIGGER_OPEN_CLASS: triggerOpenClassOption
+			});
+			expander.init();
+			// When
+			element.BUTTON.click();
+			// Then
+			expect(element.BUTTON.classList.contains(triggerOpenClassOption)).toBe(true);
+		});
+
+		test('Should use TRIGGER_OPEN_LABEL option if it is passed to constructor', () => {
+			// Given
+			const triggerOpenLabelOption = 'new-trigger-open-label';
+			const expander = new Expander(element.BUTTON, element.TARGET, {
+				TRIGGER_OPEN_LABEL: triggerOpenLabelOption
+			});
+			expander.init();
+			// When
+			element.BUTTON.click();
+			// Then
+			expect(element.BUTTON.textContent).toEqual(triggerOpenLabelOption);
+		});
+
+		test('Should use CLOSE_ON_FOCUS_OUT option if it is passed to constructor', () => {
+			// Given
+			const clickOffElement = document.createElement('div');
+			element.TARGET.parentNode.insertBefore(clickOffElement, element.TARGET.nextSibling);
+			const expander = new Expander(element.BUTTON, element.TARGET, {
+				CLOSE_ON_FOCUS_OUT: false
+			});
+			expander.init();
+			element.BUTTON.click();
+			// When
+			clickOffElement.click();
+			// Then
+			expect(element.TARGET.classList.contains(className.HIDE)).toBe(false);
+			expect(element.TARGET.hasAttribute('hidden')).toBe(false);
+		});
+
+		test('Should use DEFAULT_OPEN option if it is passed to constructor', () => {
+			// Given
+			const clickOffElement = document.createElement('div');
+			element.TARGET.parentNode.insertBefore(clickOffElement, element.TARGET.nextSibling);
+			const expander = new Expander(element.BUTTON, element.TARGET, {
+				DEFAULT_OPEN: true
+			});
+			
+			// When
+			expander.init();
+
+			// Then
+			expect(element.TARGET.classList.contains(className.HIDE)).toBe(false);
+			expect(element.TARGET.hasAttribute('hidden')).toBe(false);
+		});
+
+		test('Should focus on first tababble element inside target when AUTOFOCUS: firstTabbable and button is clicked on', () => {
+			// Given
+			element.TARGET.innerHTML = '<input type="text" value="value">';
+			const expander = new Expander(element.BUTTON, element.TARGET, {
+				AUTOFOCUS: 'firstTabbable'
+			});
+			expander.init();
+			// When
+			element.BUTTON.click();
+			// Then
+			const input = element.TARGET.querySelector('input');
+			expect(input).toEqual(document.activeElement);
+			expect(input.selectionStart === 0).toBe(true);
+			expect(input.selectionEnd === input.value.length).toBe(true);
+		});
+
+		test('Should focus on first tababble element inside target when AUTOFOCUS: firstTabbable and enter key pressed on native button', () => {
+			// Given
+			element.TARGET.innerHTML = '<input type="text" value="value">';
+			const expander = new Expander(element.BUTTON, element.TARGET, {
+				AUTOFOCUS: 'firstTabbable'
+			});
+			expander.init();
+			// When
+			const keydownEnterEvent = createKeydownEvent('Enter');
+			element.BUTTON.dispatchEvent(keydownEnterEvent);
+			// Then
+			const input = element.TARGET.querySelector('input');
+			expect(input).toEqual(document.activeElement);
+			expect(input.selectionStart === 0).toBe(true);
+			expect(input.selectionEnd === input.value.length).toBe(true);
+		});
+
+		test('Should focus on first tababble element inside target when AUTOFOCUS: firstTabbable and space key pressed on anchor link button', () => {
+			// Given
+			element.BUTTON.outerHTML = linkButtonElement;
+			element.TARGET.innerHTML = '<input type="text" value="value">';
+			const expander = new Expander(element.BUTTON, element.TARGET, {
+				AUTOFOCUS: 'firstTabbable'
+			});
+			expander.init();
+			// When
+			const keydownSpaceEvent = createKeydownEvent('Space');
+			element.BUTTON.dispatchEvent(keydownSpaceEvent);
+			// Then
+			const input = element.TARGET.querySelector('input');
+			expect(input).toEqual(document.activeElement);
+			expect(input.selectionStart === 0).toBe(true);
+			expect(input.selectionEnd === input.value.length).toBe(true);
+		});
+
+		test('Should not fire focus event by default', () => {
+			// Given
+			const button = document.querySelector('[data-expander]');
+			const spy = jest.spyOn(button, 'dispatchEvent');
+			const expander = new Expander(element.BUTTON, element.TARGET, {});
+			expander.init();
+			// When
+			element.BUTTON.click();
+			// Then
+			expect(spy).not.toHaveBeenCalled();
+		});
+
+		test('Should fire event if OPEN_EVENT: true option passed to constructor', () => {
+			// Given
+			const button = document.querySelector('[data-expander]');
+			const spy = jest.spyOn(button, 'dispatchEvent');
+			const expander = new Expander(element.BUTTON, element.TARGET, {
+				OPEN_EVENT: true
+			});
+			expander.init();
+			// When
+			element.BUTTON.click();
+			// Then
+			expect(spy).toHaveBeenCalled();
+		});
+
+		test('Should collapse the target on init', () => {
+			// Given
+			const expander = new Expander(element.BUTTON, element.TARGET);
+			expander.init();
+
+			expect(element.BUTTON.getAttribute('aria-expanded')).toBe('false');
+			expect(element.TARGET.classList.contains(className.HIDE)).toBe(true);
+			expect(element.TARGET.hasAttribute('hidden')).toBe(true);
+		});
+	});
+});
+

--- a/context/brand-context/default/__tests__/unit/dom/expander/index.spec.js
+++ b/context/brand-context/default/__tests__/unit/dom/expander/index.spec.js
@@ -1,0 +1,92 @@
+import {Expander} from '../../../../js/helpers/dom/expander/_expander';
+import {expander} from '../../../../js/helpers/dom/expander';
+
+jest.mock('../../../../js/helpers/dom/expander/_expander');
+
+describe('Data Attribute API', () => {
+	const elements = {};
+
+	beforeEach(() => {
+		Expander.mockClear();
+
+		document.body.innerHTML = `
+			<button id="button1"
+					data-expander
+					data-expander-target="#target1">Expander 1</button>
+			<div id="target1">Target 1</div>
+			<button id="button2"
+					data-expander
+					data-expander-target="#target2"
+					data-expander-hide-class="data-target-hide-class"
+					data-expander-trigger-open-class="data-trigger-open-class"
+					data-expander-trigger-open-label="data-trigger-shown-label"
+					data-expander-close-on-focus-out="true"
+					data-expander-autofocus="false"
+					data-expander-default-open="false">Expander 2</button>
+			<div id="target2">Target 2</div>
+		`;
+
+		elements.button1 = document.querySelector('#button1');
+		elements.button2 = document.querySelector('#button2');
+		elements.target1 = document.querySelector('#target1');
+		elements.target2 = document.querySelector('#target2');
+	});
+
+	test('Should create a new Expander and call init for each data-expander in the DOM', () => {
+		// When
+		expander();
+
+		// Then
+		expect(Expander).toHaveBeenCalledTimes(2);
+
+		for (const instance of Expander.mock.instances) {
+			expect(instance.init).toHaveBeenCalled();
+		}
+	});
+
+	test('Should use options passed during initialisation', () => {
+		// Given
+		const initialisationOptions = {
+			TARGET_HIDE_CLASS: 'init-target-hide-class',
+			TRIGGER_OPEN_CLASS: 'init-trigger-open-class',
+			TRIGGER_OPEN_LABEL: 'init-trigger-open-label',
+			CLOSE_ON_FOCUS_OUT: true,
+			AUTOFOCUS: true,
+			OPEN_EVENT: false,
+			DEFAULT_OPEN: false
+		};
+
+		// When
+		expander(initialisationOptions);
+
+		// Then
+		expect(Expander).toHaveBeenNthCalledWith(1, elements.button1, elements.target1, initialisationOptions);
+	});
+
+	test('Should use options passed via data-* attributes over options passed during initialisation', () => {
+		// Given
+		const initialisationOptions = {
+			TARGET_HIDE_CLASS: 'init-target-hide-class',
+			TRIGGER_OPEN_CLASS: 'init-trigger-open-class',
+			TRIGGER_OPEN_LABEL: 'init-trigger-open-label',
+			CLOSE_ON_FOCUS_OUT: false,
+			AUTOFOCUS: true,
+			OPEN_EVENT: false,
+			DEFAULT_OPEN: true
+		};
+
+		// When
+		expander(initialisationOptions);
+
+		// Then
+		expect(Expander).toHaveBeenNthCalledWith(2, elements.button2, elements.target2, {
+			TARGET_HIDE_CLASS: 'data-target-hide-class',
+			TRIGGER_OPEN_CLASS: 'data-trigger-open-class',
+			TRIGGER_OPEN_LABEL: 'data-trigger-shown-label',
+			CLOSE_ON_FOCUS_OUT: true,
+			AUTOFOCUS: false,
+			OPEN_EVENT: false,
+			DEFAULT_OPEN: false
+		});
+	});
+});

--- a/context/brand-context/default/__tests__/unit/dom/get-data-options.spec.js
+++ b/context/brand-context/default/__tests__/unit/dom/get-data-options.spec.js
@@ -1,0 +1,27 @@
+import {getDataOptions} from '../../../js/helpers';
+
+describe('getDataOptions', () => {
+	const DataOptions = {
+		OPTION_1: 'data-mycomponent-option1',
+		OPTION_2: 'data-mycomponent-option2',
+		OPTION_3: 'data-mycomponent-option3',
+		OPTION_4: 'data-mycomponent-option4',
+		OPTION_5: 'data-mycomponent-option5'
+	};
+
+	const element = {};
+
+	beforeEach(() => {
+		document.body.innerHTML = `
+			<div data-mycomponent-option1="foo" data-mycomponent-option2="bar" data-mycomponent-option3="baz" data-mycomponent-option4="true" data-mycomponent-option5="false" data-notmycomponent="test">My Component</div>
+		`;
+
+		element.COMPONENT = document.querySelector('div');
+	});
+
+	test('Should return an Object with the values for each key as the values of the data-attributes', () => {
+		const options = getDataOptions(element.COMPONENT, DataOptions);
+
+		expect(options).toMatchObject({OPTION_1: 'foo', OPTION_2: 'bar', OPTION_3: 'baz', OPTION_4: true, OPTION_5: false});
+	});
+});

--- a/context/brand-context/default/__tests__/unit/util/create-event.spec.js
+++ b/context/brand-context/default/__tests__/unit/util/create-event.spec.js
@@ -1,0 +1,97 @@
+import {createEvent} from '../../../js/helpers';
+
+describe('createEvent: customEvent supported', () => {
+	it('Should be defined as a function', () => {
+		expect(() => {
+			createEvent('test', 'component');
+		}).not.toThrow();
+	});
+
+	it('Should work as expected', () => {
+		var event = createEvent('test', 'component');
+		expect(event.type).toEqual('component:test');
+	});
+
+	it('Should work as expected, with custom parameters', () => {
+		var event = createEvent('test', 'component', {
+			bubbles: true,
+			detail: {
+				hazcheeseburger: true
+			}
+		});
+		expect(event.type).toEqual('component:test');
+		expect(event.bubbles).toEqual(true);
+		expect(event.detail).toEqual({hazcheeseburger: true});
+	});
+
+	it('Should throw when no namespace defined', () => {
+		expect(() => {
+			createEvent('test');
+		}).toThrowError(new Error('Missing namespace in `createEvent` function'));
+	});
+
+	it('Should be possible to call .preventDefault', () => {
+		var event = createEvent('test', 'component', {cancelable: true});
+		event.preventDefault();
+		expect(event.defaultPrevented).toEqual(true);
+	});
+
+	it('Should be NOT be possible to call .preventDefault if cancelable not set', () => {
+		var event = createEvent('test', 'component');
+		event.preventDefault();
+		expect(event.defaultPrevented).toEqual(false);
+	});
+});
+
+describe('createEvent: customEvent NOT supported', () => {
+	const originalCustomEvent = window.CustomEvent;
+
+	beforeEach(() => {
+		window.CustomEvent = null;
+	});
+
+	afterEach(() => {
+		window.CustomEvent = originalCustomEvent;
+	});
+
+	it('Should be defined as a function', () => {
+		expect(() => {
+			createEvent('test', 'component');
+		}).not.toThrow();
+	});
+
+	it('Should work as expected', () => {
+		var event = createEvent('test', 'component');
+		expect(event.type).toEqual('component:test');
+	});
+
+	it('Should work as expected, with custom parameters', () => {
+		var event = createEvent('test', 'component', {
+			bubbles: true,
+			detail: {
+				hazcheeseburger: true
+			}
+		});
+		expect(event.type).toEqual('component:test');
+		expect(event.bubbles).toEqual(true);
+		expect(event.detail).toEqual({hazcheeseburger: true});
+	});
+
+	it('Should throw when no namespace defined', () => {
+		expect(() => {
+			createEvent('test');
+		}).toThrowError(new Error('Missing namespace in `createEvent` function'));
+	});
+
+	it('Should be possible to call .preventDefault', () => {
+		var event = createEvent('test', 'component', {cancelable: true});
+		event.preventDefault();
+		expect(event.defaultPrevented).toEqual(true);
+	});
+
+	it('Should be NOT be possible to call .preventDefault if cancelable not set', () => {
+		var event = createEvent('test', 'component');
+		event.preventDefault();
+		expect(event.defaultPrevented).toEqual(false);
+	});
+});

--- a/context/brand-context/default/__tests__/unit/util/debounce.spec.js
+++ b/context/brand-context/default/__tests__/unit/util/debounce.spec.js
@@ -1,0 +1,83 @@
+import {debounce} from "../../../js/helpers";
+
+describe('requestAnimationFrame', () => {
+	test('Should not call func until the next animation frame after the last call', done => {
+		const func = jest.fn();
+		const debouncedFunc = debounce(func);
+
+		for(let i = 0; i < 5; i++) {
+			debouncedFunc();
+		}
+
+		expect(func).not.toHaveBeenCalled();
+
+		window.requestAnimationFrame(() => {
+			expect(func).toHaveBeenCalledTimes(1);
+			done();
+		});
+	});
+
+	test('When immediate is true, it should call func the first time', done => {
+		const func = jest.fn();
+		const debouncedFunc = debounce(func, {immediate: true});
+
+		debouncedFunc();
+		expect(func).toBeCalledTimes(1);
+
+		// Call it several times with 100ms between each call
+		for(let i = 0; i < 5; i++) {
+			debouncedFunc();
+		}
+
+		window.requestAnimationFrame(() => {
+			expect(func).toHaveBeenCalledTimes(2);
+			done();
+		});
+	});
+});
+
+describe('setTimeout', () => {
+	beforeEach(() => jest.useFakeTimers());
+
+	test('Should not call func until the wait time has passed after the last call', () => {
+		const func = jest.fn();
+		const debouncedFunc = debounce(func, {wait: 200});
+
+		// Call it several times with 100ms between each call
+		for(let i = 0; i < 5; i++) {
+			jest.advanceTimersByTime(100);
+			debouncedFunc();
+		}
+
+		expect(func).not.toHaveBeenCalled();
+
+		jest.runAllTimers();
+
+		expect(func).toBeCalled();
+		expect(func).toHaveBeenCalledTimes(1);
+	});
+
+	test('When immediate is true, it should call func the first time', () => {
+		const func = jest.fn();
+		const debouncedFunc = debounce(func, {wait: 200, immediate: true});
+
+		debouncedFunc();
+		expect(func).toBeCalledTimes(1);
+
+		jest.runAllTimers();
+
+		for(let i = 0; i < 5; i++) {
+			jest.advanceTimersByTime(100);
+			debouncedFunc();
+		}
+
+		jest.runAllTimers();
+
+		expect(func).toHaveBeenCalledTimes(2);
+	});
+});
+
+
+
+
+

--- a/context/brand-context/default/__tests__/unit/util/delete-cookie.spec.js
+++ b/context/brand-context/default/__tests__/unit/util/delete-cookie.spec.js
@@ -1,0 +1,23 @@
+import {deleteCookie} from "../../../js/helpers/util/delete-cookie";
+import {setCookie} from "../../../js/helpers/util/set-cookie";
+jest.mock('../../../js/helpers/util/set-cookie');
+
+describe('deleteCookie', () => {
+	test('Should call setCookie with empty value and a past expires date', () => {
+		deleteCookie('my-cookie');
+		expect(setCookie).toBeCalledWith('my-cookie', '', {expires: 'Thu, 01 Jan 1970 00:00:00 GMT'});
+	});
+
+	test('Should call setCookie with domain and path if set', () => {
+		const deleteCookieOptions = {
+			path: '/',
+			domain: 'my-domain.com'
+		};
+
+		const setCookieOptions = Object.assign(deleteCookieOptions, {expires: 'Thu, 01 Jan 1970 00:00:00 GMT'});
+
+		deleteCookie('my-cookie', deleteCookieOptions);
+		expect(setCookie).toBeCalledWith('my-cookie', '', setCookieOptions);
+	});
+});
+

--- a/context/brand-context/default/__tests__/unit/util/get-cookie.spec.js
+++ b/context/brand-context/default/__tests__/unit/util/get-cookie.spec.js
@@ -1,0 +1,17 @@
+import {getCookie} from "../../../js/helpers";
+
+test('Should get cookie from document.cookie', () => {
+	const cookieOne = '123456789';
+	const cookieTwo = '987654321';
+	const cookieThree = '2020-07-10stringstring';
+
+	Object.defineProperty(window.document, 'cookie', {
+		writable: true,
+		value: `cookie-one=${cookieOne}; cookie-two=${cookieTwo}; cookie-three=${cookieThree};`
+	});
+
+	expect(getCookie('cookie-one')).toBe(cookieOne);
+	expect(getCookie('cookie-two')).toBe(cookieTwo);
+	expect(getCookie('cookie-three')).toBe(cookieThree);
+});
+

--- a/context/brand-context/default/__tests__/unit/util/make-array.spec.js
+++ b/context/brand-context/default/__tests__/unit/util/make-array.spec.js
@@ -1,0 +1,18 @@
+import {makeArray} from '../../../js/helpers';
+
+describe('makeArray', () => {
+	test('Should take a node list and return an array', () => {
+		// Given
+		document.body.innerHTML = `
+			<div>Node 1</div>
+			<div>Node 2</div>
+			<div>Node 3</div>
+			<div>Node 4</div>
+		`;
+		let nodes = document.querySelectorAll('div');
+		// When
+		nodes = makeArray(nodes);
+		// Then
+		expect(Array.isArray(nodes)).toBe(true);
+	});
+});

--- a/context/brand-context/default/__tests__/unit/util/onetrust.spec.js
+++ b/context/brand-context/default/__tests__/unit/util/onetrust.spec.js
@@ -1,0 +1,46 @@
+import {checkConsent, isConsentBannerClosed} from "../../../js/helpers/util/onetrust";
+
+describe('checkConsent', () => {
+	const originalDocumentCookie = window.document.cookie;
+
+	beforeEach(() => {
+		Object.defineProperty(window.document, 'cookie', {
+			writable: true,
+			value: 'OptanonConsent=isIABGlobal=false&datestamp=Tue+Jul+14+2020+07%3A58%3A59+GMT%2B0100+(British+Summer+Time)&version=6.3.0&landingPath=NotLandingPage&groups=C0001%3A1%2CC0002%3A1%2CC0003%3A0%2CC0008%3A1%2CC0009%3A0&hosts=&legInt=&geolocation=%3B&AwaitingReconsent=false'
+		});
+	});
+
+	afterEach(() => window.document.cookie = originalDocumentCookie);
+
+	test('Should return boolean of each valid consent group set in the OptanonConsent cookie', () => {
+		expect(checkConsent('strictlyNecessary')).toBe(true);
+		expect(checkConsent('performance')).toBe(true);
+		expect(checkConsent('functional')).toBe(false);
+		expect(checkConsent('targetingFirstParty')).toBe(true);
+		expect(checkConsent('targetingThirdParty')).toBe(false);
+	});
+
+	test('Should throw error if invalid group name passed in', () => {
+		expect(() => {
+			checkConsent('invalidGroupName');
+		}).toThrowError();
+	});
+});
+
+describe('isConsentBannerClosed', () => {
+	const originalDocumentCookie = window.document.cookie;
+	afterEach(() => window.document.cookie = originalDocumentCookie);
+
+	test('Should return true if OptanonAlertBoxClosed cookie is set', () => {
+		Object.defineProperty(window.document, 'cookie', {
+			writable: true,
+			value: 'OptanonAlertBoxClosed=2020-07-13T21:33:32.497Z'
+		});
+
+		expect(isConsentBannerClosed()).toBe(true);
+	});
+
+	test('Should return false if OptanonAlertBoxClosed cookie is not set', () => {
+		expect(isConsentBannerClosed()).toBe(false);
+	});
+});

--- a/context/brand-context/default/__tests__/unit/util/set-cookie.spec.js
+++ b/context/brand-context/default/__tests__/unit/util/set-cookie.spec.js
@@ -1,0 +1,26 @@
+import {setCookie} from '../../../js/helpers';
+
+describe('setCookie', () => {
+	const originalDocumentCookie = window.document.cookie;
+
+	beforeEach(() => {
+		Object.defineProperty(window.document, 'cookie', {
+			writable: true,
+			value: ''
+		});
+	});
+
+	afterEach(() => window.document.cookie = originalDocumentCookie);
+
+	test('Should set cookie', () => {
+		setCookie('test-cookie', 'test-value');
+		expect(document.cookie).toBe('test-cookie=test-value')
+	});
+
+	test('Should set cookie with options', () => {
+		setCookie('test-cookie', 'test-value', {path: '/test-path', domain: 'test-domain'});
+		expect(document.cookie).toBe('test-cookie=test-value;path=/test-path;domain=test-domain')
+	});
+});
+
+

--- a/context/brand-context/default/__tests__/unit/util/throttle.spec.js
+++ b/context/brand-context/default/__tests__/unit/util/throttle.spec.js
@@ -1,0 +1,37 @@
+import {throttle} from '../../../js/helpers';
+
+beforeEach(() => jest.useFakeTimers());
+
+describe('throttle', () => {
+	test('Should only call func once within the wait time', () => {
+		const func = jest.fn();
+		const throttledFunc = throttle(func, 500);
+
+		// Call it several times with 100ms between each call
+		for(let i = 0; i < 5; i++) {
+			jest.advanceTimersByTime(100);
+			throttledFunc();
+		}
+
+		// Fast-forward to wait time
+		jest.runAllTimers();
+
+		expect(func).toHaveBeenCalledTimes(1);
+	});
+
+	test('Should call func if wait time has passed', () => {
+		const func = jest.fn();
+		const throttledFunc = throttle(func, 500);
+
+		// Call it several times with 100ms between each call
+		for(let i = 0; i < 5; i++) {
+			jest.advanceTimersByTime(500);
+			throttledFunc();
+		}
+
+		// Fast-forward to wait time
+		jest.runAllTimers();
+
+		expect(func).toHaveBeenCalledTimes(5);
+	});
+});

--- a/context/brand-context/default/js/README.md
+++ b/context/brand-context/default/js/README.md
@@ -11,7 +11,7 @@ A collection of JavaScript helpers to achieve common, repetitive tasks.
 You can import as many of the named exports from the helpers as you require for your project.
 
 ```javascript
-    import {helper1, helper2} from '@springernature/brand-context';
+import {helper1, helper2} from '@springernature/brand-context';
 ```
 
 **Util**

--- a/context/brand-context/default/js/README.md
+++ b/context/brand-context/default/js/README.md
@@ -1,0 +1,268 @@
+# Javascript
+
+Shared Javascript that can be included in your project or component.
+
+## Helpers
+
+A collection of JavaScript helpers to achieve common, repetitive tasks.
+
+### Usage
+
+You can import as many of the named exports from the helpers as you require for your project.
+
+```javascript
+    import {helper1, helper2} from '@springernature/brand-context';
+```
+
+**Util**
+- [makeArray](#makearray)
+- [createEvent](#createevent)
+- [getCookie](#getcookie)
+- [setCookie](#setcookie)
+- [deleteCookie](#deletecookie)
+- [debounce](#debounce)
+- [throttle](#throttle)
+- [onetrust](#onetrust)
+
+
+**Dom**
+- [getDataOptions](#getdataoptions)
+- [expander](#expander)
+
+### Util
+Util helpers are used to help achieve JavaScript tasks that do not involve touching the DOM.
+
+#### makeArray
+Makes an array from an iterable.
+Commonly used for converting a NodeList into an Array so array methods can then be used on the iterable.
+
+```javascript
+const elementsNodeList = document.querySelectorAll('.elements');
+const elementsArray = makeArray(elementsNodeList);
+
+elementsArray.forEach(element => {
+    // Do something
+});
+```
+
+#### createEvent
+Simple wrapper for [`customEvent`](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent) that enforces an event namespace of the form `namespace:event`.
+
+This should be the **default** method for component module communication, where the name of the component is used as the namespace.
+
+```javascript
+const elementToBind = document.getElementById('element');
+
+// Create event namespaced to component
+const event = createEvent('eventName', 'componentName', {
+    bubbles:true,
+    cancelable: true,
+    detail: {
+        hazcheeseburger: true
+    }
+});
+
+// Dispatch event
+elementToBind.dispatchEvent(event);
+
+// Listen for event
+elementToBind.addEventListener('componentName:eventName', function (event) {
+    // Do something
+}, false);
+```
+
+#### getCookie
+Retrieves a cookie by name from `document.cookie`.
+
+```javascript
+const myCookie = getCookie('name-of-cookie');
+```
+
+#### setCookie
+Sets a cookie with a name, value and attributes using `document.cookie`.
+Configurable options are:
+
+- `path` (string)
+- `domain` (string)
+- `max-age` (number as string)
+- `expires` (string)
+- `secure` (string)
+- `samesite` (string) 
+
+```javascript
+setCookie('name-of-cookie', 'cookie-value', {
+    path: '/',
+    domain: 'mydomain.com',
+    'max-age': '31536000'
+});
+```
+
+#### deleteCookie
+Expires a cookie by name from `document.cookie`.
+Configurable options are:
+
+- `path` (string)
+- `domain` (string)
+
+```javascript
+deleteCookie('name-of-cookie', {
+    path: '/',
+    domain: 'mydomain.com',
+});
+```
+
+#### debounce
+Allows sequential calls to a function to be grouped together so that the function will only be called once.
+The call will be made once the timeframe has passed after the last call.
+
+The `debounce` function accepts two arguments, `func,` and an options object that accepts `wait` and `immediate`.
+`func` is the function to debounce; `wait` is the time (in ms) that should pass after the last function call; `immediate` allows the function to be called once _before_ the timer begins.
+
+`debounce` returns a function and will use `requestAnimationFrame` if no wait time is passed in.
+`immediate` defaults to `false`.
+
+Common use cases are when you want to execute a handler only at the end of a series of events, for example when making asynchronous requests in response to a users input.
+
+```javascript
+const input = document.querySelector('input.autocomplete');
+input.addEventListener('input', debounce(myHandler, {wait: 200, immediate: true}));
+```
+
+#### throttle
+Allows a function to be called once within a set timeframe. Additional function calls within the timeframe will be ignored.
+The `throttle` function accepts two arguments, `func`, which is the function to throttle, and `wait`, which is the duration of the throttle (in ms).
+
+`throttle` returns a function with a default `wait` time of 100.
+
+Common use cases are when you want to consistently execute a handler but at a decreased ratio to the browsers default 1:1, for example scroll and resize event handlers.
+
+```javascript
+document.addEventListener('scroll', throttle(myHandler, 200));
+```
+
+#### onetrust
+OneTrust is the cookie management tool we use in order to aid GDPR compliance.
+This helper exports two named functions, `checkConsent` and `isConsentBannerClosed`.
+
+##### checkConsent
+
+Takes a OneTrust category string and returns a boolean representing whether the category has been consent to (retrieved from the `OptanonConsent` cookie).
+
+Valid categories are: 
+
+- "strictlyNecessary"
+- "performance"
+- "functional"
+- "targetingFirstParty"
+- "targetingThirdParty"
+
+```javascript
+checkConsent('targetingThirdParty');
+```
+
+An error will be thrown if an invalid category is passed in.
+
+##### isConsentBannerClosed
+
+Returns a boolean representing whether the cookie consent banner has been closed (retrieved from the `OptanonAlertBoxClosed` cookie).
+
+```javascript
+isConsentBannerClosed();
+```
+
+### Dom
+Dom helpers are used to help achieve JavaScript tasks that involve getting information from, or manipulating the DOM.
+
+#### getDataOptions
+Takes an element and an Object of component options and data-attribute selectors and returns the an Object with the value for those data-attributes.
+Because it returns an Object, it is easy to merge with other options Objects, such as the default options.
+
+```html
+<div class="my-component" data-mycomponent-option1="foo" data-mycomponent-option2="bar" data-mycomponent-option3="baz">My Component</div>
+```
+
+```javascript
+// my-component.js
+const DataOptions = {
+    OPTION_1: 'data-mycomponent-option1',
+    OPTION_2: 'data-mycomponent-option2',
+    OPTION_3: 'data-mycomponent-option3',
+};
+
+const component = document.querySelector('.my-component');
+
+const options = getDataOptions(component, DataOptions);
+
+console.log(options);
+
+// Output:
+
+// {
+//	OPTION_1: 'foo',
+//	OPTION_2: 'bar',
+//	OPTION_3: 'baz',
+// }
+``` 
+
+#### Expander
+Click a trigger element to toggle the display of a unique target element.
+
+```javascript
+import {expander} from '@springernature/brand-context';
+
+expander(options);
+```
+
+```html
+<button id="button1" data-expander data-expander-target="#target1">Expander 1</button>
+<div id="target1">Target 1</div>
+```
+
+For more flexibility you can use the Expander class directly:
+
+```javascript
+const trigger = document.querySelector('.my-trigger');
+const target = document.querySelector('.my-target');
+
+const myExpander = new Expander(trigger, target, options);
+
+myExpander.init();
+``` 
+
+You can also manually open and close any instance of expander with:
+
+```javascript
+expander.open();
+expander.close();
+```
+
+##### Options
+
+| Option             | Default Value | Type    | Description |
+|--------------------|---------------|---------|------------------------------------------------------------------------------------------------------------------------------------|
+| TARGET_HIDE_CLASS  | 'u-js-hide'   | String  | HTML class to be toggled on the target                                                                                             |
+| TRIGGER_OPEN_CLASS | -             | String  | HTML class to be toggled to the trigger                                                                                            |
+| TRIGGER_OPEN_LABEL | -             | String  | Text to set on the trigger when open                                                                                               |
+| CLOSE_ON_FOCUS_OUT | true          | Boolean | Closes when you click or tab outside of the target                                                                                 |
+| AUTOFOCUS          | null          | String  | Moves focus to an element when hitting trigger:                                                                                    |
+|                    |               |         |`firstTabbable` will find the first tabbable element inside the target (will highlight text if appropriate, e.g. input with value). |
+|                    |               |         |`target` will set focus on target element                                                                                           |
+| OPEN_EVENT         | false         | Boolean | Dispatch custom event on trigger once Global Expander has completed it's Open method                                               |
+| DEFAULT_OPEN       | false         | Boolean | Set the expander to be open by default                                                                                             |
+
+The data attribute options are the same, but are lowercase and hyphenated (and strings where the option is a boolean):
+
+- `data-expander-target-hide-class`
+- `data-expander-trigger-open-class`
+- `data-expander-trigger-open-label`
+- `data-expander-close-on-focus-out`
+- `data-expander-autofocus`
+- `data-expander-open-event`
+- `data-expander-default-open`
+
+> *Note*: data attribute options will take precedence over any options set during initialisation.
+
+##### Polyfills / Babel plugins required
+
+- [plugin-transform-object-assign](https://babeljs.io/docs/en/babel-plugin-transform-object-assign)
+

--- a/context/brand-context/default/js/helpers/dom/expander/_expander.js
+++ b/context/brand-context/default/js/helpers/dom/expander/_expander.js
@@ -1,0 +1,250 @@
+import {makeArray} from '../../util/make-array';
+import {createEvent} from '../../util/create-event';
+
+/**
+ * Local Constants
+ */
+
+const defaultOptions = {
+	TARGET_HIDE_CLASS: 'u-js-hide',
+	TRIGGER_OPEN_CLASS: 'is-open',
+	TRIGGER_OPEN_LABEL: undefined,
+	CLOSE_ON_FOCUS_OUT: true,
+	AUTOFOCUS: null,
+	OPEN_EVENT: false,
+	DEFAULT_OPEN: false
+};
+
+const Expander = class {
+	constructor(trigger, target, options = {}) {
+		this._options = Object.assign({}, defaultOptions, options);
+		this._autoFocusElement = trigger;
+		this._triggerEl = trigger;
+		this._targetEl = target;
+		this._originalTriggerText = trigger.textContent;
+		this._isOpen = this._options.DEFAULT_OPEN;
+		this._handleButtonClick = this._handleButtonClick.bind(this);
+		this._handleButtonKeydown = this._handleButtonKeydown.bind(this);
+		this._handleDocumentClick = this._handleDocumentClick.bind(this);
+		this._handleDocumentKeydown = this._handleDocumentKeydown.bind(this);
+	}
+
+	/**
+	 * Event Handlers
+	 */
+
+	_handleButtonClick(event) {
+		event.preventDefault();
+
+		if (this._isOpen) {
+			this.close();
+		} else {
+			this.open();
+		}
+	}
+
+	_handleButtonKeydown(event) {
+		if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+			event.preventDefault();
+
+			if (this._isOpen) {
+				this.close();
+			} else {
+				this.open();
+			}
+		}
+	}
+
+	_handleDocumentKeydown(event) {
+		if (event.key === 'Escape') {
+			this.close();
+			this._triggerEl.focus();
+		}
+
+		if (this._options.CLOSE_ON_FOCUS_OUT) {
+			if (event.key === 'Tab' && event.shiftKey === true) {
+				if (event.target === this._targetTabbableItems[0] || event.target === this._triggerEl || event.target === this._targetEl) {
+					event.preventDefault();
+					window.requestAnimationFrame(() => {
+						this.close();
+						this._triggerEl.focus();
+					});
+				}
+			}
+
+			if (event.key === 'Tab' && event.shiftKey === false) {
+				if (event.target === this._targetTabbableItems[this._targetTabbableItems.length - 1]) {
+					event.preventDefault();
+					window.requestAnimationFrame(() => {
+						this.close();
+						this._triggerEl.focus();
+					});
+				}
+			}
+		}
+	}
+
+	_handleDocumentClick(event) {
+		let target = event.target;
+
+		if (target === this._targetEl || target === this._triggerEl || this._targetEl.contains(target) || this._triggerEl.contains(target)) {
+			return;
+		}
+
+		this.close();
+	}
+
+	/**
+	 * Temporary Event Listeners
+	 */
+
+	_setupTemporaryEventListeners() {
+		document.addEventListener('keydown', this._handleDocumentKeydown);
+
+		if (this._options.CLOSE_ON_FOCUS_OUT) {
+			document.addEventListener('click', this._handleDocumentClick);
+		}
+	}
+
+	_removeTemporaryEventListeners() {
+		document.removeEventListener('keydown', this._handleDocumentKeydown);
+
+		if (this._options.CLOSE_ON_FOCUS_OUT) {
+			document.removeEventListener('click', this._handleDocumentClick);
+		}
+	}
+
+	/**
+	 * Attributes
+	 */
+
+	_updateAttributes() {
+		// eslint-disable-next-line unicorn/consistent-function-scoping
+		this._triggerEl.setAttribute('aria-expanded', this._isOpen.toString());
+
+		if (this._isOpen) {
+			this._targetEl.removeAttribute('hidden');
+		} else {
+			this._targetEl.setAttribute('hidden', '');
+		}
+	}
+
+	/**
+	 * Class attributes
+	 */
+
+	_updateClassAttributes() {
+		if (this._isOpen) {
+			this._triggerEl.classList.add(this._options.TRIGGER_OPEN_CLASS);
+			this._targetEl.classList.remove(this._options.TARGET_HIDE_CLASS);
+		} else {
+			this._triggerEl.classList.remove(this._options.TRIGGER_OPEN_CLASS);
+			this._targetEl.classList.add(this._options.TARGET_HIDE_CLASS);
+		}
+	}
+
+	/**
+	 * Trigger Label
+	 */
+
+	_updateTriggerLabel() {
+		if (this._options.TRIGGER_OPEN_LABEL) {
+			this._triggerEl.textContent = this._isOpen ? this._options.TRIGGER_OPEN_LABEL : this._originalTriggerText;
+		}
+	}
+
+	/**
+	 * Tabbable Items
+	 */
+
+	_updateTabbableItems() {
+		this._targetTabbableItems = makeArray(this._targetEl.querySelectorAll(
+			'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+		)).filter(element => window.getComputedStyle(element).getPropertyValue('visibility') !== 'hidden');
+	}
+
+	/**
+	 * AutoFocus
+	 */
+
+	_handleAutoFocus() {
+		if (this._options.AUTOFOCUS === 'target') {
+			this._autoFocusElement = this._targetEl;
+			this._targetEl.setAttribute('tabindex', '-1');
+		}
+		if (this._options.AUTOFOCUS === 'firstTabbable') {
+			this._autoFocusElement = this._targetTabbableItems.length > 0 && this._targetTabbableItems[0];
+			if (this._autoFocusElement.setSelectionRange) {
+				this._autoFocusElement.setSelectionRange(0, this._autoFocusElement.value.length);
+			}
+		}
+		this._autoFocusElement.focus();
+	}
+
+	/**
+	 * @public
+	 */
+
+	/**
+	 * Toggling
+	 */
+
+	open() {
+		if (this._isOpen) {
+			return;
+		}
+
+		this._isOpen = true;
+
+		this._updateTriggerLabel();
+		this._updateAttributes();
+		this._updateClassAttributes();
+		this._updateTabbableItems();
+
+		this._setupTemporaryEventListeners();
+		this._handleAutoFocus();
+
+		if (this._options.OPEN_EVENT) {
+			const event = createEvent('open', 'globalExpander', {
+				bubbles: false
+			});
+			this._triggerEl.dispatchEvent(event);
+		}
+	}
+
+	close() {
+		if (!this._isOpen) {
+			return;
+		}
+
+		this._isOpen = false;
+
+		this._updateTriggerLabel();
+		this._updateAttributes();
+		this._updateClassAttributes();
+
+		this._removeTemporaryEventListeners();
+	}
+
+	init() {
+		if (this._triggerEl.tagName === 'A' && this._triggerEl.getAttribute('href').charAt(0) === '#') {
+			// eslint-disable-next-line no-script-url
+			this._triggerEl.setAttribute('href', 'javascript:;');
+			this._triggerEl.setAttribute('role', 'button');
+		}
+
+		// Warn screen reader users when you are stealing focus
+		if (this._options.AUTOFOCUS) {
+			this._triggerEl.setAttribute('aria-haspopup', 'true');
+		}
+
+		this._updateTriggerLabel();
+		this._updateAttributes();
+		this._updateClassAttributes();
+
+		this._triggerEl.addEventListener('click', this._handleButtonClick);
+		this._triggerEl.addEventListener('keydown', this._handleButtonKeydown);
+	}
+};
+
+export {Expander};

--- a/context/brand-context/default/js/helpers/dom/expander/index.js
+++ b/context/brand-context/default/js/helpers/dom/expander/index.js
@@ -1,0 +1,46 @@
+import {makeArray} from '../../util/make-array';
+import {getDataOptions} from '../../dom/get-data-options';
+import {Expander} from './_expander';
+
+const DATA_COMPONENT = 'data-expander';
+
+const attributes = {
+	TARGET_HIDE_CLASS: DATA_COMPONENT + '-hide-class',
+	TRIGGER_OPEN_CLASS: DATA_COMPONENT + '-trigger-open-class',
+	TRIGGER_OPEN_LABEL: DATA_COMPONENT + '-trigger-open-label',
+	CLOSE_ON_FOCUS_OUT: DATA_COMPONENT + '-close-on-focus-out',
+	AUTOFOCUS: DATA_COMPONENT + '-autofocus',
+	OPEN_EVENT: DATA_COMPONENT + '-open-event',
+	DEFAULT_OPEN: DATA_COMPONENT + '-default-open'
+};
+
+/**
+ * Data Attribute API
+ */
+
+const expander = (options = {}) => {
+	const triggers = document.querySelectorAll(`[${DATA_COMPONENT}]`);
+
+	if (triggers.length === 0) {
+		return;
+	}
+
+	makeArray(triggers).forEach(trigger => {
+		const dataTarget = DATA_COMPONENT + '-target';
+
+		if (!trigger.hasAttribute(dataTarget)) {
+			return;
+		}
+
+		const targetElement = document.querySelector(trigger.getAttribute(dataTarget));
+		if (!targetElement) {
+			return;
+		}
+
+		const dataOptions = getDataOptions(trigger, attributes);
+		const expander = new Expander(trigger, targetElement, Object.assign({}, options, dataOptions));
+		expander.init();
+	});
+};
+
+export {expander};

--- a/context/brand-context/default/js/helpers/dom/get-data-options.js
+++ b/context/brand-context/default/js/helpers/dom/get-data-options.js
@@ -1,0 +1,28 @@
+/**
+ * @param element
+ * @param attributeMap - An Object of data attribute options
+ * @returns Object
+ */
+const getDataOptions = (element, attributeMap) => {
+	const dataOptions = {};
+
+	for (const key in attributeMap) {
+		// eslint-disable-next-line no-prototype-builtins
+		if (attributeMap.hasOwnProperty(key)) {
+			let value = attributeMap[key];
+			const attributeValue = element.hasAttribute(value) && element.getAttribute(value);
+
+			if (attributeValue) {
+				// 'true' and 'false' attribute values need to be converted to a boolean
+				// Checking equality against 'true' will return a boolean of true or false. e.g. 'false' === 'true' returns false
+				dataOptions[key] = (attributeValue === 'true' || attributeValue === 'false') ? attributeValue === 'true' : attributeValue;
+			}
+		}
+	}
+
+	return dataOptions;
+};
+
+export {
+	getDataOptions
+};

--- a/context/brand-context/default/js/helpers/index.js
+++ b/context/brand-context/default/js/helpers/index.js
@@ -1,0 +1,15 @@
+// Util
+import {makeArray} from './util/make-array';
+import {createEvent} from './util/create-event';
+import {debounce} from './util/debounce';
+import {throttle} from './util/throttle';
+import {getCookie} from './util/get-cookie';
+import {setCookie} from './util/set-cookie';
+import {deleteCookie} from './util/delete-cookie';
+import {checkConsent, isConsentBannerClosed} from './util/onetrust';
+
+// Dom
+import {getDataOptions} from './dom/get-data-options';
+import {expander} from './dom/expander';
+
+export {makeArray, createEvent, debounce, throttle, getCookie, setCookie, deleteCookie, getDataOptions, checkConsent, isConsentBannerClosed, expander};

--- a/context/brand-context/default/js/helpers/util/create-event.js
+++ b/context/brand-context/default/js/helpers/util/create-event.js
@@ -1,0 +1,46 @@
+/**
+ * create-event.js
+ * Wrapper for customEvent
+ * Generate namespaced events
+ */
+'use strict';
+
+/**
+ * Polyfill customEvent
+ * @function customEvent
+ * @param {String} eventName namespaced name of the event
+ * @param {Object=} _parameters customEvent options
+ * @return {Event}
+ */
+const customEvent = (eventName, _parameters) => {
+	_parameters = _parameters || {bubbles: false, cancelable: false, detail: null};
+	var event = document.createEvent('CustomEvent');
+	event.initCustomEvent(eventName, _parameters.bubbles, _parameters.cancelable, _parameters.detail);
+	return event;
+};
+
+/**
+ * Create a custom event
+ * @function createEvent
+ * @param {String} eventName name of the event
+ * @param {String} namespace namespace e.g. component name
+ * @param {Object=} _parameters customEvent options
+ * @return {Event}
+ */
+const createEvent = (eventName, namespace, _parameters) => {
+	let event;
+
+	if (namespace === undefined) {
+		throw new Error('Missing namespace in `createEvent` function');
+	}
+
+	if (typeof window.CustomEvent === 'function') {
+		event = new CustomEvent(`${namespace}:${eventName}`, _parameters);
+	} else {
+		event = customEvent(`${namespace}:${eventName}`, _parameters);
+	}
+
+	return event;
+};
+
+export {createEvent};

--- a/context/brand-context/default/js/helpers/util/debounce.js
+++ b/context/brand-context/default/js/helpers/util/debounce.js
@@ -1,0 +1,45 @@
+/**
+ * @param {function} func - function to execute
+ * @param {Object} options
+ * @param {number | string} options.wait - Time in ms, defaults to 'raf'
+ * @param {Boolean} options.immediate - Whether the func should be called immediately, defaults to false
+ * @return {function} - debounced function
+ */
+
+export const debounce = (func, {wait = 'raf', immediate = false} = {}) => {
+	const raf = (wait === 'raf');
+
+	if (!raf && typeof wait !== 'number') {
+		return;
+	}
+
+	let timeout;
+
+	// Return a function to run debounced
+	return function () {
+		let context = this;
+		let args = arguments; // eslint-disable-line unicorn/prevent-abbreviations
+		const later = () => {
+			timeout = null;
+			if (!immediate) {
+				func.apply(context, args);
+			}
+		};
+		const callNow = immediate && !timeout;
+
+		// If there's a timer, cancel it
+		if (timeout) {
+			if (raf) {
+				window.cancelAnimationFrame(timeout);
+			} else {
+				clearTimeout(timeout);
+			}
+		}
+
+		timeout = raf ? window.requestAnimationFrame(() => func.apply(context, args)) : setTimeout(later, wait);
+
+		if (callNow) {
+			func.apply(context, args);
+		}
+	};
+};

--- a/context/brand-context/default/js/helpers/util/delete-cookie.js
+++ b/context/brand-context/default/js/helpers/util/delete-cookie.js
@@ -1,0 +1,18 @@
+import {setCookie} from './set-cookie';
+
+export const deleteCookie = (name, options = {}) => {
+	const {domain, path} = options;
+	const setCookieOptions = {
+		expires: 'Thu, 01 Jan 1970 00:00:00 GMT'
+	};
+
+	if (domain) {
+		setCookieOptions.domain = domain;
+	}
+
+	if (path) {
+		setCookieOptions.path = path;
+	}
+
+	setCookie(name, '', setCookieOptions);
+};

--- a/context/brand-context/default/js/helpers/util/get-cookie.js
+++ b/context/brand-context/default/js/helpers/util/get-cookie.js
@@ -1,0 +1,12 @@
+/**
+ * @param {string} name - name of cookie
+ * @returns {string} - value of the cookie
+ */
+
+export const getCookie = name => {
+	const value = `; ${document.cookie}`;
+	const parts = value.split(`; ${name}=`);
+	if (parts.length === 2) {
+		return parts.pop().split(';').shift();
+	}
+};

--- a/context/brand-context/default/js/helpers/util/make-array.js
+++ b/context/brand-context/default/js/helpers/util/make-array.js
@@ -1,0 +1,15 @@
+const makeArray = iterable => {
+	const list = [];
+
+	if (!iterable) {
+		return list;
+	}
+
+	Array.prototype.forEach.call(iterable, function (item) {
+		list.push(item);
+	});
+
+	return list;
+};
+
+export {makeArray};

--- a/context/brand-context/default/js/helpers/util/onetrust.js
+++ b/context/brand-context/default/js/helpers/util/onetrust.js
@@ -1,0 +1,39 @@
+import {getCookie} from './get-cookie';
+
+/**
+ * onetrust.js
+ * @param {string} category - name of OneTrust category
+ * @return {boolean}
+ */
+
+const checkConsent = category => {
+	const validCategories = {
+		strictlyNecessary: 'C0001',
+		performance: 'C0002',
+		functional: 'C0003',
+		targetingFirstParty: 'C0008',
+		targetingThirdParty: 'C0009'
+	};
+
+	if (!validCategories[category]) {
+		throw new Error('Invalid category: ' + category);
+	}
+
+	const consent = getCookie('OptanonConsent');
+
+	if (consent) {
+		const consentGroups = consent.split('groups=').pop().split('&')[0];
+		const colonEncoding = '%3A';
+
+		return consentGroups.includes(validCategories[category] + colonEncoding + '1');
+	}
+};
+
+/**
+ * isConsentBannerClosed
+ * @return {boolean}
+ */
+
+const isConsentBannerClosed = () => Boolean(getCookie('OptanonAlertBoxClosed'));
+
+export {checkConsent, isConsentBannerClosed};

--- a/context/brand-context/default/js/helpers/util/set-cookie.js
+++ b/context/brand-context/default/js/helpers/util/set-cookie.js
@@ -1,0 +1,24 @@
+/**
+ * @param {string} name - The name / key of the cookie
+ * @param {string} value - The value of the cookie
+ * @param {Object} [options] - The attribute values for the cookie. See https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie for attribute descriptions
+ * @param {string} [options.path]
+ * @param {string} [options.domain]
+ * @param {string} [options.max-age]
+ * @param {string} [options.expires]
+ * @param {string} [options.secure]
+ * @param {string} [options.samesite]
+ */
+
+export const setCookie = (name, value, options = {}) => {
+	const {path, domain, 'max-age': maxAge, expires, secure, samesite} = options;
+
+	document.cookie = encodeURIComponent(name) +
+		'=' + value +
+		(path ? (';path=' + path) : '') +
+		(domain ? (';domain=' + domain) : '') +
+		(maxAge ? (';max-age=' + maxAge) : '') +
+		(expires ? (';expires=' + expires) : '') +
+		(secure ? (';secure') : '') +
+		(samesite ? (';samesite=' + samesite) : '');
+};

--- a/context/brand-context/default/js/helpers/util/throttle.js
+++ b/context/brand-context/default/js/helpers/util/throttle.js
@@ -1,0 +1,18 @@
+/**
+ * @param {function} func - function to execute
+ * @param {number} wait - timeout to execute
+ * @return {function} - throttled function
+ */
+
+export const throttle = (func, wait = 100) => {
+	let timer = null;
+	// not arrow function due to 'this' value
+	return function (...args) { // eslint-disable-line unicorn/prevent-abbreviations
+		if (timer === null) {
+			timer = setTimeout(() => {
+				func.apply(this, args);
+				timer = null;
+			}, wait);
+		}
+	};
+};

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "20.0.3",
+  "version": "20.1.0",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -4,5 +4,6 @@
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],
-  "author": "Springer Nature"
+  "author": "Springer Nature",
+  "main": "./default/js/helpers/index.js"
 }

--- a/context/package-manager.json
+++ b/context/package-manager.json
@@ -6,6 +6,10 @@
       "css",
       "md"
     ],
+    "js": [
+      "js",
+      "md"
+    ],
     "img": [
       "jpg",
       "gif",


### PR DESCRIPTION
This PR adds the following to the `brand-context`:
- The contents of the `global-javascript` component
- The contents of the `global-expander` component

Work to do after this PR:
- Deprecate `global-javascript`
- Deprecate `global-expander`