### PR TITLE
global-corporate-footer: update brand-context

### DIFF
--- a/toolkits/global/packages/global-corporate-footer/HISTORY.md
+++ b/toolkits/global/packages/global-corporate-footer/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 5.0.0 (2022-04-13)
+    * Update to latest brand-context v20.1.1
+
 ## 4.0.4 (2022-03-22)
     * Small update to footer guidance following subject matter expert review
 

--- a/toolkits/global/packages/global-corporate-footer/package.json
+++ b/toolkits/global/packages/global-corporate-footer/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@springernature/global-corporate-footer",
-  "version": "4.0.4",
+  "version": "5.0.0",
   "description": "corporate footer",
   "license": "MIT",
   "author": "Springer Nature",
-  "brandContext": "^20.0.0"
+  "brandContext": "^20.1.1"
 }

--- a/toolkits/global/packages/global-corporate-footer/scss/10-settings/default.scss
+++ b/toolkits/global/packages/global-corporate-footer/scss/10-settings/default.scss
@@ -11,7 +11,7 @@ $corporate-footer--border: 2px solid #dadada;
 $corporate-footer--padding-top: $corporate-footer--vertical-rhythm;
 $corporate-footer--padding-bottom: $corporate-footer--vertical-rhythm;
 $corporate-footer--font-family: $context--font-family-sans;
-$corporate-footer--background-color: #01324b;
+$corporate-footer--background-color: $context--universal-blue;
 $corporate-footer--font-size: 1rem;
 $corporate-footer--text-color: white;
 


### PR DESCRIPTION
- Update to latest version of the `brand-context`
- This version includes the corporate brand colours shared within the default level, so we can now use that here