### PR TITLE
Update h2 line height

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,4 +1,7 @@
 # History
+## 20.1.3 (2022-04-20)
+    * Adjusted h2 line height for Springer Nature
+
 ## 20.1.2 (2022-03-30)
     * Adjusted heading sizes and styles for Springer
     

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "20.1.2",
+  "version": "20.1.3",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/springernature/scss/10-settings/typography.scss
+++ b/context/brand-context/springernature/scss/10-settings/typography.scss
@@ -26,7 +26,7 @@ $context--font-size-h5: $context--font-size-md;
 $context--font-size-base: 1em;
 
 $context--line-height-h1: 2.625rem;
-$context--line-height-h2: 1.75rem;
+$context--line-height-h2: 2rem;
 $context--line-height-h3: 1.5rem;
 $context--line-height-h4: 1.5rem;
 $context--line-height-h5: 1.188rem;


### PR DESCRIPTION
This is to adjust the h2 line height from 1.75rem to 2rem for Springer Nature. Full context: https://github.com/springernature/frontend-toolkits/issues/723