### PR TITLE
adds curly brace to missing design tokens value

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 21.0.1 (2022-04-29)
+    * BUG
+      * fixes issue with compiled Design Tokens having an missing opening curly brace
+
 ## 21.0.0 (2022-04-27)
     * FEATURE:
       * Introduces Design Tokens as a way to manage and create Sass variables from Design decisions.

--- a/context/brand-context/default/scss/00-tokens/_background.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_background.variables.scss
@@ -1,9 +1,9 @@
 
 // Do not edit directly
-// Generated on Wed, 27 Apr 2022 21:29:22 GMT
+// Generated on Fri, 29 Apr 2022 11:08:36 GMT
 
 $tokens--background-page: #f8f8f8;
-$tokens--background-container: color.white};
+$tokens--background-container: #ffffff;
 $tokens--background-facet: #f3f3f3;
 $tokens--background-footer: #01324b;
 $tokens--background-table-heading: #666666;

--- a/context/brand-context/default/scss/00-tokens/_border.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_border.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 27 Apr 2022 21:29:22 GMT
+// Generated on Fri, 29 Apr 2022 11:08:36 GMT
 
 $tokens--border-color-primary: #000000;
 $tokens--border-color-input: #555555;

--- a/context/brand-context/default/scss/00-tokens/_breakpoints.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_breakpoints.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 27 Apr 2022 21:29:21 GMT
+// Generated on Fri, 29 Apr 2022 11:08:35 GMT
 
 $tokens--breakpoints-xs: 320px; // mobile
 $tokens--breakpoints-sm: 580px; // small tablet

--- a/context/brand-context/default/scss/00-tokens/_button.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_button.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 27 Apr 2022 21:29:22 GMT
+// Generated on Fri, 29 Apr 2022 11:08:36 GMT
 
 $tokens--button-background-primary-resting: #025e8d;
 $tokens--button-background-primary-hover: #ffffff;

--- a/context/brand-context/default/scss/00-tokens/_link.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_link.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 27 Apr 2022 21:29:22 GMT
+// Generated on Fri, 29 Apr 2022 11:08:36 GMT
 
 $tokens--link-color: #025e8d;
 $tokens--link-hover: #01324b;

--- a/context/brand-context/default/scss/00-tokens/_sizing.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_sizing.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 27 Apr 2022 21:29:21 GMT
+// Generated on Fri, 29 Apr 2022 11:08:35 GMT
 
 $tokens--sizing-0: 0; // no spacing, zero.
 $tokens--sizing-25: .0625; // .0625rem, 1px

--- a/context/brand-context/default/scss/00-tokens/_spacing.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_spacing.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 27 Apr 2022 21:29:21 GMT
+// Generated on Fri, 29 Apr 2022 11:08:35 GMT
 
 $tokens--spacing-0: 0; // no spacing, zero.
 $tokens--spacing-100: .25rem; // .25rem, 4px.

--- a/context/brand-context/default/scss/00-tokens/_state.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_state.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 27 Apr 2022 21:29:22 GMT
+// Generated on Fri, 29 Apr 2022 11:08:36 GMT
 
 $tokens--state-focus: #ffcc00;
 $tokens--state-error: #c40606;

--- a/context/brand-context/default/scss/00-tokens/_text.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_text.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 27 Apr 2022 21:29:22 GMT
+// Generated on Fri, 29 Apr 2022 11:08:36 GMT
 
 $tokens--text-primary: #000000;
 $tokens--text-secondary: #666666;

--- a/context/brand-context/nature/scss/00-tokens/_illustration.variables.scss
+++ b/context/brand-context/nature/scss/00-tokens/_illustration.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 27 Apr 2022 21:29:22 GMT
+// Generated on Fri, 29 Apr 2022 11:08:36 GMT
 
 $tokens--illustration-background-001: #29303C;
 $tokens--illustration-background-002: #536179;

--- a/context/brand-context/nature/scss/00-tokens/_typography.variables.scss
+++ b/context/brand-context/nature/scss/00-tokens/_typography.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 27 Apr 2022 21:29:22 GMT
+// Generated on Fri, 29 Apr 2022 11:08:36 GMT
 
 $tokens--typography-heading-font-family: serif;
 $tokens--typography-heading-letter-spacing: 0.2rem;

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "21.0.0",
+  "version": "21.0.1",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/springer/scss/00-tokens/_typography.variables.scss
+++ b/context/brand-context/springer/scss/00-tokens/_typography.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 27 Apr 2022 21:29:22 GMT
+// Generated on Fri, 29 Apr 2022 11:08:36 GMT
 
 $tokens--typography-heading-font-family: serif;
 $tokens--typography-heading-letter-spacing: 0.2rem;

--- a/context/brand-context/springernature/scss/00-tokens/_breakpoints.variables.scss
+++ b/context/brand-context/springernature/scss/00-tokens/_breakpoints.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 27 Apr 2022 21:29:21 GMT
+// Generated on Fri, 29 Apr 2022 11:08:35 GMT
 
 $tokens--breakpoints-tablet-width: 480px; // tablet-width
 $tokens--breakpoints-tablet-wide-width: 768px; // tablet-wide-width

--- a/context/brand-context/springernature/scss/00-tokens/_typography.variables.scss
+++ b/context/brand-context/springernature/scss/00-tokens/_typography.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 27 Apr 2022 21:29:22 GMT
+// Generated on Fri, 29 Apr 2022 11:08:36 GMT
 
 $tokens--typography-heading-font-family: serif;
 $tokens--typography-heading-letter-spacing: 0.2rem;

--- a/context/design-tokens/alias/default/background/background.json
+++ b/context/design-tokens/alias/default/background/background.json
@@ -4,7 +4,7 @@
 			"value": "{color.grayscale.200}"
 		},
 		"container": {
-			"value": "color.white}"
+			"value": "{color.white}"
 		},
 		"facet": {
 			"value": "{color.grayscale.300}"


### PR DESCRIPTION
@morgaan reached out with a but that was producing 

`$tokens--background-container: color.white};`

looks like we missed a curly bracket in a `.json` file. 

This PR fixes that.

To make sure this doesn't happen in future - I'm investigating ways to 'test' the `.json` so it adheres to some sort of spec. 

🙏🖤 