### PR TITLE
manually removes `_index.scss` file from the `_index.scss` file

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 21.0.2 (2022-04-29)
+    * BUG
+      * manually removes `_index.scss` file from the `_index.scss` file for each brands generated tokens.
 ## 21.0.1 (2022-04-29)
     * BUG
       * fixes issue with compiled Design Tokens having an missing opening curly brace

--- a/context/brand-context/default/scss/00-tokens/_background.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_background.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 11:08:36 GMT
+// Generated on Fri, 29 Apr 2022 11:42:50 GMT
 
 $tokens--background-page: #f8f8f8;
 $tokens--background-container: #ffffff;

--- a/context/brand-context/default/scss/00-tokens/_border.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_border.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 11:08:36 GMT
+// Generated on Fri, 29 Apr 2022 11:42:50 GMT
 
 $tokens--border-color-primary: #000000;
 $tokens--border-color-input: #555555;

--- a/context/brand-context/default/scss/00-tokens/_breakpoints.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_breakpoints.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 11:08:35 GMT
+// Generated on Fri, 29 Apr 2022 11:42:50 GMT
 
 $tokens--breakpoints-xs: 320px; // mobile
 $tokens--breakpoints-sm: 580px; // small tablet

--- a/context/brand-context/default/scss/00-tokens/_button.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_button.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 11:08:36 GMT
+// Generated on Fri, 29 Apr 2022 11:42:50 GMT
 
 $tokens--button-background-primary-resting: #025e8d;
 $tokens--button-background-primary-hover: #ffffff;

--- a/context/brand-context/default/scss/00-tokens/_index.scss
+++ b/context/brand-context/default/scss/00-tokens/_index.scss
@@ -2,7 +2,6 @@
 @import '_border.variables.scss';
 @import '_breakpoints.variables.scss';
 @import '_button.variables.scss';
-@import '_index.scss';
 @import '_link.variables.scss';
 @import '_sizing.variables.scss';
 @import '_spacing.variables.scss';

--- a/context/brand-context/default/scss/00-tokens/_link.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_link.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 11:08:36 GMT
+// Generated on Fri, 29 Apr 2022 11:42:50 GMT
 
 $tokens--link-color: #025e8d;
 $tokens--link-hover: #01324b;

--- a/context/brand-context/default/scss/00-tokens/_sizing.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_sizing.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 11:08:35 GMT
+// Generated on Fri, 29 Apr 2022 11:42:50 GMT
 
 $tokens--sizing-0: 0; // no spacing, zero.
 $tokens--sizing-25: .0625; // .0625rem, 1px

--- a/context/brand-context/default/scss/00-tokens/_spacing.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_spacing.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 11:08:35 GMT
+// Generated on Fri, 29 Apr 2022 11:42:50 GMT
 
 $tokens--spacing-0: 0; // no spacing, zero.
 $tokens--spacing-100: .25rem; // .25rem, 4px.

--- a/context/brand-context/default/scss/00-tokens/_state.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_state.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 11:08:36 GMT
+// Generated on Fri, 29 Apr 2022 11:42:50 GMT
 
 $tokens--state-focus: #ffcc00;
 $tokens--state-error: #c40606;

--- a/context/brand-context/default/scss/00-tokens/_text.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_text.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 11:08:36 GMT
+// Generated on Fri, 29 Apr 2022 11:42:50 GMT
 
 $tokens--text-primary: #000000;
 $tokens--text-secondary: #666666;

--- a/context/brand-context/nature/scss/00-tokens/_illustration.variables.scss
+++ b/context/brand-context/nature/scss/00-tokens/_illustration.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 11:08:36 GMT
+// Generated on Fri, 29 Apr 2022 11:42:50 GMT
 
 $tokens--illustration-background-001: #29303C;
 $tokens--illustration-background-002: #536179;

--- a/context/brand-context/nature/scss/00-tokens/_index.scss
+++ b/context/brand-context/nature/scss/00-tokens/_index.scss
@@ -1,3 +1,2 @@
 @import '_illustration.variables.scss';
-@import '_index.scss';
 @import '_typography.variables.scss';

--- a/context/brand-context/nature/scss/00-tokens/_typography.variables.scss
+++ b/context/brand-context/nature/scss/00-tokens/_typography.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 11:08:36 GMT
+// Generated on Fri, 29 Apr 2022 11:42:50 GMT
 
 $tokens--typography-heading-font-family: serif;
 $tokens--typography-heading-letter-spacing: 0.2rem;

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "21.0.1",
+  "version": "21.0.2",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/springer/scss/00-tokens/_index.scss
+++ b/context/brand-context/springer/scss/00-tokens/_index.scss
@@ -1,2 +1,1 @@
-@import '_index.scss';
 @import '_typography.variables.scss';

--- a/context/brand-context/springer/scss/00-tokens/_typography.variables.scss
+++ b/context/brand-context/springer/scss/00-tokens/_typography.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 11:08:36 GMT
+// Generated on Fri, 29 Apr 2022 11:42:50 GMT
 
 $tokens--typography-heading-font-family: serif;
 $tokens--typography-heading-letter-spacing: 0.2rem;

--- a/context/brand-context/springernature/scss/00-tokens/_breakpoints.variables.scss
+++ b/context/brand-context/springernature/scss/00-tokens/_breakpoints.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 11:08:35 GMT
+// Generated on Fri, 29 Apr 2022 11:42:50 GMT
 
 $tokens--breakpoints-tablet-width: 480px; // tablet-width
 $tokens--breakpoints-tablet-wide-width: 768px; // tablet-wide-width

--- a/context/brand-context/springernature/scss/00-tokens/_index.scss
+++ b/context/brand-context/springernature/scss/00-tokens/_index.scss
@@ -1,3 +1,2 @@
 @import '_breakpoints.variables.scss';
-@import '_index.scss';
 @import '_typography.variables.scss';

--- a/context/brand-context/springernature/scss/00-tokens/_typography.variables.scss
+++ b/context/brand-context/springernature/scss/00-tokens/_typography.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 11:08:36 GMT
+// Generated on Fri, 29 Apr 2022 11:42:50 GMT
 
 $tokens--typography-heading-font-family: serif;
 $tokens--typography-heading-letter-spacing: 0.2rem;


### PR DESCRIPTION
It appears my little bit of JS to generate a manifest file for each brands set of tokens has regressed and is now including itself in the list of `@imports` 

This PR is a 'hotfix' (I guess) as I've manually removed the `@import "_index.scss" for each brands `00-tokens`. 

I've run a local Sass compile and it's not erroring now. 

🙏🖤 