### PR TITLE
using default base size of 1.125rem

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,5 +1,6 @@
 # History
-
+## 21.0.4 (2022-05-04)
+    * uses base font size for springer text furniture
 ## 21.0.3 (2022-04-29)
     * BUG
       * removes de-duplication of creating an `_index.scss` file.

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "21.0.3",
+  "version": "21.0.4",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/springer/scss/10-settings/typography.scss
+++ b/context/brand-context/springer/scss/10-settings/typography.scss
@@ -21,5 +21,5 @@ $context--font-size-h3-min: $context--font-size-h4;
 $context--font-size-h4-min: $context--font-size-h5;
 $context--font-size-h5-min: 1rem;
 
-$context--font-size-furniture: $context--font-size-sm;
-$context--font-size-interface: $context--font-size-sm;
+$context--font-size-furniture: $context--font-size-base;
+$context--font-size-interface: $context--font-size-base;


### PR DESCRIPTION
The furniture font size was incorrectly `1rem`. Since we hack the `body` size for an old Chrome bug it should be `1.125rem`, hence this PR!