### PR TITLE
Springer Hero image and content now optional

### DIFF
--- a/toolkits/springer/packages/springer-hero/HISTORY.md
+++ b/toolkits/springer/packages/springer-hero/HISTORY.md
@@ -1,4 +1,6 @@
 # History
+## 0.2.0 (2022-05-06)
+    * Image and content now optional
 ## 0.1.3 (2022-04-04)
     * Image sized to content (and automatically is removed from narrow view)
 ## 0.1.2 (2022-02-18)

--- a/toolkits/springer/packages/springer-hero/README.md
+++ b/toolkits/springer/packages/springer-hero/README.md
@@ -15,6 +15,8 @@ Then compile the template located in the `./view` folder whenever the component 
 
 ## Variants
 
+Both the image (`imageSrc`) and content (`content`) are optional. The component reconfigures automatically where these properties are omitted.
+
 ### `imageLeft`
 
 You can display the image on the right (default; bottom on smaller screens) or left (top on smaller screens) by changing the data’s `imageLeft` property to `true`.

--- a/toolkits/springer/packages/springer-hero/demo/context.json
+++ b/toolkits/springer/packages/springer-hero/demo/context.json
@@ -5,11 +5,22 @@
 		"content": "<ul><li>First item of list</li><li>Another list item</li><li>The final item in the list</li></ul>",
 		"imageLeft": false
 	},
+	"defaultNoImage": {
+		"title": "What a hero",
+		"content": "<ul><li>First item of list</li><li>Another list item</li><li>The final item in the list</li></ul>",
+		"imageLeft": false
+	},
 	"customColor": {
 		"title": "Custom color hero",
 		"color": "#000",
 		"imageSrc": "https://picsum.photos/700/700",
 		"content": "<ul><li>First item of list</li><li>Another list item</li><li>The final item in the list</li></ul>",
+		"imageLeft": false
+	},
+	"customColorNoContent": {
+		"title": "Custom color hero",
+		"color": "#000",
+		"imageSrc": "https://picsum.photos/700/700",
 		"imageLeft": false
 	},
 	"dynamicPartials": {

--- a/toolkits/springer/packages/springer-hero/demo/dist/index.html
+++ b/toolkits/springer/packages/springer-hero/demo/dist/index.html
@@ -3,6 +3,7 @@
     		(function(e){var t=e.documentElement,n=e.implementation;t.className='js';})(document)
 		</script>
 		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<title>@springernature/springer-hero</title>
 		<style>
 			@charset "UTF-8";
@@ -1728,7 +1729,6 @@ cite {
 
 .c-hero__image {
   position: relative;
-  min-height: 17rem;
   flex-grow: 1;
   flex-basis: 30rem;
 }
@@ -1768,21 +1768,37 @@ cite {
 <div class="c-hero">
 		<div class="c-hero__content">
 			<h1>What a hero</h1>
-			<ul><li>First item of list</li><li>Another list item</li><li>The final item in the list</li></ul>
+				<ul><li>First item of list</li><li>Another list item</li><li>The final item in the list</li></ul>
 		</div>
-		<div class="c-hero__image">
-			<img src="https://picsum.photos/800/600" alt="">
+			<div class="c-hero__image">
+				<img src="https://picsum.photos/800/600" alt="">
+			</div>
+</div>
+<h2 class="u-mt-32">Default without <code>imgSrc</code></h2>
+<div class="c-hero">
+		<div class="c-hero__content">
+			<h1>What a hero</h1>
+				<ul><li>First item of list</li><li>Another list item</li><li>The final item in the list</li></ul>
 		</div>
 </div>
 <h2 class="u-mt-32">Custom background color</h2>
 <div class="c-hero" style="background-color: #000">
 		<div class="c-hero__content">
 			<h1>Custom color hero</h1>
-			<ul><li>First item of list</li><li>Another list item</li><li>The final item in the list</li></ul>
+				<ul><li>First item of list</li><li>Another list item</li><li>The final item in the list</li></ul>
 		</div>
-		<div class="c-hero__image">
-			<img src="https://picsum.photos/700/700" alt="">
+			<div class="c-hero__image">
+				<img src="https://picsum.photos/700/700" alt="">
+			</div>
+</div>
+<h2 class="u-mt-32">Custom background color with no <code>content</code></h2>
+<div class="c-hero" style="background-color: #000">
+		<div class="c-hero__content">
+			<h1>Custom color hero</h1>
 		</div>
+			<div class="c-hero__image">
+				<img src="https://picsum.photos/700/700" alt="">
+			</div>
 </div>
 
 		<script>

--- a/toolkits/springer/packages/springer-hero/demo/index.hbs
+++ b/toolkits/springer/packages/springer-hero/demo/index.hbs
@@ -1,4 +1,8 @@
 <h2>Default</h2>
 {{>hero default}}
+<h2 class="u-mt-32">Default without <code>imgSrc</code></h2>
+{{>hero defaultNoImage}}
 <h2 class="u-mt-32">Custom background color</h2>
 {{>hero customColor}}
+<h2 class="u-mt-32">Custom background color with no <code>content</code></h2>
+{{>hero customColorNoContent}}

--- a/toolkits/springer/packages/springer-hero/package.json
+++ b/toolkits/springer/packages/springer-hero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-hero",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "license": "MIT",
   "description": "A hero component, principally for subject/discipline pages",
   "keywords": [],

--- a/toolkits/springer/packages/springer-hero/view/springer-hero.hbs
+++ b/toolkits/springer/packages/springer-hero/view/springer-hero.hbs
@@ -1,19 +1,27 @@
 <div class="c-hero"{{#if color}} style="background-color: {{color}}"{{/if}}>
 	{{#if imageLeft}}
-		<div class="c-hero__image">
-			<img src="{{imageSrc}}" alt=""/>
-		</div>
+		{{#if imageSrc}}
+			<div class="c-hero__image">
+				<img src="{{imageSrc}}" alt=""/>
+			</div>
+		{{/if}}
 		<div class="c-hero__content">
 			<h1>{{title}}</h1>
-			{{{content}}}
+			{{#if content}}
+				{{{content}}}
+			{{/if}}
 		</div>
 	{{else}}
 		<div class="c-hero__content">
 			<h1>{{title}}</h1>
-			{{{content}}}
+			{{#if content}}
+				{{{content}}}
+			{{/if}}
 		</div>
-		<div class="c-hero__image">
-			<img src="{{imageSrc}}" alt=""/>
-		</div>
+		{{#if imageSrc}}
+			<div class="c-hero__image">
+				<img src="{{imageSrc}}" alt=""/>
+			</div>
+		{{/if}}
 	{{/if}}
 </div>


### PR DESCRIPTION
```
## 0.2.0 (2022-05-06)
    * Image and content now optional
```

Changed the template logic to reflect how people use the CMS.