### PR TITLE
uses negation to left align lists without classes

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,4 +1,6 @@
 # History
+## 21.1.1 (2022-05-23)
+    * Left aligns basic lists in the springer context
 ## 21.1.0 (2022-05-10)
     * Adds a new icon for the use of expanding images
     

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "21.1.0",
+  "version": "21.1.1",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/springer/scss/40-base/typography.scss
+++ b/context/brand-context/springer/scss/40-base/typography.scss
@@ -34,6 +34,13 @@ dl {
 	margin-top: 0;
 }
 
+/* Basic lists should be aligned to the left */
+ul:not([class]),
+ol:not([class]) {
+	/* Allow for bullet itself */
+	padding-left: 0.9em;
+}
+
 dd {
 	margin: 0;
 }


### PR DESCRIPTION
```
## 21.1.1 (2022-05-23)
    * Left aligns basic lists in the springer context
```

`0.9em` feels magic numbery 😬 but I tested across multiple fonts and font-sizes and it is the most reliable value.

```
/* Basic lists should be aligned to the left */
ul:not([class]),
ol:not([class]) {
	/* Allow for bullet itself */
	padding-left: 0.9em;
}
```