### PR TITLE
IE image fix

### DIFF
--- a/toolkits/global/packages/global-card/HISTORY.md
+++ b/toolkits/global/packages/global-card/HISTORY.md
@@ -1,4 +1,6 @@
 # History
+## 8.2.2 (2022-05-30)
+    * Adjustment for better IE11 rendering
 ## 8.2.1 (2022-05-17)
     * Corrected padding for shaped cards with no images
 ## 8.2.0 (2022-04-04)

--- a/toolkits/global/packages/global-card/demo/context.json
+++ b/toolkits/global/packages/global-card/demo/context.json
@@ -31,7 +31,7 @@
 			{
 				"noBlockLink": true,
 				"image": {
-					"src": "https://picsum.photos/400/300",
+					"src": "https://picsum.photos/200/200",
 					"alt": "descriptive alternative text"
 				},
 				"title": "No Block Link",

--- a/toolkits/global/packages/global-card/demo/dist/index.html
+++ b/toolkits/global/packages/global-card/demo/dist/index.html
@@ -1397,7 +1397,6 @@ cite {
 }
 
 .c-card__image {
-  flex: 0 1 auto;
   position: relative;
   display: flex;
   justify-content: center;
@@ -1412,16 +1411,14 @@ cite {
 }
 .c-card__image img {
   position: absolute;
-  max-width: unset;
+  left: 0;
   min-width: 100%;
   min-height: 100%;
-  transform: translateY(-50%);
 }
 @supports (object-fit: cover) {
   .c-card__image img {
     width: 100%;
     height: 100%;
-    transform: unset;
     object-fit: cover;
   }
 }
@@ -1564,7 +1561,7 @@ cite {
 		</div>
 		<div class="c-card">
 			<div class="c-card__image">
-				<img src="https://picsum.photos/400/300" alt="descriptive alternative text">
+				<img src="https://picsum.photos/200/200" alt="descriptive alternative text">
 			</div>
 		    <div class="c-card__body">
 				<h3 class="c-card__title">

--- a/toolkits/global/packages/global-card/demo/main.scss
+++ b/toolkits/global/packages/global-card/demo/main.scss
@@ -1,5 +1,5 @@
-@import '../node_modules/@springernature/brand-context/default/scss/core.scss';
-@import '../node_modules/@springernature/brand-context/default/scss/enhanced.scss';
+@import '../node_modules/@springernature/brand-context/springer/scss/core.scss';
+@import '../node_modules/@springernature/brand-context/springer/scss/enhanced.scss';
 
-@import '../scss/10-settings/default';
+@import '../scss/10-settings/springer';
 @import '../scss/50-components/card';

--- a/toolkits/global/packages/global-card/package.json
+++ b/toolkits/global/packages/global-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-card",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "license": "MIT",
   "description": "card component",
   "keywords": [

--- a/toolkits/global/packages/global-card/scss/50-components/card.scss
+++ b/toolkits/global/packages/global-card/scss/50-components/card.scss
@@ -22,7 +22,6 @@
 }
 
 .c-card__image {
-	flex: 0 1 auto;
 	position: relative;
 	display: flex;
 	// Center image horizontally
@@ -40,16 +39,14 @@
 	// Not direct child due to picture element usage
 	img {
 		position: absolute;
-		max-width: unset;
+		left: 0;
 		// Maintain aspect ratio but overflow container
 		// possibly in both dimensions
 		min-width: 100%;
 		min-height: 100%;
-		transform: translateY(-50%);
 		@supports (object-fit: cover) {
 			width: 100%;
 			height: 100%;
-			transform: unset;
 			// Maintain aspect ratio
 			// but only overflow in on dimension
 			object-fit: cover;


### PR DESCRIPTION
* The fallback for IE did not work quite as expected in real IE11
* This has been addressed by removing a `transform` and setting an explicit `left: 0` for the positioning

### Before

<img width="410" alt="broken layout" src="https://user-images.githubusercontent.com/683558/171023945-65a38675-feaa-4e87-b781-f9dc3ee8f157.png">

### After

<img width="409" alt="unbroken layout" src="https://user-images.githubusercontent.com/683558/171023977-9544cc25-5a82-490a-9a48-a955506e0821.png">
