### PR TITLE
Fix Springer Nature media queries to use correct breakpoint keys

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,6 +1,8 @@
 # History
+## 22.2.0 (2022-06-10)
+    * BUG: Springer Nature brand-context media queires were using old breakpoint keys instead of news ones introduced in v22.0.0 
 ## 22.1.0 (2022-06-08)
-      * Adds u-hide-print mixin 
+    * Adds u-hide-print mixin 
 ## 22.0.0 (2022-05-24)
     * BREAKING
       * Updates SpringerNature brand-context breakpoints keys to match default brand-context 

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "22.1.0",
+  "version": "22.2.0",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/springernature/scss/30-mixins/media-query.scss
+++ b/context/brand-context/springernature/scss/30-mixins/media-query.scss
@@ -1,35 +1,35 @@
 @mixin from-tablet {
-	@include media-query('tablet-width', 'min', $context--breakpoints) {
+	@include media-query('xs', 'min', $context--breakpoints) {
 		@content;
 	}
 }
 
 @mixin from-wide-tablet {
-	@include media-query('tablet-wide-width', 'min', $context--breakpoints) {
+	@include media-query('sm', 'min', $context--breakpoints) {
 		@content;
 	}
 }
 
 @mixin from-desktop {
-	@include media-query('desktop-width', 'min', $context--breakpoints) {
+	@include media-query('lg', 'min', $context--breakpoints) {
 		@content;
 	}
 }
 
 @mixin from-wide-layout {
-	@include media-query('wide-layout', 'min', $context--breakpoints) {
+	@include media-query('md', 'min', $context--breakpoints) {
 		@content;
 	}
 }
 
 @mixin until-tablet {
-	@include media-query('tablet-width', 'max', $context--breakpoints) {
+	@include media-query('xs', 'max', $context--breakpoints) {
 		@content;
 	}
 }
 
 @mixin until-desktop {
-	@include media-query('desktop-width', 'max', $context--breakpoints) {
+	@include media-query('lg', 'max', $context--breakpoints) {
 		@content;
 	}
 }


### PR DESCRIPTION
Caused by this PR https://github.com/springernature/frontend-toolkits/pull/712 and
should have been included in https://github.com/springernature/frontend-toolkits/commit/d45a2b672350ddf18e0866a9db21fbf87c53d7d4.