### PR TITLE
small updates to literal and alias design tokens

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,27 +1,32 @@
 # History
+## 23.0.0 (2022-06-10)
+    * UPDATES:
+      * updates alias color tokens to match recent updates in Sketch.
+    * BREAKING:
+      * removes options 4 and 5 of nature illustration colours available.
 ## 22.2.0 (2022-06-10)
-    * BUG: Springer Nature brand-context media queires were using old breakpoint keys instead of news ones introduced in v22.0.0 
+    * BUG: Springer Nature brand-context media queires were using old breakpoint keys instead of news ones introduced in v22.0.0
 ## 22.1.0 (2022-06-08)
-    * Adds u-hide-print mixin 
+    * Adds u-hide-print mixin
 ## 22.0.0 (2022-05-24)
     * BREAKING
-      * Updates SpringerNature brand-context breakpoints keys to match default brand-context 
+      * Updates SpringerNature brand-context breakpoints keys to match default brand-context
 ## 21.1.1 (2022-05-23)
     * Left aligns basic lists in the springer context
 ## 21.1.0 (2022-05-10)
     * Adds a new icon for the use of expanding images
-    
+
 ## 21.0.4 (2022-05-04)
     * uses base font size for springer text furniture
-    
+
 ## 21.0.3 (2022-04-29)
     * BUG
       * removes de-duplication of creating an `_index.scss` file.
-      
+
 ## 21.0.2 (2022-04-29)
     * BUG
       * manually removes `_index.scss` file from the `_index.scss` file for each brands generated tokens.
-      
+
 ## 21.0.1 (2022-04-29)
     * BUG
       * fixes issue with compiled Design Tokens having an missing opening curly brace

--- a/context/brand-context/default/scss/00-tokens/_background.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_background.variables.scss
@@ -1,11 +1,7 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 12:04:04 GMT
+// Generated on Mon, 27 Jun 2022 09:45:32 GMT
 
 $tokens--background-page: #f8f8f8;
 $tokens--background-container: #ffffff;
-$tokens--background-facet: #f3f3f3;
-$tokens--background-footer: #01324b;
-$tokens--background-table-heading: #666666;
-$tokens--background-table-row-odd: #cedbe0;
-$tokens--background-table-row-even: #ebf1f5;
+$tokens--background-container-inverted: #222222;

--- a/context/brand-context/default/scss/00-tokens/_border.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_border.variables.scss
@@ -1,10 +1,11 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 12:04:04 GMT
+// Generated on Mon, 27 Jun 2022 09:45:32 GMT
 
-$tokens--border-color-primary: #000000;
+$tokens--border-color-primary: #222222;
 $tokens--border-color-input: #555555;
 $tokens--border-color-button: #025e8d;
+$tokens--border-color-indent: #dadada;
 $tokens--border-width-25: .0625;
 $tokens--border-width-50: .125rem;
 $tokens--border-width-100: .25rem;

--- a/context/brand-context/default/scss/00-tokens/_breakpoints.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_breakpoints.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 12:04:04 GMT
+// Generated on Mon, 27 Jun 2022 09:45:32 GMT
 
 $tokens--breakpoints-xs: 320px; // mobile
 $tokens--breakpoints-sm: 580px; // small tablet

--- a/context/brand-context/default/scss/00-tokens/_button.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_button.variables.scss
@@ -1,8 +1,8 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 12:04:04 GMT
+// Generated on Mon, 27 Jun 2022 09:45:32 GMT
 
-$tokens--button-background-primary-resting: #025e8d;
+$tokens--button-background-primary-resting: #01324b;
 $tokens--button-background-primary-hover: #ffffff;
 $tokens--button-background-secondary-resting: #ffffff;
-$tokens--button-background-secondary-hover: #025e8d;
+$tokens--button-background-secondary-hover: #01324b;

--- a/context/brand-context/default/scss/00-tokens/_link.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_link.variables.scss
@@ -1,8 +1,8 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 12:04:04 GMT
+// Generated on Mon, 27 Jun 2022 09:45:32 GMT
 
 $tokens--link-color: #025e8d;
 $tokens--link-hover: #01324b;
-$tokens--link-visited: #a345c9;
-$tokens--link-focus: #ffcc00;
+$tokens--link-visited: #01324b;
+$tokens--link-focus: #0088cc;

--- a/context/brand-context/default/scss/00-tokens/_sizing.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_sizing.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 12:04:04 GMT
+// Generated on Mon, 27 Jun 2022 09:45:32 GMT
 
 $tokens--sizing-0: 0; // no spacing, zero.
 $tokens--sizing-25: .0625; // .0625rem, 1px

--- a/context/brand-context/default/scss/00-tokens/_spacing.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_spacing.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 12:04:04 GMT
+// Generated on Mon, 27 Jun 2022 09:45:32 GMT
 
 $tokens--spacing-0: 0; // no spacing, zero.
 $tokens--spacing-100: .25rem; // .25rem, 4px.

--- a/context/brand-context/default/scss/00-tokens/_state.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_state.variables.scss
@@ -1,8 +1,8 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 12:04:04 GMT
+// Generated on Mon, 27 Jun 2022 09:45:32 GMT
 
-$tokens--state-focus: #ffcc00;
+$tokens--state-focus: #0088cc;
 $tokens--state-error: #c40606;
 $tokens--state-warning: #f58220;
 $tokens--state-success: #00a69d;

--- a/context/brand-context/default/scss/00-tokens/_text.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_text.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 12:04:04 GMT
+// Generated on Mon, 27 Jun 2022 09:45:32 GMT
 
 $tokens--text-primary: #000000;
 $tokens--text-secondary: #666666;

--- a/context/brand-context/nature/scss/00-tokens/_illustration.variables.scss
+++ b/context/brand-context/nature/scss/00-tokens/_illustration.variables.scss
@@ -1,9 +1,7 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 12:04:04 GMT
+// Generated on Mon, 27 Jun 2022 09:45:32 GMT
 
 $tokens--illustration-background-001: #29303C;
 $tokens--illustration-background-002: #536179;
 $tokens--illustration-background-003: #c2c9d6;
-$tokens--illustration-background-004: #999999;
-$tokens--illustration-background-005: #dadada;

--- a/context/brand-context/nature/scss/00-tokens/_typography.variables.scss
+++ b/context/brand-context/nature/scss/00-tokens/_typography.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 12:04:04 GMT
+// Generated on Mon, 27 Jun 2022 09:45:32 GMT
 
 $tokens--typography-heading-font-family: serif;
 $tokens--typography-heading-letter-spacing: 0.2rem;
@@ -11,3 +11,5 @@ $tokens--typography-heading-level-1-fluid-font-size: clamp(1.5rem, 4vw, 2rem);
 $tokens--typography-heading-level-2-default-font-size: 1.5rem;
 $tokens--typography-heading-level-2-fluid-font-size: clamp(1.25rem, 4vw, 1.5rem);
 $tokens--typography-heading-level-3-default-font-size: 1.25rem;
+$tokens--typography-heading-level-4-default-font-size: 1.25rem;
+$tokens--typography-heading-level-5-default-font-size: 1.125rem;

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "22.2.0",
+  "version": "23.0.0",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/springer/scss/00-tokens/_index.scss
+++ b/context/brand-context/springer/scss/00-tokens/_index.scss
@@ -1,1 +1,2 @@
+@import '_illustration.variables.scss';
 @import '_typography.variables.scss';

--- a/context/brand-context/springer/scss/00-tokens/_typography.variables.scss
+++ b/context/brand-context/springer/scss/00-tokens/_typography.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 12:04:04 GMT
+// Generated on Mon, 27 Jun 2022 09:45:32 GMT
 
 $tokens--typography-heading-font-family: serif;
 $tokens--typography-heading-letter-spacing: 0.2rem;

--- a/context/brand-context/springernature/scss/00-tokens/_breakpoints.variables.scss
+++ b/context/brand-context/springernature/scss/00-tokens/_breakpoints.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 12:04:04 GMT
+// Generated on Mon, 27 Jun 2022 09:45:32 GMT
 
 $tokens--breakpoints-tablet-width: 480px; // tablet-width
 $tokens--breakpoints-tablet-wide-width: 768px; // tablet-wide-width

--- a/context/brand-context/springernature/scss/00-tokens/_typography.variables.scss
+++ b/context/brand-context/springernature/scss/00-tokens/_typography.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Apr 2022 12:04:04 GMT
+// Generated on Mon, 27 Jun 2022 09:45:32 GMT
 
 $tokens--typography-heading-font-family: serif;
 $tokens--typography-heading-letter-spacing: 0.2rem;

--- a/context/design-tokens/alias/default/background/background.json
+++ b/context/design-tokens/alias/default/background/background.json
@@ -6,24 +6,28 @@
 		"container": {
 			"value": "{color.white}"
 		},
+		"container-inverted": {
+			"value": "{color.grayscale.800}"
+		},
+	}
 		"facet": {
-			"value": "{color.grayscale.300}"
+		"value": "{color.grayscale.300}"
+	},
+	"footer": {
+		"value": "{color.primary.universal-dark-blue}"
+	},
+	"table": {
+		"heading": {
+			"value": "{color.grayscale.600}"
 		},
-		"footer": {
-			"value": "{color.primary.universal-dark-blue}"
-		},
-		"table": {
-			"heading": {
-				"value": "{color.grayscale.600}"
+		"row": {
+			"odd": {
+				"value": "{color.primary.grey-blue-light-2}"
 			},
-			"row": {
-				"odd": {
-					"value": "{color.primary.grey-blue-light-2}"
-				},
-				"even": {
-					"value": "{color.primary.grey-blue-light-1}"
-				}
+			"even": {
+				"value": "{color.primary.grey-blue-light-1}"
 			}
 		}
 	}
+}
 }

--- a/context/design-tokens/alias/default/background/background.json
+++ b/context/design-tokens/alias/default/background/background.json
@@ -8,9 +8,9 @@
 		},
 		"container-inverted": {
 			"value": "{color.grayscale.800}"
-		},
-	}
-		"facet": {
+		}
+	},
+	"facet": {
 		"value": "{color.grayscale.300}"
 	},
 	"footer": {
@@ -29,5 +29,4 @@
 			}
 		}
 	}
-}
 }

--- a/context/design-tokens/alias/default/border/border.json
+++ b/context/design-tokens/alias/default/border/border.json
@@ -2,13 +2,16 @@
 	"border": {
 		"color": {
 			"primary": {
-				"value": "{color.black}"
+				"value": "{color.grayscale.800}"
 			},
 			"input": {
 				"value": "{color.grayscale.700}"
 			},
 			"button": {
 				"value": "{color.primary.medium-blue}"
+			},
+			"indent": {
+				"value": "{color.grayscale.400}"
 			}
 		},
 		"width": {

--- a/context/design-tokens/alias/default/button/button.json
+++ b/context/design-tokens/alias/default/button/button.json
@@ -3,7 +3,7 @@
 		"background": {
 			"primary": {
 				"resting": {
-					"value": "{color.primary.universal-dark-blue}",
+					"value": "{color.primary.universal-dark-blue}"
 				},
 				"hover": {
 					"value": "{color.white}"

--- a/context/design-tokens/alias/default/button/button.json
+++ b/context/design-tokens/alias/default/button/button.json
@@ -3,7 +3,7 @@
 		"background": {
 			"primary": {
 				"resting": {
-					"value": "{color.primary.medium-blue}"
+					"value": "{color.primary.universal-dark-blue}",
 				},
 				"hover": {
 					"value": "{color.white}"
@@ -14,10 +14,9 @@
 					"value": "{color.white}"
 				},
 				"hover": {
-					"value": "{color.primary.medium-blue}"
+					"value": "{color.primary.universal-dark-blue}"
 				}
 			}
-
 		}
 	}
 }

--- a/context/design-tokens/alias/default/link/link.json
+++ b/context/design-tokens/alias/default/link/link.json
@@ -7,10 +7,10 @@
 			"value": "{color.primary.universal-dark-blue}"
 		},
 		"visited": {
-			"value": "{color.interaction.visited}"
+			"value": "{color.primary.universal-dark-blue}"
 		},
 		"focus": {
-			"value": "{color.interaction.focus}"
+			"value": "{color.primary.bright-blue}"
 		}
 	}
 }

--- a/context/design-tokens/alias/nature/illustration/illustration.json
+++ b/context/design-tokens/alias/nature/illustration/illustration.json
@@ -12,14 +12,6 @@
 			"003": {
 				"value": "{nature-color.gunmetal.300}",
 				"description": "background color for illustrations"
-			},
-			"004": {
-				"value": "{color.grayscale.500}",
-				"description": "background color for illustrations"
-			},
-			"005": {
-				"value": "{color.grayscale.400}",
-				"description": "background color for illustrations"
 			}
 		}
 	}

--- a/context/design-tokens/alias/nature/typography/typography.json
+++ b/context/design-tokens/alias/nature/typography/typography.json
@@ -43,6 +43,20 @@
 						"value": "{font-size.500.value}"
 					}
 				}
+			},
+			"level-4": {
+				"default": {
+					"font-size": {
+						"value": "{font-size.500}"
+					}
+				}
+			},
+			"level-5": {
+				"default": {
+					"font-size": {
+						"value": "{font-size.450}"
+					}
+				}
 			}
 		}
 	}

--- a/context/design-tokens/literal/default/color/color.json
+++ b/context/design-tokens/literal/default/color/color.json
@@ -45,6 +45,9 @@
 			"medium-blue": {
 				"value": "#025E8D"
 			},
+			"bright-blue": {
+				"value": "#0088CC"
+			},
 			"grey-blue-light-1": {
 				"value": "#EBF1F5"
 			},
@@ -80,7 +83,7 @@
 				"value": "#A345C9"
 			},
 			"focus": {
-				"value": "#FFCC00"
+				"value": "{color.primary.bright-blue}"
 			}
 		}
 	}


### PR DESCRIPTION
@foxintherain has recently made some updates to the Sketch files to make sure they're consistent with the Design Tokens naming convention. They noticed some errors that have been rectified. This PR updates to match the [updated styleguide in Sketch](https://www.sketch.com/s/fa9c2fc9-a179-43f0-b21e-9562c9c17c0c/p/F36D7BB7-BA2F-4E89-BB54-80C7DB72A707).

## Literal Tokens
### Adds
- `colors.primary.bright-blue` token (#0088CC).
### Changes
- default focus style to use new `colors.primary.bright-blue`.
---
## Alias Tokens
### Adds
- `border.color.indent` token for use with indent global form elements.
- adds H4 and H5 typographic styles for Nature.
### Changes
- `border.color.primary` token to reference `color.grayscale.800`.
- primary and secondary button colours.
- text link `visited` and `focus` styles.
### Removes
- `004` and `005` variants of illustration colours for Nature.
---
## Front-End Toolkits
Generates new `.scss` as needed from new design tokens files.


