### PR TITLE
more token updates needed.

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,4 +1,11 @@
 # History
+
+## 24.0.0 (2022-06-28)
+    * UPDATES:
+      * adds border width design tokens
+    * BREAKING:
+      * removes exisiting relative spacing and sizing tokens
+      * creates new namespaced 'relative' and 'absolute' spacing and sizing tokens
 ## 23.0.0 (2022-06-10)
     * UPDATES:
       * updates alias color tokens to match recent updates in Sketch.

--- a/context/brand-context/default/scss/00-tokens/_background.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_background.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 28 Jun 2022 09:55:43 GMT
+// Generated on Tue, 28 Jun 2022 10:44:21 GMT
 
 $tokens--background-page: #f8f8f8;
 $tokens--background-container: #ffffff;

--- a/context/brand-context/default/scss/00-tokens/_background.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_background.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 27 Jun 2022 09:45:32 GMT
+// Generated on Tue, 28 Jun 2022 09:55:43 GMT
 
 $tokens--background-page: #f8f8f8;
 $tokens--background-container: #ffffff;

--- a/context/brand-context/default/scss/00-tokens/_border.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_border.variables.scss
@@ -1,11 +1,14 @@
 
 // Do not edit directly
-// Generated on Mon, 27 Jun 2022 09:45:32 GMT
+// Generated on Tue, 28 Jun 2022 09:55:43 GMT
 
-$tokens--border-color-primary: #222222;
+$tokens--border-color-primary: #000000;
 $tokens--border-color-input: #555555;
 $tokens--border-color-button: #025e8d;
 $tokens--border-color-indent: #dadada;
-$tokens--border-width-25: .0625;
-$tokens--border-width-50: .125rem;
-$tokens--border-width-100: .25rem;
+$tokens--border-radius-50: 2px;
+$tokens--border-radius-100: 4px;
+$tokens--border-width-25: 1px;
+$tokens--border-width-50: 2px;
+$tokens--border-width-100: 4px;
+$tokens--border-width-200: 8px;

--- a/context/brand-context/default/scss/00-tokens/_border.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_border.variables.scss
@@ -1,10 +1,10 @@
 
 // Do not edit directly
-// Generated on Tue, 28 Jun 2022 09:55:43 GMT
+// Generated on Tue, 28 Jun 2022 10:44:21 GMT
 
-$tokens--border-color-primary: #000000;
+$tokens--border-color-primary: #222222;
 $tokens--border-color-input: #555555;
-$tokens--border-color-button: #025e8d;
+$tokens--border-color-button: #01324b;
 $tokens--border-color-indent: #dadada;
 $tokens--border-radius-50: 2px;
 $tokens--border-radius-100: 4px;

--- a/context/brand-context/default/scss/00-tokens/_breakpoints.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_breakpoints.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 27 Jun 2022 09:45:32 GMT
+// Generated on Tue, 28 Jun 2022 09:55:43 GMT
 
 $tokens--breakpoints-xs: 320px; // mobile
 $tokens--breakpoints-sm: 580px; // small tablet

--- a/context/brand-context/default/scss/00-tokens/_breakpoints.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_breakpoints.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 28 Jun 2022 09:55:43 GMT
+// Generated on Tue, 28 Jun 2022 10:44:21 GMT
 
 $tokens--breakpoints-xs: 320px; // mobile
 $tokens--breakpoints-sm: 580px; // small tablet

--- a/context/brand-context/default/scss/00-tokens/_button.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_button.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 27 Jun 2022 09:45:32 GMT
+// Generated on Tue, 28 Jun 2022 09:55:43 GMT
 
 $tokens--button-background-primary-resting: #01324b;
 $tokens--button-background-primary-hover: #ffffff;

--- a/context/brand-context/default/scss/00-tokens/_button.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_button.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 28 Jun 2022 09:55:43 GMT
+// Generated on Tue, 28 Jun 2022 10:44:21 GMT
 
 $tokens--button-background-primary-resting: #01324b;
 $tokens--button-background-primary-hover: #ffffff;

--- a/context/brand-context/default/scss/00-tokens/_link.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_link.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 27 Jun 2022 09:45:32 GMT
+// Generated on Tue, 28 Jun 2022 09:55:43 GMT
 
 $tokens--link-color: #025e8d;
 $tokens--link-hover: #01324b;

--- a/context/brand-context/default/scss/00-tokens/_link.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_link.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 28 Jun 2022 09:55:43 GMT
+// Generated on Tue, 28 Jun 2022 10:44:21 GMT
 
 $tokens--link-color: #025e8d;
 $tokens--link-hover: #01324b;

--- a/context/brand-context/default/scss/00-tokens/_sizing.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_sizing.variables.scss
@@ -1,14 +1,24 @@
 
 // Do not edit directly
-// Generated on Mon, 27 Jun 2022 09:45:32 GMT
+// Generated on Tue, 28 Jun 2022 09:55:43 GMT
 
-$tokens--sizing-0: 0; // no spacing, zero.
-$tokens--sizing-25: .0625; // .0625rem, 1px
-$tokens--sizing-50: .125rem; // .125rem, 2px
-$tokens--sizing-100: .25rem; // .25rem, 4px.
-$tokens--sizing-200: .5rem; // .5rem, 8px.
-$tokens--sizing-400: 1rem; // 1rem, 16px.
-$tokens--sizing-600: 1.5rem; // 1.5rem, 24px.
-$tokens--sizing-800: 2rem; // 2rem, 32px.
-$tokens--sizing-1200: 3rem; // 3rem, 48px.
-$tokens--sizing-1600: 4rem; // 4rem, 64px.
+$tokens--sizing-relative-0: 0; // no spacing, zero.
+$tokens--sizing-relative-25: .0625; // .0625rem, 1px
+$tokens--sizing-relative-50: .125rem; // .125rem, 2px
+$tokens--sizing-relative-100: .25rem; // .25rem, 4px.
+$tokens--sizing-relative-200: .5rem; // .5rem, 8px.
+$tokens--sizing-relative-400: 1rem; // 1rem, 16px.
+$tokens--sizing-relative-600: 1.5rem; // 1.5rem, 24px.
+$tokens--sizing-relative-800: 2rem; // 2rem, 32px.
+$tokens--sizing-relative-1200: 3rem; // 3rem, 48px.
+$tokens--sizing-relative-1600: 4rem; // 4rem, 64px.
+$tokens--sizing-absolute-0: 0; // no spacing, zero.
+$tokens--sizing-absolute-25: 1px; // .0625rem, 1px
+$tokens--sizing-absolute-50: 2px; // .125rem, 2px
+$tokens--sizing-absolute-100: 4px; // .25rem, 4px.
+$tokens--sizing-absolute-200: 8px; // .5rem, 8px.
+$tokens--sizing-absolute-400: 16px; // 1rem, 16px.
+$tokens--sizing-absolute-600: 24px; // 1.5rem, 24px.
+$tokens--sizing-absolute-800: 32px; // 2rem, 32px.
+$tokens--sizing-absolute-1200: 48px; // 3rem, 48px.
+$tokens--sizing-absolute-1600: 64px; // 4rem, 64px.

--- a/context/brand-context/default/scss/00-tokens/_sizing.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_sizing.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 28 Jun 2022 09:55:43 GMT
+// Generated on Tue, 28 Jun 2022 10:44:21 GMT
 
 $tokens--sizing-relative-0: 0; // no spacing, zero.
 $tokens--sizing-relative-25: .0625; // .0625rem, 1px

--- a/context/brand-context/default/scss/00-tokens/_spacing.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_spacing.variables.scss
@@ -1,12 +1,20 @@
 
 // Do not edit directly
-// Generated on Mon, 27 Jun 2022 09:45:32 GMT
+// Generated on Tue, 28 Jun 2022 09:55:43 GMT
 
-$tokens--spacing-0: 0; // no spacing, zero.
-$tokens--spacing-100: .25rem; // .25rem, 4px.
-$tokens--spacing-200: .5rem; // .5rem, 8px.
-$tokens--spacing-400: 1rem; // 1rem, 16px.
-$tokens--spacing-600: 1.5rem; // 1.5rem, 24px.
-$tokens--spacing-800: 2rem; // 2rem, 32px.
-$tokens--spacing-1200: 3rem; // 3rem, 48px.
-$tokens--spacing-1600: 4rem; // 4rem, 64px.
+$tokens--spacing-relative-0: 0; // no spacing, zero.
+$tokens--spacing-relative-100: .25rem; // .25rem, 4px.
+$tokens--spacing-relative-200: .5rem; // .5rem, 8px.
+$tokens--spacing-relative-400: 1rem; // 1rem, 16px.
+$tokens--spacing-relative-600: 1.5rem; // 1.5rem, 24px.
+$tokens--spacing-relative-800: 2rem; // 2rem, 32px.
+$tokens--spacing-relative-1200: 3rem; // 3rem, 48px.
+$tokens--spacing-relative-1600: 4rem; // 4rem, 64px.
+$tokens--spacing-absolute-0: 0; // no spacing, zero.
+$tokens--spacing-absolute-100: 4px; // .25rem, 4px.
+$tokens--spacing-absolute-200: 8px; // .5rem, 8px.
+$tokens--spacing-absolute-400: 16px; // 1rem, 16px.
+$tokens--spacing-absolute-600: 24px; // 1.5rem, 24px.
+$tokens--spacing-absolute-800: 32px; // 2rem, 32px.
+$tokens--spacing-absolute-1200: 48px; // 3rem, 48px.
+$tokens--spacing-absolute-1600: 64px; // 4rem, 64px.

--- a/context/brand-context/default/scss/00-tokens/_spacing.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_spacing.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 28 Jun 2022 09:55:43 GMT
+// Generated on Tue, 28 Jun 2022 10:44:21 GMT
 
 $tokens--spacing-relative-0: 0; // no spacing, zero.
 $tokens--spacing-relative-100: .25rem; // .25rem, 4px.

--- a/context/brand-context/default/scss/00-tokens/_state.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_state.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 27 Jun 2022 09:45:32 GMT
+// Generated on Tue, 28 Jun 2022 09:55:43 GMT
 
 $tokens--state-focus: #0088cc;
 $tokens--state-error: #c40606;

--- a/context/brand-context/default/scss/00-tokens/_state.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_state.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 28 Jun 2022 09:55:43 GMT
+// Generated on Tue, 28 Jun 2022 10:44:21 GMT
 
 $tokens--state-focus: #0088cc;
 $tokens--state-error: #c40606;

--- a/context/brand-context/default/scss/00-tokens/_text.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_text.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 27 Jun 2022 09:45:32 GMT
+// Generated on Tue, 28 Jun 2022 09:55:43 GMT
 
 $tokens--text-primary: #000000;
 $tokens--text-secondary: #666666;

--- a/context/brand-context/default/scss/00-tokens/_text.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_text.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 28 Jun 2022 09:55:43 GMT
+// Generated on Tue, 28 Jun 2022 10:44:21 GMT
 
 $tokens--text-primary: #000000;
 $tokens--text-secondary: #666666;

--- a/context/brand-context/nature/scss/00-tokens/_illustration.variables.scss
+++ b/context/brand-context/nature/scss/00-tokens/_illustration.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 27 Jun 2022 09:45:32 GMT
+// Generated on Tue, 28 Jun 2022 09:55:43 GMT
 
 $tokens--illustration-background-001: #29303C;
 $tokens--illustration-background-002: #536179;

--- a/context/brand-context/nature/scss/00-tokens/_illustration.variables.scss
+++ b/context/brand-context/nature/scss/00-tokens/_illustration.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 28 Jun 2022 09:55:43 GMT
+// Generated on Tue, 28 Jun 2022 10:44:21 GMT
 
 $tokens--illustration-background-001: #29303C;
 $tokens--illustration-background-002: #536179;

--- a/context/brand-context/nature/scss/00-tokens/_typography.variables.scss
+++ b/context/brand-context/nature/scss/00-tokens/_typography.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 27 Jun 2022 09:45:32 GMT
+// Generated on Tue, 28 Jun 2022 09:55:43 GMT
 
 $tokens--typography-heading-font-family: serif;
 $tokens--typography-heading-letter-spacing: 0.2rem;

--- a/context/brand-context/nature/scss/00-tokens/_typography.variables.scss
+++ b/context/brand-context/nature/scss/00-tokens/_typography.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 28 Jun 2022 09:55:43 GMT
+// Generated on Tue, 28 Jun 2022 10:44:22 GMT
 
 $tokens--typography-heading-font-family: serif;
 $tokens--typography-heading-letter-spacing: 0.2rem;

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "23.0.0",
+  "version": "24.0.0",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/springer/scss/00-tokens/_index.scss
+++ b/context/brand-context/springer/scss/00-tokens/_index.scss
@@ -1,2 +1,1 @@
-@import '_illustration.variables.scss';
 @import '_typography.variables.scss';

--- a/context/brand-context/springer/scss/00-tokens/_typography.variables.scss
+++ b/context/brand-context/springer/scss/00-tokens/_typography.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 28 Jun 2022 09:55:43 GMT
+// Generated on Tue, 28 Jun 2022 10:44:21 GMT
 
 $tokens--typography-heading-font-family: serif;
 $tokens--typography-heading-letter-spacing: 0.2rem;

--- a/context/brand-context/springer/scss/00-tokens/_typography.variables.scss
+++ b/context/brand-context/springer/scss/00-tokens/_typography.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 27 Jun 2022 09:45:32 GMT
+// Generated on Tue, 28 Jun 2022 09:55:43 GMT
 
 $tokens--typography-heading-font-family: serif;
 $tokens--typography-heading-letter-spacing: 0.2rem;

--- a/context/brand-context/springernature/scss/00-tokens/_breakpoints.variables.scss
+++ b/context/brand-context/springernature/scss/00-tokens/_breakpoints.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 28 Jun 2022 09:55:43 GMT
+// Generated on Tue, 28 Jun 2022 10:44:21 GMT
 
 $tokens--breakpoints-tablet-width: 480px; // tablet-width
 $tokens--breakpoints-tablet-wide-width: 768px; // tablet-wide-width

--- a/context/brand-context/springernature/scss/00-tokens/_breakpoints.variables.scss
+++ b/context/brand-context/springernature/scss/00-tokens/_breakpoints.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 27 Jun 2022 09:45:32 GMT
+// Generated on Tue, 28 Jun 2022 09:55:43 GMT
 
 $tokens--breakpoints-tablet-width: 480px; // tablet-width
 $tokens--breakpoints-tablet-wide-width: 768px; // tablet-wide-width

--- a/context/brand-context/springernature/scss/00-tokens/_typography.variables.scss
+++ b/context/brand-context/springernature/scss/00-tokens/_typography.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 28 Jun 2022 09:55:43 GMT
+// Generated on Tue, 28 Jun 2022 10:44:21 GMT
 
 $tokens--typography-heading-font-family: serif;
 $tokens--typography-heading-letter-spacing: 0.2rem;

--- a/context/brand-context/springernature/scss/00-tokens/_typography.variables.scss
+++ b/context/brand-context/springernature/scss/00-tokens/_typography.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 27 Jun 2022 09:45:32 GMT
+// Generated on Tue, 28 Jun 2022 09:55:43 GMT
 
 $tokens--typography-heading-font-family: serif;
 $tokens--typography-heading-letter-spacing: 0.2rem;

--- a/context/design-tokens/alias/default/background/background.json
+++ b/context/design-tokens/alias/default/background/background.json
@@ -20,13 +20,14 @@
 		"heading": {
 			"value": "{color.grayscale.600}"
 		},
-		"row": {
-			"odd": {
-				"value": "{color.primary.grey-blue-light-2}"
-			},
-			"even": {
-				"value": "{color.primary.grey-blue-light-1}"
-			}
+		"table-heading": {
+			"value": "{color.grayscale.600}"
+		},
+		"table-row-odd": {
+			"value": "{color.primary.grey-blue-light-2}"
+		},
+		"table-row-even": {
+			"value": "{color.primary.grey-blue-light-1}"
 		}
 	}
 }

--- a/context/design-tokens/alias/default/border/border.json
+++ b/context/design-tokens/alias/default/border/border.json
@@ -2,7 +2,7 @@
 	"border": {
 		"color": {
 			"primary": {
-				"value": "{color.grayscale.800}"
+				"value": "{color.black}"
 			},
 			"input": {
 				"value": "{color.grayscale.700}"
@@ -14,15 +14,26 @@
 				"value": "{color.grayscale.400}"
 			}
 		},
-		"width": {
-			"25": {
-				"value": "{sizing.25}"
-			},
+		"radius": {
 			"50": {
-				"value": "{sizing.50}"
+				"value": "{sizing.absolute.50}"
 			},
 			"100": {
-				"value": "{sizing.100}"
+				"value": "{sizing.absolute.100}"
+			}
+		},
+		"width": {
+			"25": {
+				"value": "{sizing.absolute.25}"
+			},
+			"50": {
+				"value": "{sizing.absolute.50}"
+			},
+			"100": {
+				"value": "{sizing.absolute.100}"
+			},
+			"200": {
+				"value": "{sizing.absolute.200}"
 			}
 		}
 	}

--- a/context/design-tokens/alias/default/border/border.json
+++ b/context/design-tokens/alias/default/border/border.json
@@ -2,13 +2,13 @@
 	"border": {
 		"color": {
 			"primary": {
-				"value": "{color.black}"
+				"value": "{color.grayscale.800}"
 			},
 			"input": {
 				"value": "{color.grayscale.700}"
 			},
 			"button": {
-				"value": "{color.primary.medium-blue}"
+				"value": "{color.primary.universal-dark-blue}"
 			},
 			"indent": {
 				"value": "{color.grayscale.400}"

--- a/context/design-tokens/literal/default/sizing/sizing.json
+++ b/context/design-tokens/literal/default/sizing/sizing.json
@@ -1,44 +1,88 @@
 {
 	"sizing": {
-		"0": {
-			"value": "0",
-			"comment": "no spacing, zero."
+		"relative": {
+			"0": {
+				"value": "0",
+				"comment": "no spacing, zero."
+			},
+			"25": {
+				"value": ".0625",
+				"comment": ".0625rem, 1px"
+			},
+			"50": {
+				"value": ".125rem",
+				"comment": ".125rem, 2px"
+			},
+			"100": {
+				"value": ".25rem",
+				"comment": ".25rem, 4px."
+			},
+			"200": {
+				"value": ".5rem",
+				"comment": ".5rem, 8px."
+			},
+			"400": {
+				"value": "1rem",
+				"comment": "1rem, 16px."
+			},
+			"600": {
+				"value": "1.5rem",
+				"comment": "1.5rem, 24px."
+			},
+			"800": {
+				"value": "2rem",
+				"comment": "2rem, 32px."
+			},
+			"1200": {
+				"value": "3rem",
+				"comment": "3rem, 48px."
+			},
+			"1600": {
+				"value": "4rem",
+				"comment": "4rem, 64px."
+			}
 		},
-		"25": {
-			"value": ".0625",
-			"comment": ".0625rem, 1px"
-		},
-		"50": {
-			"value": ".125rem",
-			"comment": ".125rem, 2px"
-		},
-		"100": {
-			"value": ".25rem",
-			"comment": ".25rem, 4px."
-		},
-		"200": {
-			"value": ".5rem",
-			"comment": ".5rem, 8px."
-		},
-		"400": {
-			"value": "1rem",
-			"comment": "1rem, 16px."
-		},
-		"600": {
-			"value": "1.5rem",
-			"comment": "1.5rem, 24px."
-		},
-		"800": {
-			"value": "2rem",
-			"comment": "2rem, 32px."
-		},
-		"1200": {
-			"value": "3rem",
-			"comment": "3rem, 48px."
-		},
-		"1600": {
-			"value": "4rem",
-			"comment": "4rem, 64px."
+		"absolute": {
+			"0": {
+				"value": "0",
+				"comment": "no spacing, zero."
+			},
+			"25": {
+				"value": "1px",
+				"comment": ".0625rem, 1px"
+			},
+			"50": {
+				"value": "2px",
+				"comment": ".125rem, 2px"
+			},
+			"100": {
+				"value": "4px",
+				"comment": ".25rem, 4px."
+			},
+			"200": {
+				"value": "8px",
+				"comment": ".5rem, 8px."
+			},
+			"400": {
+				"value": "16px",
+				"comment": "1rem, 16px."
+			},
+			"600": {
+				"value": "24px",
+				"comment": "1.5rem, 24px."
+			},
+			"800": {
+				"value": "32px",
+				"comment": "2rem, 32px."
+			},
+			"1200": {
+				"value": "48px",
+				"comment": "3rem, 48px."
+			},
+			"1600": {
+				"value": "64px",
+				"comment": "4rem, 64px."
+			}
 		}
 	}
 }

--- a/context/design-tokens/literal/default/spacing/spacing.json
+++ b/context/design-tokens/literal/default/spacing/spacing.json
@@ -1,36 +1,72 @@
 {
-  	"spacing": {
-		"0" : {
-			"value": "0",
-			"comment": "no spacing, zero."
+	"spacing": {
+		"relative": {
+			"0": {
+				"value": "0",
+				"comment": "no spacing, zero."
+			},
+			"100": {
+				"value": ".25rem",
+				"comment": ".25rem, 4px."
+			},
+			"200": {
+				"value": ".5rem",
+				"comment": ".5rem, 8px."
+			},
+			"400": {
+				"value": "1rem",
+				"comment": "1rem, 16px."
+			},
+			"600": {
+				"value": "1.5rem",
+				"comment": "1.5rem, 24px."
+			},
+			"800": {
+				"value": "2rem",
+				"comment": "2rem, 32px."
+			},
+			"1200": {
+				"value": "3rem",
+				"comment": "3rem, 48px."
+			},
+			"1600": {
+				"value": "4rem",
+				"comment": "4rem, 64px."
+			}
 		},
-		"100" : {
-			"value": ".25rem",
-			"comment": ".25rem, 4px."
-		},
-		"200" : {
-			"value": ".5rem",
-			"comment": ".5rem, 8px."
-		},
-		"400" : {
-			"value": "1rem",
-			"comment": "1rem, 16px."
-		},
-		"600" : {
-			"value": "1.5rem",
-			"comment": "1.5rem, 24px."
-		},
-		"800" : {
-			"value": "2rem",
-			"comment": "2rem, 32px."
-		},
-		"1200" : {
-			"value": "3rem",
-			"comment": "3rem, 48px."
-		},
-		"1600" : {
-			"value": "4rem",
-			"comment": "4rem, 64px."
+		"absolute": {
+			"0": {
+				"value": "0",
+				"comment": "no spacing, zero."
+			},
+			"100": {
+				"value": "4px",
+				"comment": ".25rem, 4px."
+			},
+			"200": {
+				"value": "8px",
+				"comment": ".5rem, 8px."
+			},
+			"400": {
+				"value": "16px",
+				"comment": "1rem, 16px."
+			},
+			"600": {
+				"value": "24px",
+				"comment": "1.5rem, 24px."
+			},
+			"800": {
+				"value": "32px",
+				"comment": "2rem, 32px."
+			},
+			"1200": {
+				"value": "48px",
+				"comment": "3rem, 48px."
+			},
+			"1600": {
+				"value": "64px",
+				"comment": "4rem, 64px."
+			}
 		}
 	}
 }


### PR DESCRIPTION
Whilst creating #758 so that the Design Tokens and the compiled Sass match what is in [the current Sketch file](https://www.sketch.com/s/fa9c2fc9-a179-43f0-b21e-9562c9c17c0c) I had forgotten changes that were being made that would have been in place (had I not created and merged #758). 

These token changes were made to accommodate the new `global-forms` component and allow @Heydon to work swiftly without waiting for updates. 

However, as mentioned #758 kinda screwed that up. This PR should fix it.

## Breaking Changes

We have introduced both `relative` and `absolute` spacing and sizing tokens for times you need exact pixel values rather than using the `rem` unit. 

Before you would use `{spacing.400}` (and eventually `$spacing-400`) you would now using `{spacing.absolute.400}` for `16px` and `{spacing.relative.400}` for `1rem`. 

The original spacing design tokens would generate `rem` values so, if you're using tokens in your components you would need to update:

| current token | new token             | value  |
|---------------|-----------------------|--------|
| spacing.0     | spacing.relative.0    | 0rem   |
| spacing.100   | spacing.relative.100  | .25rem |
| spacing.200   | spacing.relative.200  | .5rem  |
| spacing.400   | spacing.relative.400  | 1rem   |
| spacing.600   | spacing.relative.600  | 1.5rem |
| spacing.800   | spacing.relative.800  | 2rem   |
| spacing.1200  | spacing.relative.1200 | 3rem   |
| spacing.1600  | spacing.relative.1600 | 4rem   |

## Other updates

adds border radius tokens