### PR TITLE
Section heading docs

### DIFF
--- a/toolkits/nature/packages/nature-section-heading/HISTORY.md
+++ b/toolkits/nature/packages/nature-section-heading/HISTORY.md
@@ -1,10 +1,12 @@
 # History
 
-## 2.0.2 (22-07-14)
-    * Assigns sensible default heading levels to Section heading variants with option to override
-    * Adds guidance on when to use variants with and without top border
-    * Adds guidance on overriding default heading levels
-    * Updates guidance on adding chevron icon to section headings as link 
+## 3.0.0 (22-07-14)
+    * BREAKING:
+        * Assigns sensible default heading levels to Section heading variants with option to override
+    * UPDATES:
+        * guidance on when to use variants with and without top border
+        * guidance on overriding default heading levels
+        * guidance on adding chevron icon to section headings as link
 
 ## 2.0.1 (2022-07-13)
     * FIXES:

--- a/toolkits/nature/packages/nature-section-heading/HISTORY.md
+++ b/toolkits/nature/packages/nature-section-heading/HISTORY.md
@@ -1,4 +1,11 @@
 # History
+
+## 2.0.2 (22-07-14)
+    * Assigns sensible default heading levels to Section heading variants with option to override
+    * Adds guidance on when to use variants with and without top border
+    * Adds guidance on overriding default heading levels
+    * Updates guidance on adding chevron icon to section headings as link 
+
 ## 2.0.1 (2022-07-13)
     * FIXES:
       * corrects SVG ID by changing `i-icon-` to `i-`

--- a/toolkits/nature/packages/nature-section-heading/README.md
+++ b/toolkits/nature/packages/nature-section-heading/README.md
@@ -4,7 +4,7 @@
 
 The Nature Section heading is a type of heading used for titles of some subsections of pages on Nature.com.
 
-It uses borders to the heading text to make it stand out from other headings on the page.
+It uses borders to make it stand out from other headings on the page.
 
 ## When to use this component
 

--- a/toolkits/nature/packages/nature-section-heading/README.md
+++ b/toolkits/nature/packages/nature-section-heading/README.md
@@ -20,11 +20,12 @@ Write clear, descriptive headings using sentence case.
 
 ### Section headings with and without a top border
 
-There are two styles of Section heading. One with a top border and one without.
+There are 2 styles of Section heading:
 
-Use the heading with a top border for `<h2>` level headings.
+- one with a top and botton border - this is set as an `<h2>` heading level
+- one with a bottom border and no top border - this is designed for sub-headings and is set at heading level `<h3>`
 
-Use the heading without a top border for sub-headings, which are usually `<h3>` level or below.
+If you need to change the default heading level of a Section heading, you can do this using the heading level with the `aria-level` property. The level should be a string, not an integer.
 
 To make our sites accessible, you must always [use heading levels correctly to communicate page structure](https://elements.public.springernature.app/nature/styleguide/typography#use-heading-levels-to-communicate-page-structure).
 

--- a/toolkits/nature/packages/nature-section-heading/README.md
+++ b/toolkits/nature/packages/nature-section-heading/README.md
@@ -31,14 +31,14 @@ To make our sites accessible, you must always [use heading levels correctly to c
 
 ### Section headings as links
 
-You may want a Section heading to link to another page.
+You can use a Section heading to link to another page.
 
-In these cases, include a chevron after the heading text to help users understand that they can click on it.
+If you're using the handlebars template and you add a link, the heading will render a chevron after the heading text to show users that they can click on it.
 
 ![Section heading with a right-arrow chevron after the heading text](https://user-images.githubusercontent.com/15365576/152791603-d876746c-ab7a-4a03-84c2-dc871df0d6b2.png)
 
-[Get the source code for the chevron icon](https://github.com/springernature/frontend-toolkits/blob/master/context/brand-context/default/img/icons/chevron-right.svg
-)
+If you're not using the handlebars template, you'll need to style it yourself using [the source code for the chevron svg icon](https://github.com/springernature/frontend-toolkits/blob/master/context/brand-context/default/img/icons/chevron-right.svg
+).
 
 ## Installation
 

--- a/toolkits/nature/packages/nature-section-heading/README.md
+++ b/toolkits/nature/packages/nature-section-heading/README.md
@@ -4,7 +4,7 @@
 
 The Nature Section heading is a type of heading used for titles of some subsections of pages on Nature.com.
 
-It uses borders above and below the heading text to make it stand out from other headings on the page.
+It uses borders to the heading text to make it stand out from other headings on the page.
 
 ## When to use this component
 
@@ -14,10 +14,19 @@ Use the Nature Section heading when you want to organise multiple pieces of cont
 
 When you need to break up content on article pages into chunks, use [default heading styles](https://frontend-design-system.private.springernature.app/nature/styleguide/typography#headings-nature-journals).
 
-
 ## How it works
 
 Write clear, descriptive headings using sentence case.
+
+### Section headings with and without a top border
+
+There are two styles of Section heading. One with a top border and one without.
+
+Use the heading with a top border for `<h2>` level headings.
+
+Use the heading without a top border for sub-headings, which are usually `<h3>` level or below.
+
+To make our sites accessible, you must always [use heading levels correctly to communicate page structure](https://elements.public.springernature.app/nature/styleguide/typography#use-heading-levels-to-communicate-page-structure).
 
 ### Section headings as links
 

--- a/toolkits/nature/packages/nature-section-heading/demo/dist/index.html
+++ b/toolkits/nature/packages/nature-section-heading/demo/dist/index.html
@@ -1297,40 +1297,45 @@ p:empty {
 	<body style="padding:2%">
 		<div>
 	<div class="c-section-heading ">
-		<h2>Heading Text</h2>
-	</div>
-	<p>The ambitious observatory has arrived at its home — near a gravitationally stable spot called L2 — for a premier view of the Universe.</p>
+			<h2>
+				Heading Text
+	
+				</h2>
+	</div>	<p>The ambitious observatory has arrived at its home — near a gravitationally stable spot called
+		L2 — for a premier view of the Universe.</p>
 
 	<div class="c-section-heading ">
-		<h2>
-			<a href="https://www.example.com" class="c-section-heading__link">
-				Heading text with link
-				<svg class="c-section-heading__icon" aria-hidden="true" focusable="false" height="16" width="16">
-					<use xlink:href="../../img/chevron-right.svg#i-chevron-right"></use>
-				</svg>
-			</a>
-		</h2>
-	</div>
-	<p>People abandoned thriving cities in Mesopotamia, the Indus Valley and farther afield at about the same time as a decades-long drought gripped parts of the planet.</p>
+			<h2>
+				<a href="JavaScript:Void(0);" class="c-section-heading__link">
+					Heading text with link
+					<svg class="c-section-heading__icon" aria-hidden="true" focusable="false" height="16" width="16">
+						<use xlink:href="../../img/chevron-right.svg#i-chevron-right"></use>
+					</svg>
+				</a>
+	
+				</h2>
+	</div>	<p>People abandoned thriving cities in Mesopotamia, the Indus Valley and farther afield at about
+		the same time as a decades-long drought gripped parts of the planet.</p>
 
 	<div class="c-section-heading c-section-heading--no-bt">
-		<h2>Heading text with no border</h2>
-	</div>
-	<p>People abandoned thriving cities in Mesopotamia, the Indus Valley and farther afield at about the same time as a decades-long drought gripped parts of the planet.</p>
+		<h3>
+				Heading text with no border
+				</h3>
+	</div>	<p>People abandoned thriving cities in Mesopotamia, the Indus Valley and farther afield at about
+		the same time as a decades-long drought gripped parts of the planet.</p>
 
 	<div class="c-section-heading c-section-heading--no-bt">
-		<h2>
-			<a href="https://www.example.com" class="c-section-heading__link">
-				Heading text with link and no border
-				<svg class="c-section-heading__icon" aria-hidden="true" focusable="false" height="16" width="16">
-					<use xlink:href="../../img/chevron-right.svg#i-chevron-right"></use>
-				</svg>
-			</a>
-		</h2>
-	</div>
-	<p>People abandoned thriving cities in Mesopotamia, the Indus Valley and farther afield at about the same time as a decades-long drought gripped parts of the planet.</p>
+		<h3 aria-level="4">
+				<a href="JavaScript:Void(0);" class="c-section-heading__link">
+					Heading text with link and no border
+					<svg class="c-section-heading__icon" aria-hidden="true" focusable="false" height="16" width="16">
+						<use xlink:href="../../img/chevron-right.svg#i-chevron-right"></use>
+					</svg>
+				</a>
+				</h3>
+	</div>	<p>People abandoned thriving cities in Mesopotamia, the Indus Valley and farther afield at about
+		the same time as a decades-long drought gripped parts of the planet.</p>
 </div>
-
 		<script>
 			// no JS found for package
 		</script>

--- a/toolkits/nature/packages/nature-section-heading/demo/index.hbs
+++ b/toolkits/nature/packages/nature-section-heading/demo/index.hbs
@@ -1,13 +1,18 @@
 <div>
 	{{> nature-section-heading }}
-	<p>The ambitious observatory has arrived at its home — near a gravitationally stable spot called L2 — for a premier view of the Universe.</p>
+	<p>The ambitious observatory has arrived at its home — near a gravitationally stable spot called
+		L2 — for a premier view of the Universe.</p>
 
-	{{> nature-section-heading text='Heading text with link' url='https://www.example.com' }}
-	<p>People abandoned thriving cities in Mesopotamia, the Indus Valley and farther afield at about the same time as a decades-long drought gripped parts of the planet.</p>
+	{{> nature-section-heading text='Heading text with link' url='JavaScript:Void(0);' }}
+	<p>People abandoned thriving cities in Mesopotamia, the Indus Valley and farther afield at about
+		the same time as a decades-long drought gripped parts of the planet.</p>
 
 	{{> nature-section-heading text="Heading text with no border" no-bt="c-section-heading--no-bt"}}
-	<p>People abandoned thriving cities in Mesopotamia, the Indus Valley and farther afield at about the same time as a decades-long drought gripped parts of the planet.</p>
+	<p>People abandoned thriving cities in Mesopotamia, the Indus Valley and farther afield at about
+		the same time as a decades-long drought gripped parts of the planet.</p>
 
-	{{> nature-section-heading text="Heading text with link and no border" url='https://www.example.com' no-bt="c-section-heading--no-bt"}}
-	<p>People abandoned thriving cities in Mesopotamia, the Indus Valley and farther afield at about the same time as a decades-long drought gripped parts of the planet.</p>
+	{{> nature-section-heading text="Heading text with link and no border" url='JavaScript:Void(0);'
+	no-bt="c-section-heading--no-bt" level="4"}}
+	<p>People abandoned thriving cities in Mesopotamia, the Indus Valley and farther afield at about
+		the same time as a decades-long drought gripped parts of the planet.</p>
 </div>

--- a/toolkits/nature/packages/nature-section-heading/package.json
+++ b/toolkits/nature/packages/nature-section-heading/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/nature-section-heading",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "license": "MIT",
   "description": "Nature Section Heading",
   "keywords": [],

--- a/toolkits/nature/packages/nature-section-heading/package.json
+++ b/toolkits/nature/packages/nature-section-heading/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/nature-section-heading",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "license": "MIT",
   "description": "Nature Section Heading",
   "keywords": [],

--- a/toolkits/nature/packages/nature-section-heading/view/section-heading.hbs
+++ b/toolkits/nature/packages/nature-section-heading/view/section-heading.hbs
@@ -1,14 +1,24 @@
-<div class="c-section-heading {{no-bt}}">
-	{{#if url}}
-	<h2>
-		<a href="{{url}}" class="c-section-heading__link">
+<div class="c-section-heading {{#if no-bt}}{{no-bt}}{{/if}}">
+	{{#if no-bt}}
+	<h3{{#if level}} aria-level="{{level}}" {{/if}}>
+		{{else}}
+		<h2{{#if level}} aria-level="{{level}}" {{/if}}>
+			{{/if}}
+			{{#if url}}
+			<a href="{{url}}" class="c-section-heading__link">
+				{{text}}
+				<svg class="c-section-heading__icon" aria-hidden="true" focusable="false"
+					height="16" width="16">
+					<use xlink:href="{{chevronURL}}"></use>
+				</svg>
+			</a>
+			{{else}}
 			{{text}}
-			<svg class="c-section-heading__icon" aria-hidden="true" focusable="false" height="16" width="16">
-				<use xlink:href="{{chevronURL}}"></use>
-			</svg>
-		</a>
-	</h2>
-	{{else}}
-	<h2>{{text}}</h2>
-	{{/if}}
+			{{/if}}
+			{{#if no-bt}}
+			</h3>
+			{{else}}
+
+			</h2>
+			{{/if}}
 </div>


### PR DESCRIPTION
This PR:

    * assigns sensible default heading levels to Section heading variants with option to override
    * adds guidance on when to use variants with and without top border
    * adds guidance on overriding default heading levels
    * updates guidance on adding chevron icon to section headings as link 
