### PR TITLE
Global forms hidden input

### DIFF
--- a/toolkits/global/packages/global-forms/HISTORY.md
+++ b/toolkits/global/packages/global-forms/HISTORY.md
@@ -1,7 +1,7 @@
 # History
 
 ## 5.0.0-rc.4 (2022-07-27)
-    * `hidden` input type
+    * `hidden` input type added
     * `pointer-events: none` to make select clickable through chevron
 
 ## 5.0.0-rc.3 (2022-07-25)

--- a/toolkits/global/packages/global-forms/HISTORY.md
+++ b/toolkits/global/packages/global-forms/HISTORY.md
@@ -1,9 +1,14 @@
 # History
 
+## 5.0.0-rc.4 (2022-07-27)
+    * `hidden` input type
+    * `pointer-events: none` to make select clickable through chevron
+
 ## 5.0.0-rc.3 (2022-07-25)
     * BREAKING
         * Removed and replaced utility classes
         * Include spacing utilities
+
 ## 5.0.0-rc.2 (2022-07-11)
     * BREAKING:
         * Arbitrary attributes now restricted to data attributes

--- a/toolkits/global/packages/global-forms/demo/context.json
+++ b/toolkits/global/packages/global-forms/demo/context.json
@@ -1,7 +1,5 @@
 {
 	"form1": {
-		"errorIconURL": "../img/error.svg#i-error",
-		"selectIconURL": "../img/chevron-more.svg#i-chevron-more",
 		"errorSummary": {
 			"id": "summary",
 			"title": "There are problems",
@@ -28,6 +26,12 @@
 						"dataAttrs": {
 							"test": "someValue"
 						}
+					},
+					{
+						"template": "globalFormHidden",
+						"name": "hidden",
+						"id": "hidden",
+						"value": "someSecretValue"
 					},
 					{
 						"template": "globalFormText",
@@ -225,6 +229,7 @@
 		"globalFormEmail": "./toolkits/global/packages/global-forms/view/fields/globalFormEmail.hbs",
 		"globalFormSelect": "./toolkits/global/packages/global-forms/view/fields/globalFormSelect.hbs",
 		"globalFormTextarea": "./toolkits/global/packages/global-forms/view/fields/globalFormTextarea.hbs",
+		"globalFormHidden": "./toolkits/global/packages/global-forms/view/fields/globalFormHidden.hbs",
 		"globalFormCheckbox": "./toolkits/global/packages/global-forms/view/fields/globalFormCheckbox.hbs",
 		"globalFormFile": "./toolkits/global/packages/global-forms/view/fields/globalFormFile.hbs",
 		"globalFormRadios": "./toolkits/global/packages/global-forms/view/fields/globalFormRadios.hbs",

--- a/toolkits/global/packages/global-forms/demo/dist/index.html
+++ b/toolkits/global/packages/global-forms/demo/dist/index.html
@@ -1205,6 +1205,7 @@ label + .c-forms__error,
   right: 0.5rem;
   top: 50%;
   transform: translateY(-50%);
+  pointer-events: none;
 }
 
 .c-forms__input--radio,
@@ -1370,6 +1371,9 @@ label + .c-forms__error,
 							Your name (simple)
 						</label>
 						<input type="text" class="c-forms__input c-forms__input--text" id="your-name" name="your-name" autocomplete="off" data-test="someValue">
+					</div>
+					<div class="c-forms__field">
+						<input type="hidden" class="c-forms__input c-forms__input--hidden" id="hidden" name="hidden" value="someSecretValue" autocomplete="off">
 					</div>
 					<div class="c-forms__field">
 						<label for="your-name-hint" class="c-forms__label">

--- a/toolkits/global/packages/global-forms/package.json
+++ b/toolkits/global/packages/global-forms/package.json
@@ -7,6 +7,6 @@
 	  "css",
 	  "component"
 	],
-  "author": "Jack Watkins",
+  "author": "Heydon Pickering",
   "brandContext": "^25.0.0"
 }

--- a/toolkits/global/packages/global-forms/package.json
+++ b/toolkits/global/packages/global-forms/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@springernature/global-forms",
-	"version": "5.0.0-rc.3",
+	"version": "5.0.0-rc.4",
 	"license": "MIT",
 	"description": "form component",
 	"keywords": [

--- a/toolkits/global/packages/global-forms/scss/50-components/_forms.scss
+++ b/toolkits/global/packages/global-forms/scss/50-components/_forms.scss
@@ -126,6 +126,7 @@ label+.c-forms__error,
 	right: $global-forms-input-padding-inline;
 	top: 50%;
 	transform: translateY(-50%);
+	pointer-events: none;
 }
 
 .c-forms__input--radio,

--- a/toolkits/global/packages/global-forms/view/fields/globalFormHidden.hbs
+++ b/toolkits/global/packages/global-forms/view/fields/globalFormHidden.hbs
@@ -1,0 +1,1 @@
+<input type="hidden" class="c-forms__input c-forms__input--hidden" {{> globalFormAttributes}}>

--- a/toolkits/springer/packages/springer-hero/package.json
+++ b/toolkits/springer/packages/springer-hero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-hero",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "license": "MIT",
   "description": "A hero component, principally for subject/discipline pages",
   "keywords": [],


### PR DESCRIPTION
```
## 5.0.0-rc.4 (2022-07-27)
    * `hidden` input type
    * `pointer-events: none` to make select clickable through chevron
```