### PR TITLE
Details icon alignment

### DIFF
--- a/toolkits/global/packages/global-details/HISTORY.md
+++ b/toolkits/global/packages/global-details/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 0.2.1 (2022-08-03)
+    * Alignment of chevron icon to baseline
+
 ## 0.2.0 (2022-07-28)
     * Upgrade the brand-context v25.0.0
     

--- a/toolkits/global/packages/global-details/demo/dist/index.html
+++ b/toolkits/global/packages/global-details/demo/dist/index.html
@@ -8,7 +8,7 @@
 		<style>
 			@charset "UTF-8";
 /**
- * Basic
+ * Core
  * Styles for all pages, included on pages that
  * both do and dont cut the mustard, keep to a minimum
  */
@@ -182,8 +182,14 @@ h3 {
   font-weight: 700;
 }
 
-h6, h5, h4 {
+h4 {
   font-size: 1.125rem;
+  font-weight: 700;
+}
+
+h5,
+h6 {
+  font-size: 1rem;
   font-weight: 700;
 }
 
@@ -193,17 +199,11 @@ h6, h5, h4 {
  * These files don’t output any CSS when compiled
  */
 /**
- * Colors
- * Maps for color values & greyscale settings
+ * Colour palette
  *
  */
 /**
- * Typography
- * Font settings
- */
-/**
- *  Button settings
- *  Nature
+ * Color and gray scales
  *
  */
 /**
@@ -212,50 +212,130 @@ h6, h5, h4 {
  *
  */
 /**
- * Global
- * Main brand settings
+ *  Button settings
+ *  Springer
+ *
+ */
+/**
+ * Generates utility classnames for base and each breakpoint
+ *
+ * Example:
+ * @include class-stack('u-text-right') would output
+ * u-text-right { @content }
+ * @include media-query('xs') { u-text-right-at-lt-xs { @content } }
+ *
+ */
+/**
+ * Default link style
+ *
+ */
+/**
+ * Alternative link color
+ *
+ */
+/**
+ * Deemphasised link color
+ *
+ */
+/**
+ * Unvisited
+ *
+ */
+/**
+ * Link like
+ * Style non-links to look like links
+ * Remember to add aria
+ *
  */
 h1 {
-  font-weight: 700;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-  font-size: 2rem;
-  font-size: min(max(1.5rem, 4vw), 2rem);
-  letter-spacing: -0.0390625rem;
-  letter-spacing: min(max(-0.011715625rem, 4vw), -0.0390625rem);
-  line-height: 2.25rem;
-  line-height: min(max(1.6rem, 4vw), 2.25rem);
-  margin-bottom: 24px;
+  font-style: normal;
+  margin-bottom: 1em;
+  line-height: 1.4;
+  font-size: 2.25rem;
+  font-size: min(max(1.75rem, 4vw), 2.25rem);
+  font-family: Georgia, Palatino, serif;
+  font-weight: 400;
+}
+h1 a {
+  text-decoration: none;
+}
+h1 a.active, h1 a:active, h1 a.hover, h1 a:hover {
+  text-decoration: underline;
+  text-decoration-skip-ink: auto;
 }
 
 h2 {
-  font-weight: 700;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-  font-size: 1.5rem;
-  font-size: min(max(1.25rem, 3.5vw), 1.5rem);
-  letter-spacing: -0.011715625rem;
-  line-height: 1.6rem;
-  line-height: min(max(1.4rem, 3.5vw), 1.6rem);
-  margin-bottom: 8px;
+  font-style: normal;
+  margin-bottom: 1em;
+  line-height: 1.4;
+  font-size: 1.75rem;
+  font-size: min(max(1.5rem, 3.5vw), 1.75rem);
+  font-family: Georgia, Palatino, serif;
+  font-weight: 400;
+}
+h2 a {
+  text-decoration: none;
+}
+h2 a.active, h2 a:active, h2 a.hover, h2 a:hover {
+  text-decoration: underline;
+  text-decoration-skip-ink: auto;
 }
 
 h3 {
-  font-weight: 700;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-  font-size: 1.25rem;
-  font-size: min(max(1.125rem, 3.0vw), 1.25rem);
-  letter-spacing: -0.011715625rem;
-  line-height: 1.4rem;
-  margin-bottom: 8px;
+  font-style: normal;
+  margin-bottom: 1em;
+  line-height: 1.4;
+  font-size: 1.5rem;
+  font-size: min(max(1.25rem, 3vw), 1.5rem);
+  font-family: Georgia, Palatino, serif;
+  font-weight: 400;
+}
+h3 a {
+  text-decoration: none;
+}
+h3 a.active, h3 a:active, h3 a.hover, h3 a:hover {
+  text-decoration: underline;
+  text-decoration-skip-ink: auto;
 }
 
-h6, h5, h4 {
-  font-weight: 700;
+h4 {
+  font-style: normal;
+  margin-bottom: 1em;
+  line-height: 1.4;
+  font-size: 1.25rem;
+  font-size: min(max(1.125rem, 2.5vw), 1.25rem);
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  font-weight: 700;
+}
+h4 a {
+  text-decoration: none;
+}
+h4 a.active, h4 a:active, h4 a.hover, h4 a:hover {
+  text-decoration: underline;
+  text-decoration-skip-ink: auto;
+}
+
+h5,
+h6 {
+  font-style: normal;
+  margin-bottom: 1em;
+  line-height: 1.4;
   font-size: 1.125rem;
   font-size: min(max(1rem, 2.5vw), 1.125rem);
-  letter-spacing: -0.011715625rem;
-  line-height: 1.4rem;
-  margin-bottom: 8px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  font-weight: 700;
+}
+h5 a,
+h6 a {
+  text-decoration: none;
+}
+h5 a.active,
+h6 a.active, h5 a:active,
+h6 a:active, h5 a.hover,
+h6 a.hover, h5 a:hover,
+h6 a:hover {
+  text-decoration: underline;
+  text-decoration-skip-ink: auto;
 }
 
 /*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
@@ -602,12 +682,13 @@ template {
  * Some default CSS styles
  */
 body {
+  font-size: 0.813rem;
   line-height: 1.5;
 }
 
 a {
   text-decoration: none;
-  color: #006699;
+  color: #069;
 }
 
 a:hover,
@@ -628,7 +709,7 @@ h2 {
 }
 
 h3 {
-  font-size: 1.063rem;
+  font-size: 1.0625rem;
 }
 
 h4 {
@@ -851,8 +932,14 @@ h3 {
   font-weight: 700;
 }
 
-h6, h5, h4 {
+h4 {
   font-size: 1.125rem;
+  font-weight: 700;
+}
+
+h5,
+h6 {
+  font-size: 1rem;
   font-weight: 700;
 }
 
@@ -862,17 +949,11 @@ h6, h5, h4 {
  * These files don’t output any CSS when compiled
  */
 /**
- * Colors
- * Maps for color values & greyscale settings
+ * Colour palette
  *
  */
 /**
- * Typography
- * Font settings
- */
-/**
- *  Button settings
- *  Nature
+ * Color and gray scales
  *
  */
 /**
@@ -881,73 +962,156 @@ h6, h5, h4 {
  *
  */
 /**
- * Global
- * Main brand settings
+ *  Button settings
+ *  Springer
+ *
+ */
+/**
+ * Generates utility classnames for base and each breakpoint
+ *
+ * Example:
+ * @include class-stack('u-text-right') would output
+ * u-text-right { @content }
+ * @include media-query('xs') { u-text-right-at-lt-xs { @content } }
+ *
+ */
+/**
+ * Default link style
+ *
+ */
+/**
+ * Alternative link color
+ *
+ */
+/**
+ * Deemphasised link color
+ *
+ */
+/**
+ * Unvisited
+ *
+ */
+/**
+ * Link like
+ * Style non-links to look like links
+ * Remember to add aria
+ *
  */
 h1 {
-  font-weight: 700;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-  font-size: 2rem;
-  font-size: min(max(1.5rem, 4vw), 2rem);
-  letter-spacing: -0.0390625rem;
-  letter-spacing: min(max(-0.011715625rem, 4vw), -0.0390625rem);
-  line-height: 2.25rem;
-  line-height: min(max(1.6rem, 4vw), 2.25rem);
-  margin-bottom: 24px;
+  font-style: normal;
+  margin-bottom: 1em;
+  line-height: 1.4;
+  font-size: 2.25rem;
+  font-size: min(max(1.75rem, 4vw), 2.25rem);
+  font-family: Georgia, Palatino, serif;
+  font-weight: 400;
+}
+h1 a {
+  text-decoration: none;
+}
+h1 a.active, h1 a:active, h1 a.hover, h1 a:hover {
+  text-decoration: underline;
+  text-decoration-skip-ink: auto;
 }
 
 h2 {
-  font-weight: 700;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-  font-size: 1.5rem;
-  font-size: min(max(1.25rem, 3.5vw), 1.5rem);
-  letter-spacing: -0.011715625rem;
-  line-height: 1.6rem;
-  line-height: min(max(1.4rem, 3.5vw), 1.6rem);
-  margin-bottom: 8px;
+  font-style: normal;
+  margin-bottom: 1em;
+  line-height: 1.4;
+  font-size: 1.75rem;
+  font-size: min(max(1.5rem, 3.5vw), 1.75rem);
+  font-family: Georgia, Palatino, serif;
+  font-weight: 400;
+}
+h2 a {
+  text-decoration: none;
+}
+h2 a.active, h2 a:active, h2 a.hover, h2 a:hover {
+  text-decoration: underline;
+  text-decoration-skip-ink: auto;
 }
 
 h3 {
-  font-weight: 700;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-  font-size: 1.25rem;
-  font-size: min(max(1.125rem, 3.0vw), 1.25rem);
-  letter-spacing: -0.011715625rem;
-  line-height: 1.4rem;
-  margin-bottom: 8px;
+  font-style: normal;
+  margin-bottom: 1em;
+  line-height: 1.4;
+  font-size: 1.5rem;
+  font-size: min(max(1.25rem, 3vw), 1.5rem);
+  font-family: Georgia, Palatino, serif;
+  font-weight: 400;
+}
+h3 a {
+  text-decoration: none;
+}
+h3 a.active, h3 a:active, h3 a.hover, h3 a:hover {
+  text-decoration: underline;
+  text-decoration-skip-ink: auto;
 }
 
-h6, h5, h4 {
-  font-weight: 700;
+h4 {
+  font-style: normal;
+  margin-bottom: 1em;
+  line-height: 1.4;
+  font-size: 1.25rem;
+  font-size: min(max(1.125rem, 2.5vw), 1.25rem);
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  font-weight: 700;
+}
+h4 a {
+  text-decoration: none;
+}
+h4 a.active, h4 a:active, h4 a.hover, h4 a:hover {
+  text-decoration: underline;
+  text-decoration-skip-ink: auto;
+}
+
+h5,
+h6 {
+  font-style: normal;
+  margin-bottom: 1em;
+  line-height: 1.4;
   font-size: 1.125rem;
   font-size: min(max(1rem, 2.5vw), 1.125rem);
-  letter-spacing: -0.011715625rem;
-  line-height: 1.4rem;
-  margin-bottom: 8px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  font-weight: 700;
+}
+h5 a,
+h6 a {
+  text-decoration: none;
+}
+h5 a.active,
+h6 a.active, h5 a:active,
+h6 a:active, h5 a.hover,
+h6 a.hover, h5 a:hover,
+h6 a:hover {
+  text-decoration: underline;
+  text-decoration-skip-ink: auto;
 }
 
-/**
- * Forms
- * Default form styles
- */
-fieldset {
-  border: 0;
+button {
+  line-height: inherit;
 }
 
-input:focus,
 button:focus,
-select:focus {
-  outline: 3px solid #fece3e;
-  will-change: transform;
+input:focus,
+select:focus,
+textarea:focus {
+  outline: 4px solid #ffcc00;
 }
 
-button:active {
-  outline: 0;
+input[type=file]:focus-within {
+  outline: 4px solid #ffcc00;
 }
 
-input + label {
-  padding-left: 0.5em;
+button:disabled:focus,
+input:disabled:focus,
+select:disabled:focus,
+textarea:disabled:focus {
+  outline: none;
+}
+
+label {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }
 
 /*
@@ -955,16 +1119,29 @@ input + label {
  * Universal layout styles
  */
 html {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
   height: 100%;
   overflow-y: scroll;
+  font-size: 100%;
+  box-sizing: border-box;
+  color: #333333;
+  line-height: 1.6180339888;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: subpixel-antialiased;
+}
+
+*,
+*:before,
+*:after {
+  box-sizing: inherit;
 }
 
 body {
+  max-width: 100%;
   min-height: 100%;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-  line-height: 1.76;
-  color: #222222;
-  background: #eeeeee;
+  background: #fcfcfc;
+  font-size: 1.125rem;
+  /* fixes chrome rems bug - http://stackoverflow.com/questions/20099844/chrome-not-respecting-rem-font-size-on-body-tag */
 }
 
 figure {
@@ -985,20 +1162,8 @@ input,
 button,
 textarea,
 p,
-blockquote,
 th,
 td {
-  margin: 0;
-  padding: 0;
-}
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-small {
   margin: 0;
   padding: 0;
 }
@@ -1009,145 +1174,99 @@ abbr[title] {
 
 [contenteditable]:focus,
 [tabindex="0"]:focus {
-  outline: 3px solid #fece3e;
-  will-change: transform;
+  outline: 4px solid #ffcc00;
 }
 
-/**
- * Links
- * Basic link styles
- */
 a {
-  text-decoration: none;
-  vertical-align: baseline;
-  color: #006699;
-}
-a:focus {
-  outline: 3px solid #fece3e;
-  will-change: transform;
-}
-
-a:hover {
+  color: #004b83;
   text-decoration: underline;
-  -webkit-text-decoration-skip: skip;
   text-decoration-skip-ink: auto;
 }
-
-a:active {
-  outline: 0;
+a.visited, a:visited {
+  color: #a345c9;
+}
+a.hover, a:hover {
+  color: #0061a9;
+  text-decoration: none;
+}
+a.active, a:active {
+  color: #003b84;
+  text-decoration: none;
+}
+a.focus, a:focus {
+  outline: 4px solid #ffcc00;
+}
+a > img {
+  vertical-align: middle;
 }
 
-/**
- * Lists
- * Default list styles
- */
-nav ul,
-nav ol {
-  list-style: none;
-  list-style-image: none;
-}
-
-/**
- * Tables
- * Default table styles
- */
 table {
+  border: 1px solid #a6a6a6;
   width: 100%;
-  margin-bottom: 0;
-  border-collapse: collapse;
-  border-spacing: 0;
-  font-size: 1rem;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  margin-bottom: 32px;
 }
 
 th,
 td {
-  padding: 4px 7px;
-  border-right: 1px solid #d5d5d5;
+  font-size: 1rem;
+  border: 1px solid #a6a6a6;
+  padding: 0.3em 0.6em;
+  vertical-align: top;
+}
+
+th {
+  background: #e6e6e6;
   text-align: left;
-  line-height: 1.15;
 }
 
-th {
-  vertical-align: top;
-}
-
-td {
-  vertical-align: middle;
-}
-
-th[valign=top] {
-  vertical-align: top;
-}
-
-th[valign=middle] {
-  vertical-align: middle;
-}
-
-thead tr {
-  border-bottom: 1px solid #d5d5d5;
-}
-
-tbody tr {
-  border-top: 1px solid #d5d5d5;
-}
-
-tbody tr:first-child {
-  border-top: 0;
-}
-
-th {
-  background: #eeeeee;
-}
-
-tfoot tr {
-  border-top: 2px solid #d5d5d5;
-}
-
-tfoot td {
-  font-weight: bold;
-}
-
-/**
- * Typography
- * Set base font size
- */
-html {
-  font-size: 100%;
-}
-
-body {
-  font-size: 1.125rem;
-}
-
-/**
- * Typographic
- * Standard text and heading formatting
- */
-/*
- * Default spacing
- * default margin 28px to match line height
- * this is used for mainting vertical rhythm on the page
- */
-p,
-ul,
-ol {
+h1,
+h2,
+h3,
+h4 {
+  line-height: 1.4;
   margin-top: 0;
-  margin-bottom: 28px;
 }
 
-/*
- * Headings
- */
+p,
+ol,
+ul,
+dl {
+  margin-top: 0;
+}
+
+/* Basic lists should be aligned to the left */
+ul:not([class]),
+ol:not([class]) {
+  /* Allow for bullet itself */
+  padding-left: 0.9em;
+}
+
+dd {
+  margin: 0;
+}
+
+p {
+  margin-bottom: 1.5em;
+}
+
+p:last-child {
+  margin-bottom: 0;
+}
+
 p:empty {
   display: none;
 }
 
+cite {
+  font-style: normal;
+}
+
+/* TODO: Move color to brand context */
 .c-details {
-  padding: 16px 0;
+  padding: 0 0;
   border-style: solid;
-  border-color: currentColor;
-  border-width: 1px 0;
+  border-color: #cccccc;
+  border-width: 0 0;
   /* In case it’s a list item */
   list-style: none;
 }
@@ -1155,7 +1274,7 @@ p:empty {
 .c-details + .c-details {
   /* for successive details instances, don't double the border */
   border-top: 0;
-  margin-top: 0;
+  margin-top: 1.5em;
 }
 
 .c-details__details {
@@ -1185,7 +1304,7 @@ p:empty {
 
   .c-details__summary:focus .c-details__title {
     text-decoration: underline;
-    text-decoration-color: #fece3e;
+    text-decoration-color: #ffcc00;
     text-decoration-thickness: 3px;
   }
 }
@@ -1196,9 +1315,9 @@ p:empty {
 
 .c-details__header .u-icon {
   flex-shrink: 0;
-  width: 0.75em;
-  height: 0.75em;
-  color: currentColor;
+  width: 1em;
+  height: 1em;
+  color: #0070a8;
 }
 
 /* ↓ Complex selector necessary to ensure
@@ -1209,14 +1328,14 @@ nested icons are not rotated */
 
 .c-details__title {
   margin-left: 8px;
-  font-family: inherit;
-  font-size: 1.25rem;
-  color: inherit;
+  font-family: Georgia, Palatino, serif;
+  font-size: 1.5rem;
+  color: #0070a8;
   line-height: 1.25;
 }
 
 .c-details__content {
-  padding: 16px 0 0 0;
+  padding: 16px 0 0 1.333em;
 }
 
 /* Remove excess margin from (for example) paragraphs */

--- a/toolkits/global/packages/global-details/demo/dist/index.html
+++ b/toolkits/global/packages/global-details/demo/dist/index.html
@@ -1,10 +1,14 @@
 <!DOCTYPE html><html lang="en"><head>
+		<script>
+    		(function(e){var t=e.documentElement,n=e.implementation;t.className='js';})(document)
+		</script>
 		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<title>@springernature/global-details</title>
 		<style>
 			@charset "UTF-8";
 /**
- * Core
+ * Basic
  * Styles for all pages, included on pages that
  * both do and dont cut the mustard, keep to a minimum
  */
@@ -164,25 +168,23 @@
  * @group 30-mixins
  */
 h1 {
-	font-size: 3.2rem;
-	font-weight: 700;
+  font-size: 2rem;
+  font-weight: 700;
 }
 
 h2 {
-	font-size: 2.4rem;
-	font-weight: 700;
+  font-size: 1.5rem;
+  font-weight: 700;
 }
 
 h3 {
-	font-size: 2rem;
-	font-weight: 700;
+  font-size: 1.25rem;
+  font-weight: 700;
 }
 
-h4,
-h5,
-h6 {
-	font-size: 1.8rem;
-	font-weight: 700;
+h6, h5, h4 {
+  font-size: 1.125rem;
+  font-weight: 700;
 }
 
 /**
@@ -191,11 +193,17 @@ h6 {
  * These files don’t output any CSS when compiled
  */
 /**
- * Colour palette
+ * Colors
+ * Maps for color values & greyscale settings
  *
  */
 /**
- * Color and gray scales
+ * Typography
+ * Font settings
+ */
+/**
+ *  Button settings
+ *  Nature
  *
  */
 /**
@@ -204,161 +212,80 @@ h6 {
  *
  */
 /**
- *  Button settings
- *  Springer
- *
- */
-/**
- * Generates utility classnames for base and each breakpoint
- *
- * Example:
- * @include class-stack('u-text-right') would output
- * u-text-right { @content }
- * @include media-query('xs') { u-text-right-at-lt-xs { @content } }
- *
- */
-/**
- * Default link style
- *
- */
-/**
- * Alternative link color
- *
- */
-/**
- * Deemphasised link color
- *
- */
-/**
- * Unvisited
- *
- */
-/**
- * Link like
- * Style non-links to look like links
- * Remember to add aria
- *
+ * Global
+ * Main brand settings
  */
 h1 {
-	font-style: normal;
-	margin-bottom: 1em;
-	line-height: 1.4;
-	font-size: 3.2rem;
-	font-size: min(max(2.8rem, 4vw), 3.2rem);
-	font-family: Georgia, Palatino, serif;
-	font-weight: 400;
-}
-
-h1 a {
-	text-decoration: none;
-}
-
-h1 a.active, h1 a:active, h1 a.hover, h1 a:hover {
-	text-decoration: underline;
-	text-decoration-skip-ink: auto;
+  font-weight: 700;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  font-size: 2rem;
+  font-size: min(max(1.5rem, 4vw), 2rem);
+  letter-spacing: -0.0390625rem;
+  letter-spacing: min(max(-0.011715625rem, 4vw), -0.0390625rem);
+  line-height: 2.25rem;
+  line-height: min(max(1.6rem, 4vw), 2.25rem);
+  margin-bottom: 24px;
 }
 
 h2 {
-	font-style: normal;
-	margin-bottom: 1em;
-	line-height: 1.4;
-	font-size: 2.8rem;
-	font-size: min(max(2.4rem, 3.5vw), 2.8rem);
-	font-family: Georgia, Palatino, serif;
-	font-weight: 400;
-}
-
-h2 a {
-	text-decoration: none;
-}
-
-h2 a.active, h2 a:active, h2 a.hover, h2 a:hover {
-	text-decoration: underline;
-	text-decoration-skip-ink: auto;
+  font-weight: 700;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  font-size: 1.5rem;
+  font-size: min(max(1.25rem, 3.5vw), 1.5rem);
+  letter-spacing: -0.011715625rem;
+  line-height: 1.6rem;
+  line-height: min(max(1.4rem, 3.5vw), 1.6rem);
+  margin-bottom: 8px;
 }
 
 h3 {
-	font-style: normal;
-	margin-bottom: 1em;
-	line-height: 1.4;
-	font-size: 2.4rem;
-	font-size: min(max(2rem, 3vw), 2.4rem);
-	font-family: Georgia, Palatino, serif;
-	font-weight: 400;
+  font-weight: 700;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  font-size: 1.25rem;
+  font-size: min(max(1.125rem, 3.0vw), 1.25rem);
+  letter-spacing: -0.011715625rem;
+  line-height: 1.4rem;
+  margin-bottom: 8px;
 }
 
-h3 a {
-	text-decoration: none;
+h6, h5, h4 {
+  font-weight: 700;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  font-size: 1.125rem;
+  font-size: min(max(1rem, 2.5vw), 1.125rem);
+  letter-spacing: -0.011715625rem;
+  line-height: 1.4rem;
+  margin-bottom: 8px;
 }
 
-h3 a.active, h3 a:active, h3 a.hover, h3 a:hover {
-	text-decoration: underline;
-	text-decoration-skip-ink: auto;
-}
-
-h4,
-h5,
-h6 {
-	font-style: normal;
-	margin-bottom: 1em;
-	line-height: 1.4;
-	font-size: 2rem;
-	font-size: min(max(1.8rem, 2.5vw), 2rem);
-	font-family: Georgia, Palatino, serif;
-	font-weight: 700;
-}
-
-h4 a, h5 a, h6 a {
-	text-decoration: none;
-}
-
-h4 a.active, h5 a.active, h6 a.active, h4 a:active, h5 a:active, h6 a:active, h4 a.hover, h5 a.hover, h6 a.hover, h4 a:hover, h5 a:hover, h6 a:hover {
-	text-decoration: underline;
-	text-decoration-skip-ink: auto;
-}
-
-/* =========================================================================
-   $NORMALIZE
-   normalize.css v5.0.0 | MIT License | github.com/necolas/normalize.css
-   ========================================================================= */
+/*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
 /* Document
    ========================================================================== */
 /**
- * 1. Change the default font family in all browsers (opinionated).
- * 2. Correct the line height in all browsers.
- * 3. Prevent adjustments of font size after orientation changes in
- *    IE on Windows Phone and in iOS.
+ * 1. Correct the line height in all browsers.
+ * 2. Prevent adjustments of font size after orientation changes in iOS.
  */
 html {
-	font-family: sans-serif;
-	/* 1 */
-	line-height: 1.15;
-	/* 2 */
-	-ms-text-size-adjust: 100%;
-	/* 3 */
-	-webkit-text-size-adjust: 100%;
-	/* 3 */
+  line-height: 1.15;
+  /* 1 */
+  -webkit-text-size-adjust: 100%;
+  /* 2 */
 }
 
 /* Sections
    ========================================================================== */
 /**
- * Remove the margin in all browsers (opinionated).
+ * Remove the margin in all browsers.
  */
 body {
-	margin: 0;
+  margin: 0;
 }
 
 /**
- * Add the correct display in IE 9-.
+ * Render the `main` element consistently in IE.
  */
-article,
-aside,
-footer,
-header,
-nav,
-section {
-	display: block;
+main {
+  display: block;
 }
 
 /**
@@ -366,41 +293,23 @@ section {
  * `article` contexts in Chrome, Firefox, and Safari.
  */
 h1 {
-	font-size: 2em;
-	margin: 0.67em 0;
+  font-size: 2em;
+  margin: 0.67em 0;
 }
 
 /* Grouping content
    ========================================================================== */
 /**
- * Add the correct display in IE 9-.
- * 1. Add the correct display in IE.
- */
-figcaption,
-figure,
-main {
-	/* 1 */
-	display: block;
-}
-
-/**
- * Add the correct margin in IE 8.
- */
-figure {
-	margin: 1em 40px;
-}
-
-/**
  * 1. Add the correct box sizing in Firefox.
  * 2. Show the overflow in Edge and IE.
  */
 hr {
-	box-sizing: content-box;
-	/* 1 */
-	height: 0;
-	/* 1 */
-	overflow: visible;
-	/* 2 */
+  box-sizing: content-box;
+  /* 1 */
+  height: 0;
+  /* 1 */
+  overflow: visible;
+  /* 2 */
 }
 
 /**
@@ -408,53 +317,32 @@ hr {
  * 2. Correct the odd `em` font sizing in all browsers.
  */
 pre {
-	font-family: monospace, monospace;
-	/* 1 */
-	font-size: 1em;
-	/* 2 */
+  font-family: monospace, monospace;
+  /* 1 */
+  font-size: 1em;
+  /* 2 */
 }
 
 /* Text-level semantics
    ========================================================================== */
 /**
- * 1. Remove the gray background on active links in IE 10.
- * 2. Remove gaps in links underline in iOS 8+ and Safari 8+.
+ * Remove the gray background on active links in IE 10.
  */
 a {
-	background-color: transparent;
-	/* 1 */
-	-webkit-text-decoration-skip: objects;
-	/* 2 */
+  background-color: transparent;
 }
 
 /**
- * Remove the outline on focused links when they are also active or hovered
- * in all browsers (opinionated).
- */
-a:active,
-a:hover {
-	outline-width: 0;
-}
-
-/**
- * 1. Remove the bottom border in Firefox 39-.
+ * 1. Remove the bottom border in Chrome 57-
  * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
  */
 abbr[title] {
-	border-bottom: none;
-	/* 1 */
-	text-decoration: underline;
-	/* 2 */
-	text-decoration: underline dotted;
-	/* 2 */
-}
-
-/**
- * Prevent the duplicate application of `bolder` by the next rule in Safari 6.
- */
-b,
-strong {
-	font-weight: inherit;
+  border-bottom: none;
+  /* 1 */
+  text-decoration: underline;
+  /* 2 */
+  text-decoration: underline dotted;
+  /* 2 */
 }
 
 /**
@@ -462,7 +350,7 @@ strong {
  */
 b,
 strong {
-	font-weight: bolder;
+  font-weight: bolder;
 }
 
 /**
@@ -472,32 +360,17 @@ strong {
 code,
 kbd,
 samp {
-	font-family: monospace, monospace;
-	/* 1 */
-	font-size: 1em;
-	/* 2 */
-}
-
-/**
- * Add the correct font style in Android 4.3-.
- */
-dfn {
-	font-style: italic;
-}
-
-/**
- * Add the correct background and color in IE 9-.
- */
-mark {
-	background-color: #ff0;
-	color: #000;
+  font-family: monospace, monospace;
+  /* 1 */
+  font-size: 1em;
+  /* 2 */
 }
 
 /**
  * Add the correct font size in all browsers.
  */
 small {
-	font-size: 80%;
+  font-size: 80%;
 }
 
 /**
@@ -506,56 +379,33 @@ small {
  */
 sub,
 sup {
-	font-size: 75%;
-	line-height: 0;
-	position: relative;
-	vertical-align: baseline;
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
 }
 
 sub {
-	bottom: -0.25em;
+  bottom: -0.25em;
 }
 
 sup {
-	top: -0.5em;
+  top: -0.5em;
 }
 
 /* Embedded content
    ========================================================================== */
 /**
- * Add the correct display in IE 9-.
- */
-audio,
-video {
-	display: inline-block;
-}
-
-/**
- * Add the correct display in iOS 4-7.
- */
-audio:not([controls]) {
-	display: none;
-	height: 0;
-}
-
-/**
- * Remove the border on images inside links in IE 10-.
+ * Remove the border on images inside links in IE 10.
  */
 img {
-	border-style: none;
-}
-
-/**
- * Hide the overflow in IE.
- */
-svg:not(:root) {
-	overflow: hidden;
+  border-style: none;
 }
 
 /* Forms
    ========================================================================== */
 /**
- * 1. Change the font styles in all browsers (opinionated).
+ * 1. Change the font styles in all browsers.
  * 2. Remove the margin in Firefox and Safari.
  */
 button,
@@ -563,14 +413,14 @@ input,
 optgroup,
 select,
 textarea {
-	font-family: sans-serif;
-	/* 1 */
-	font-size: 100%;
-	/* 1 */
-	line-height: 1.15;
-	/* 1 */
-	margin: 0;
-	/* 2 */
+  font-family: inherit;
+  /* 1 */
+  font-size: 100%;
+  /* 1 */
+  line-height: 1.15;
+  /* 1 */
+  margin: 0;
+  /* 2 */
 }
 
 /**
@@ -579,8 +429,8 @@ textarea {
  */
 button,
 input {
-	/* 1 */
-	overflow: visible;
+  /* 1 */
+  overflow: visible;
 }
 
 /**
@@ -589,51 +439,46 @@ input {
  */
 button,
 select {
-	/* 1 */
-	text-transform: none;
+  /* 1 */
+  text-transform: none;
 }
 
 /**
- * 1. Prevent a WebKit bug where (2) destroys native `audio` and `video`
- *    controls in Android 4.
- * 2. Correct the inability to style clickable types in iOS and Safari.
+ * Correct the inability to style clickable types in iOS and Safari.
  */
 button,
-html [type='button'],
-[type='reset'],
-[type='submit'] {
-	-webkit-appearance: button;
-	/* 2 */
+[type=button],
+[type=reset],
+[type=submit] {
+  -webkit-appearance: button;
 }
 
 /**
  * Remove the inner border and padding in Firefox.
  */
 button::-moz-focus-inner,
-[type='button']::-moz-focus-inner,
-[type='reset']::-moz-focus-inner,
-[type='submit']::-moz-focus-inner {
-	border-style: none;
-	padding: 0;
+[type=button]::-moz-focus-inner,
+[type=reset]::-moz-focus-inner,
+[type=submit]::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
 }
 
 /**
  * Restore the focus styles unset by the previous rule.
  */
 button:-moz-focusring,
-[type='button']:-moz-focusring,
-[type='reset']:-moz-focusring,
-[type='submit']:-moz-focusring {
-	outline: 1px dotted ButtonText;
+[type=button]:-moz-focusring,
+[type=reset]:-moz-focusring,
+[type=submit]:-moz-focusring {
+  outline: 1px dotted ButtonText;
 }
 
 /**
- * Change the border, margin, and padding in all browsers (opinionated).
+ * Correct the padding in Firefox.
  */
 fieldset {
-	border: 1px solid #c0c0c0;
-	margin: 0 2px;
-	padding: 0.35em 0.625em 0.75em;
+  padding: 0.35em 0.75em 0.625em;
 }
 
 /**
@@ -643,75 +488,70 @@ fieldset {
  *    `fieldset` elements in all browsers.
  */
 legend {
-	box-sizing: border-box;
-	/* 1 */
-	color: inherit;
-	/* 2 */
-	display: table;
-	/* 1 */
-	max-width: 100%;
-	/* 1 */
-	padding: 0;
-	/* 3 */
-	white-space: normal;
-	/* 1 */
+  box-sizing: border-box;
+  /* 1 */
+  color: inherit;
+  /* 2 */
+  display: table;
+  /* 1 */
+  max-width: 100%;
+  /* 1 */
+  padding: 0;
+  /* 3 */
+  white-space: normal;
+  /* 1 */
 }
 
 /**
- * 1. Add the correct display in IE 9-.
- * 2. Add the correct vertical alignment in Chrome, Firefox, and Opera.
+ * Add the correct vertical alignment in Chrome, Firefox, and Opera.
  */
 progress {
-	display: inline-block;
-	/* 1 */
-	vertical-align: baseline;
-	/* 2 */
+  vertical-align: baseline;
 }
 
 /**
- * Remove the default vertical scrollbar in IE.
+ * Remove the default vertical scrollbar in IE 10+.
  */
 textarea {
-	overflow: auto;
+  overflow: auto;
 }
 
 /**
- * 1. Add the correct box sizing in IE 10-.
- * 2. Remove the padding in IE 10-.
+ * 1. Add the correct box sizing in IE 10.
+ * 2. Remove the padding in IE 10.
  */
-[type='checkbox'],
-[type='radio'] {
-	box-sizing: border-box;
-	/* 1 */
-	padding: 0;
-	/* 2 */
+[type=checkbox],
+[type=radio] {
+  box-sizing: border-box;
+  /* 1 */
+  padding: 0;
+  /* 2 */
 }
 
 /**
  * Correct the cursor style of increment and decrement buttons in Chrome.
  */
-[type='number']::-webkit-inner-spin-button,
-[type='number']::-webkit-outer-spin-button {
-	height: auto;
+[type=number]::-webkit-inner-spin-button,
+[type=number]::-webkit-outer-spin-button {
+  height: auto;
 }
 
 /**
  * 1. Correct the odd appearance in Chrome and Safari.
  * 2. Correct the outline style in Safari.
  */
-[type='search'] {
-	-webkit-appearance: textfield;
-	/* 1 */
-	outline-offset: -2px;
-	/* 2 */
+[type=search] {
+  -webkit-appearance: textfield;
+  /* 1 */
+  outline-offset: -2px;
+  /* 2 */
 }
 
 /**
- * Remove the inner padding and cancel buttons in Chrome and Safari on macOS.
+ * Remove the inner padding in Chrome and Safari on macOS.
  */
-[type='search']::-webkit-search-cancel-button,
-[type='search']::-webkit-search-decoration {
-	-webkit-appearance: none;
+[type=search]::-webkit-search-decoration {
+  -webkit-appearance: none;
 }
 
 /**
@@ -719,53 +559,42 @@ textarea {
  * 2. Change font properties to `inherit` in Safari.
  */
 ::-webkit-file-upload-button {
-	-webkit-appearance: button;
-	/* 1 */
-	font: inherit;
-	/* 2 */
+  -webkit-appearance: button;
+  /* 1 */
+  font: inherit;
+  /* 2 */
 }
 
 /* Interactive
    ========================================================================== */
 /*
- * Add the correct display in IE 9-.
- * 1. Add the correct display in Edge, IE, and Firefox.
+ * Add the correct display in Edge, IE 10+, and Firefox.
  */
-details,
-menu {
-	display: block;
+details {
+  display: block;
 }
 
 /*
  * Add the correct display in all browsers.
  */
 summary {
-	display: list-item;
+  display: list-item;
 }
 
-/* Scripting
+/* Misc
    ========================================================================== */
 /**
- * Add the correct display in IE 9-.
- */
-canvas {
-	display: inline-block;
-}
-
-/**
- * Add the correct display in IE.
+ * Add the correct display in IE 10+.
  */
 template {
-	display: none;
+  display: none;
 }
 
-/* Hidden
-   ========================================================================== */
 /**
- * Add the correct display in IE 10-.
+ * Add the correct display in IE 10.
  */
 [hidden] {
-	display: none;
+  display: none;
 }
 
 /**
@@ -773,62 +602,57 @@ template {
  * Some default CSS styles
  */
 body {
-	font-size: 13px;
-	line-height: 1.5;
+  line-height: 1.5;
 }
 
 a {
-	text-decoration: none;
-	color: #069;
+  text-decoration: none;
+  color: #006699;
 }
 
 a:hover,
 a:focus {
-	text-decoration: underline;
+  text-decoration: underline;
 }
 
 button {
-	cursor: pointer;
+  cursor: pointer;
 }
 
 h1 {
-	font-size: 30px;
-	font-size: 3rem;
+  font-size: 1.875rem;
 }
 
 h2 {
-	font-size: 24px;
-	font-size: 2.4rem;
+  font-size: 1.5rem;
 }
 
 h3 {
-	font-size: 17px;
-	font-size: 1.7rem;
+  font-size: 1.063rem;
 }
 
 h4 {
-	font-size: 14px;
-	font-size: 1.4rem;
+  font-size: 0.875rem;
 }
 
 cite {
-	font-style: normal;
+  font-style: normal;
 }
 
 ins {
-	text-decoration: none;
+  text-decoration: none;
 }
 
 img {
-	border: 0;
-	max-width: 100%;
-	height: auto;
-	vertical-align: middle;
+  border: 0;
+  max-width: 100%;
+  height: auto;
+  vertical-align: middle;
 }
 
 button {
-	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
-	border-radius: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  border-radius: 0;
 }
 
 /* accessible focus styles */
@@ -850,7 +674,7 @@ i:focus,
 b:focus,
 em:focus,
 strong:focus {
-	outline: none;
+  outline: none;
 }
 
 /**
@@ -1013,25 +837,23 @@ strong:focus {
  * @group 30-mixins
  */
 h1 {
-	font-size: 3.2rem;
-	font-weight: 700;
+  font-size: 2rem;
+  font-weight: 700;
 }
 
 h2 {
-	font-size: 2.4rem;
-	font-weight: 700;
+  font-size: 1.5rem;
+  font-weight: 700;
 }
 
 h3 {
-	font-size: 2rem;
-	font-weight: 700;
+  font-size: 1.25rem;
+  font-weight: 700;
 }
 
-h4,
-h5,
-h6 {
-	font-size: 1.8rem;
-	font-weight: 700;
+h6, h5, h4 {
+  font-size: 1.125rem;
+  font-weight: 700;
 }
 
 /**
@@ -1040,11 +862,17 @@ h6 {
  * These files don’t output any CSS when compiled
  */
 /**
- * Colour palette
+ * Colors
+ * Maps for color values & greyscale settings
  *
  */
 /**
- * Color and gray scales
+ * Typography
+ * Font settings
+ */
+/**
+ *  Button settings
+ *  Nature
  *
  */
 /**
@@ -1053,143 +881,73 @@ h6 {
  *
  */
 /**
- *  Button settings
- *  Springer
- *
- */
-/**
- * Generates utility classnames for base and each breakpoint
- *
- * Example:
- * @include class-stack('u-text-right') would output
- * u-text-right { @content }
- * @include media-query('xs') { u-text-right-at-lt-xs { @content } }
- *
- */
-/**
- * Default link style
- *
- */
-/**
- * Alternative link color
- *
- */
-/**
- * Deemphasised link color
- *
- */
-/**
- * Unvisited
- *
- */
-/**
- * Link like
- * Style non-links to look like links
- * Remember to add aria
- *
+ * Global
+ * Main brand settings
  */
 h1 {
-	font-style: normal;
-	margin-bottom: 1em;
-	line-height: 1.4;
-	font-size: 3.2rem;
-	font-size: min(max(2.8rem, 4vw), 3.2rem);
-	font-family: Georgia, Palatino, serif;
-	font-weight: 400;
-}
-
-h1 a {
-	text-decoration: none;
-}
-
-h1 a.active, h1 a:active, h1 a.hover, h1 a:hover {
-	text-decoration: underline;
-	text-decoration-skip-ink: auto;
+  font-weight: 700;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  font-size: 2rem;
+  font-size: min(max(1.5rem, 4vw), 2rem);
+  letter-spacing: -0.0390625rem;
+  letter-spacing: min(max(-0.011715625rem, 4vw), -0.0390625rem);
+  line-height: 2.25rem;
+  line-height: min(max(1.6rem, 4vw), 2.25rem);
+  margin-bottom: 24px;
 }
 
 h2 {
-	font-style: normal;
-	margin-bottom: 1em;
-	line-height: 1.4;
-	font-size: 2.8rem;
-	font-size: min(max(2.4rem, 3.5vw), 2.8rem);
-	font-family: Georgia, Palatino, serif;
-	font-weight: 400;
-}
-
-h2 a {
-	text-decoration: none;
-}
-
-h2 a.active, h2 a:active, h2 a.hover, h2 a:hover {
-	text-decoration: underline;
-	text-decoration-skip-ink: auto;
+  font-weight: 700;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  font-size: 1.5rem;
+  font-size: min(max(1.25rem, 3.5vw), 1.5rem);
+  letter-spacing: -0.011715625rem;
+  line-height: 1.6rem;
+  line-height: min(max(1.4rem, 3.5vw), 1.6rem);
+  margin-bottom: 8px;
 }
 
 h3 {
-	font-style: normal;
-	margin-bottom: 1em;
-	line-height: 1.4;
-	font-size: 2.4rem;
-	font-size: min(max(2rem, 3vw), 2.4rem);
-	font-family: Georgia, Palatino, serif;
-	font-weight: 400;
+  font-weight: 700;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  font-size: 1.25rem;
+  font-size: min(max(1.125rem, 3.0vw), 1.25rem);
+  letter-spacing: -0.011715625rem;
+  line-height: 1.4rem;
+  margin-bottom: 8px;
 }
 
-h3 a {
-	text-decoration: none;
+h6, h5, h4 {
+  font-weight: 700;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  font-size: 1.125rem;
+  font-size: min(max(1rem, 2.5vw), 1.125rem);
+  letter-spacing: -0.011715625rem;
+  line-height: 1.4rem;
+  margin-bottom: 8px;
 }
 
-h3 a.active, h3 a:active, h3 a.hover, h3 a:hover {
-	text-decoration: underline;
-	text-decoration-skip-ink: auto;
+/**
+ * Forms
+ * Default form styles
+ */
+fieldset {
+  border: 0;
 }
 
-h4,
-h5,
-h6 {
-	font-style: normal;
-	margin-bottom: 1em;
-	line-height: 1.4;
-	font-size: 2rem;
-	font-size: min(max(1.8rem, 2.5vw), 2rem);
-	font-family: Georgia, Palatino, serif;
-	font-weight: 700;
-}
-
-h4 a, h5 a, h6 a {
-	text-decoration: none;
-}
-
-h4 a.active, h5 a.active, h6 a.active, h4 a:active, h5 a:active, h6 a:active, h4 a.hover, h5 a.hover, h6 a.hover, h4 a:hover, h5 a:hover, h6 a:hover {
-	text-decoration: underline;
-	text-decoration-skip-ink: auto;
-}
-
-button {
-	line-height: inherit;
-}
-
-button:focus,
 input:focus,
-select:focus,
-textarea:focus {
-	outline: 4px solid #ffcc00;
+button:focus,
+select:focus {
+  outline: 3px solid #fece3e;
+  will-change: transform;
 }
 
-input[type="file"]:focus-within {
-	outline: 4px solid #ffcc00;
+button:active {
+  outline: 0;
 }
 
-button:disabled:focus,
-input:disabled:focus,
-select:disabled:focus,
-textarea:disabled:focus {
-	outline: none;
-}
-
-label {
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+input + label {
+  padding-left: 0.5em;
 }
 
 /*
@@ -1197,33 +955,20 @@ label {
  * Universal layout styles
  */
 html {
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	height: 100%;
-	overflow-y: scroll;
-	font-size: 62.5%;
-	box-sizing: border-box;
-	color: #333333;
-	line-height: 1.61803;
-	-moz-osx-font-smoothing: auto;
-	-webkit-font-smoothing: subpixel-antialiased;
-}
-
-*,
-*:before,
-*:after {
-	box-sizing: inherit;
+  height: 100%;
+  overflow-y: scroll;
 }
 
 body {
-	max-width: 100%;
-	min-height: 100%;
-	background: #fcfcfc;
-	font-size: 1.8em;
-	/* fixes chrome rems bug - http://stackoverflow.com/questions/20099844/chrome-not-respecting-rem-font-size-on-body-tag */
+  min-height: 100%;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  line-height: 1.76;
+  color: #222222;
+  background: #eeeeee;
 }
 
 figure {
-	margin: 0;
+  margin: 0;
 }
 
 body,
@@ -1240,185 +985,244 @@ input,
 button,
 textarea,
 p,
+blockquote,
 th,
 td {
-	margin: 0;
-	padding: 0;
-}
-
-abbr[title] {
-	text-decoration: none;
-}
-
-[contenteditable]:focus,
-[tabindex="0"]:focus {
-	outline: 4px solid #ffcc00;
-}
-
-a {
-	color: #004b83;
-	text-decoration: underline;
-	text-decoration-skip-ink: auto;
-}
-
-a.visited, a:visited {
-	color: #a345c9;
-}
-
-a.hover, a:hover {
-	color: #0061a9;
-	text-decoration: none;
-}
-
-a.active, a:active {
-	color: #003b84;
-	text-decoration: none;
-}
-
-a.focus, a:focus {
-	outline: 4px solid #ffcc00;
-}
-
-a > img {
-	vertical-align: middle;
-}
-
-table {
-	border: 1px solid #a6a6a6;
-	width: 100%;
-	margin-bottom: 32px;
-}
-
-th,
-td {
-	font-size: 16px;
-	border: 1px solid #a6a6a6;
-	padding: 0.3em 0.6em;
-	vertical-align: top;
-}
-
-th {
-	background: #e6e6e6;
-	text-align: left;
+  margin: 0;
+  padding: 0;
 }
 
 h1,
 h2,
 h3,
-h4 {
-	line-height: 1.4;
-	margin-top: 0;
+h4,
+h5,
+h6,
+small {
+  margin: 0;
+  padding: 0;
 }
 
+abbr[title] {
+  text-decoration: none;
+}
+
+[contenteditable]:focus,
+[tabindex="0"]:focus {
+  outline: 3px solid #fece3e;
+  will-change: transform;
+}
+
+/**
+ * Links
+ * Basic link styles
+ */
+a {
+  text-decoration: none;
+  vertical-align: baseline;
+  color: #006699;
+}
+a:focus {
+  outline: 3px solid #fece3e;
+  will-change: transform;
+}
+
+a:hover {
+  text-decoration: underline;
+  -webkit-text-decoration-skip: skip;
+  text-decoration-skip-ink: auto;
+}
+
+a:active {
+  outline: 0;
+}
+
+/**
+ * Lists
+ * Default list styles
+ */
+nav ul,
+nav ol {
+  list-style: none;
+  list-style-image: none;
+}
+
+/**
+ * Tables
+ * Default table styles
+ */
+table {
+  width: 100%;
+  margin-bottom: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
+  font-size: 1rem;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+}
+
+th,
+td {
+  padding: 4px 7px;
+  border-right: 1px solid #d5d5d5;
+  text-align: left;
+  line-height: 1.15;
+}
+
+th {
+  vertical-align: top;
+}
+
+td {
+  vertical-align: middle;
+}
+
+th[valign=top] {
+  vertical-align: top;
+}
+
+th[valign=middle] {
+  vertical-align: middle;
+}
+
+thead tr {
+  border-bottom: 1px solid #d5d5d5;
+}
+
+tbody tr {
+  border-top: 1px solid #d5d5d5;
+}
+
+tbody tr:first-child {
+  border-top: 0;
+}
+
+th {
+  background: #eeeeee;
+}
+
+tfoot tr {
+  border-top: 2px solid #d5d5d5;
+}
+
+tfoot td {
+  font-weight: bold;
+}
+
+/**
+ * Typography
+ * Set base font size
+ */
+html {
+  font-size: 100%;
+}
+
+body {
+  font-size: 1.125rem;
+}
+
+/**
+ * Typographic
+ * Standard text and heading formatting
+ */
+/*
+ * Default spacing
+ * default margin 28px to match line height
+ * this is used for mainting vertical rhythm on the page
+ */
 p,
-ol,
 ul,
-dl {
-	margin-top: 0;
+ol {
+  margin-top: 0;
+  margin-bottom: 28px;
 }
 
-dd {
-	margin: 0;
-}
-
-p {
-	margin-bottom: 1.5em;
-}
-
-p:last-child {
-	margin-bottom: 0;
-}
-
+/*
+ * Headings
+ */
 p:empty {
-	display: none;
+  display: none;
 }
 
-cite {
-	font-style: normal;
-}
-
-/* TODO: Move color to brand context */
 .c-details {
-	padding: 0 0;
-	border-style: solid;
-	border-color: #cccccc;
-	border-width: 0 0;
-	/* In case it’s a list item */
-	list-style: none;
+  padding: 16px 0;
+  border-style: solid;
+  border-color: currentColor;
+  border-width: 1px 0;
+  /* In case it’s a list item */
+  list-style: none;
 }
 
 .c-details + .c-details {
-	/* for successive details instances, don't double the border */
-	border-top: 0;
-	margin-top: 1em;
+  /* for successive details instances, don't double the border */
+  border-top: 0;
+  margin-top: 0;
 }
 
 .c-details__details {
-	/* For IE11 (unknown element) */
-	display: block;
+  /* For IE11 (unknown element) */
+  display: block;
 }
 
 .c-details__summary {
-	cursor: pointer;
-	/* For IE11 (unknown element) */
-	display: block;
-	/* remove marker in Firefox */
-	list-style-type: none;
+  cursor: pointer;
+  /* For IE11 (unknown element) */
+  display: block;
+  /* remove marker in Firefox */
+  list-style-type: none;
 }
 
 /* remove marker in other browsers */
 .c-details__summary::marker,
 .c-details__summary::-webkit-details-marker {
-	display: none;
+  display: none;
 }
 
 /* enhance focus styles */
 @supports (text-decoration-color: #000) {
-	.c-details__summary:focus {
-		outline: none;
-	}
-	.c-details__summary:focus .c-details__title {
-		text-decoration: underline;
-		text-decoration-color: #ffcc00;
-		text-decoration-thickness: 3px;
-	}
-}
+  .c-details__summary:focus {
+    outline: none;
+  }
 
+  .c-details__summary:focus .c-details__title {
+    text-decoration: underline;
+    text-decoration-color: #fece3e;
+    text-decoration-thickness: 3px;
+  }
+}
 .c-details__header {
-	display: flex;
-	align-items: center;
+  display: flex;
+  align-items: baseline;
 }
 
 .c-details__header .u-icon {
-	flex-shrink: 0;
-	width: 0.75em;
-	height: 0.75em;
-	color: #0070a8;
+  flex-shrink: 0;
+  width: 0.75em;
+  height: 0.75em;
+  color: currentColor;
 }
 
 /* ↓ Complex selector necessary to ensure
 nested icons are not rotated */
 .c-details > [open] > summary > div > .u-icon {
-	transform: rotate(90deg);
+  transform: rotate(90deg);
 }
 
 .c-details__title {
-	margin-left: 8px;
-	font-family: Georgia, Palatino, serif;
-	font-size: 2.4rem;
-	color: #0070a8;
-	line-height: 1.25;
+  margin-left: 8px;
+  font-family: inherit;
+  font-size: 1.25rem;
+  color: inherit;
+  line-height: 1.25;
 }
 
 .c-details__content {
-	padding: 16px 0 0 1.25em;
+  padding: 16px 0 0 0;
 }
 
 /* Remove excess margin from (for example) paragraphs */
 .c-details__content > :last-child {
-	margin-bottom: 0;
+  margin-bottom: 0;
 }
-
 		</style>
 	</head>
 	<body style="padding:2%">

--- a/toolkits/global/packages/global-details/demo/main.scss
+++ b/toolkits/global/packages/global-details/demo/main.scss
@@ -2,9 +2,9 @@
 
 // we must not add `node_modules/` to the Sass includePaths config,
 //   so use relative paths here. Paths should be relative to this file.
-@import '../node_modules/@springernature/brand-context/nature/scss/core.scss';
-@import '../node_modules/@springernature/brand-context/nature/scss/enhanced.scss';
+@import '../node_modules/@springernature/brand-context/default/scss/core.scss';
+@import '../node_modules/@springernature/brand-context/default/scss/enhanced.scss';
 
 // component SCSS
-@import '../scss/10-settings/nature';
+@import '../scss/10-settings/default';
 @import '../scss/50-components/details';

--- a/toolkits/global/packages/global-details/demo/main.scss
+++ b/toolkits/global/packages/global-details/demo/main.scss
@@ -2,9 +2,9 @@
 
 // we must not add `node_modules/` to the Sass includePaths config,
 //   so use relative paths here. Paths should be relative to this file.
-@import '../node_modules/@springernature/brand-context/springer/scss/core.scss';
-@import '../node_modules/@springernature/brand-context/springer/scss/enhanced.scss';
+@import '../node_modules/@springernature/brand-context/nature/scss/core.scss';
+@import '../node_modules/@springernature/brand-context/nature/scss/enhanced.scss';
 
 // component SCSS
-@import '../scss/10-settings/springer';
+@import '../scss/10-settings/nature';
 @import '../scss/50-components/details';

--- a/toolkits/global/packages/global-details/package.json
+++ b/toolkits/global/packages/global-details/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-details",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "description": "A JS-independent, accessible disclosure component",
   "keywords": [],

--- a/toolkits/global/packages/global-details/scss/10-settings/springer.scss
+++ b/toolkits/global/packages/global-details/scss/10-settings/springer.scss
@@ -6,6 +6,7 @@ $details--border-width: 0;
 $details--padding: 0;
 $details--content-padding: spacing(16) 0 0 1.333em;
 $details--spacing: 1.5em;
+$details--icon-size: 1em;
 $details--focus-underline-color: color('action-focus');
 /* TODO: Move color to brand context */
 $details--title-color: #0070a8;

--- a/toolkits/global/packages/global-details/scss/10-settings/springernature.scss
+++ b/toolkits/global/packages/global-details/scss/10-settings/springernature.scss
@@ -1,4 +1,5 @@
 // Default setting
 @import 'default';
 
+$details--icon-size: 1em;
 $details--focus-underline-color: $context--focus-color;

--- a/toolkits/global/packages/global-details/scss/50-components/details.scss
+++ b/toolkits/global/packages/global-details/scss/50-components/details.scss
@@ -47,7 +47,7 @@
 
 .c-details__header {
 	display: flex;
-	align-items: center;
+	align-items: baseline;
 }
 
 .c-details__header .u-icon {


### PR DESCRIPTION
```
## 0.2.1 (2022-08-03)
    * Alignment of chevron icon to baseline
```

Before (springer example):

<img width="507" alt="poor alignment" src="https://user-images.githubusercontent.com/683558/182616673-880b4de9-e846-4fe6-88db-08414f2a81dd.png">

After (springer example):

<img width="507" alt="good alignment" src="https://user-images.githubusercontent.com/683558/182616768-443f9384-7147-4136-985c-6baf7ddcbcf0.png">
