### PR TITLE
Springer flow spacing

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,4 +1,11 @@
 # History
+
+## 26.0.0 (2022-08-10)
+    * BREAKING:
+      * Springer: erroneous use of placeholders removed to fix cascade
+	  * Springer: new spacing algorithm for flow elements
+    * Removal of `outline: none` for non-interactive elements (redundant)
+
 ## 25.0.0 (2022-06-29)
     * UDPATES:
       * updates generated Sass from Design Tokens

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "25.0.0",
+  "version": "26.0.0",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/springer/scss/30-mixins/typography.scss
+++ b/context/brand-context/springer/scss/30-mixins/typography.scss
@@ -20,22 +20,15 @@
 
 @mixin heading-base {
 	font-style: normal;
-	margin-block-start: spacing(32);
-	margin-block-end: spacing(8);
 	line-height: $context--line-height-tight;
 
 	a {
 		@include u-link-interface;
 	}
-
-	&:first-child {
-		margin-block-start: 0;
-	}
 }
 
 @mixin u-h1 {
 	@include heading-base;
-	margin-block-end: spacing(48);
 	font-size: $context--font-size-h1;
 	font-size: unquote('min(max(#{$context--font-size-h1-min}, 4vw), #{$context--font-size-h1})');
 	font-family: $context--font-family-serif;
@@ -44,7 +37,6 @@
 
 @mixin u-h2 {
 	@include heading-base;
-	margin-block-end: spacing(16);
 	font-size: $context--font-size-h2;
 	font-size: unquote('min(max(#{$context--font-size-h2-min}, 3.5vw), #{$context--font-size-h2})');
 	font-family: $context--font-family-serif;
@@ -74,4 +66,6 @@
 	font-family: $context--font-family-sans;
 	font-weight: $context--font-weight-bold;
 }
+
+
 

--- a/context/brand-context/springer/scss/30-mixins/typography.scss
+++ b/context/brand-context/springer/scss/30-mixins/typography.scss
@@ -21,32 +21,37 @@
 @mixin heading-base {
 	font-style: normal;
 	margin-block-start: spacing(32);
-	margin-block-end: spacing(16);
+	margin-block-end: spacing(8);
 	line-height: $context--line-height-tight;
 
 	a {
 		@include u-link-interface;
 	}
+
+	&:first-child {
+		margin-block-start: 0;
+	}
 }
 
-%u-h1 {
+@mixin u-h1 {
 	@include heading-base;
-	margin-block-end: spacing(32);
+	margin-block-end: spacing(48);
 	font-size: $context--font-size-h1;
 	font-size: unquote('min(max(#{$context--font-size-h1-min}, 4vw), #{$context--font-size-h1})');
 	font-family: $context--font-family-serif;
 	font-weight: $context--font-weight-normal;
 }
 
-%u-h2 {
+@mixin u-h2 {
 	@include heading-base;
+	margin-block-end: spacing(16);
 	font-size: $context--font-size-h2;
 	font-size: unquote('min(max(#{$context--font-size-h2-min}, 3.5vw), #{$context--font-size-h2})');
 	font-family: $context--font-family-serif;
 	font-weight: $context--font-weight-normal;
 }
 
-%u-h3 {
+@mixin u-h3 {
 	@include heading-base;
 	font-size: $context--font-size-h3;
 	font-size: unquote('min(max(#{$context--font-size-h3-min}, 3vw), #{$context--font-size-h3})');
@@ -54,7 +59,7 @@
 	font-weight: $context--font-weight-normal;
 }
 
-%u-h4 {
+@mixin u-h4 {
 	@include heading-base;
 	font-size: $context--font-size-h4;
 	font-size: unquote('min(max(#{$context--font-size-h4-min}, 2.5vw), #{$context--font-size-h4})');
@@ -62,7 +67,7 @@
 	font-weight: $context--font-weight-bold;
 }
 
-%u-h5 {
+@mixin u-h5 {
 	@include heading-base;
 	font-size: $context--font-size-h5;
 	font-size: unquote('min(max(#{$context--font-size-h5-min}, 2.5vw), #{$context--font-size-h5})');

--- a/context/brand-context/springer/scss/30-mixins/typography.scss
+++ b/context/brand-context/springer/scss/30-mixins/typography.scss
@@ -20,7 +20,8 @@
 
 @mixin heading-base {
 	font-style: normal;
-	margin-bottom: 1em;
+	margin-block-start: spacing(32);
+	margin-block-end: spacing(16);
 	line-height: $context--line-height-tight;
 
 	a {
@@ -30,6 +31,7 @@
 
 %u-h1 {
 	@include heading-base;
+	margin-block-end: spacing(32);
 	font-size: $context--font-size-h1;
 	font-size: unquote('min(max(#{$context--font-size-h1-min}, 4vw), #{$context--font-size-h1})');
 	font-family: $context--font-family-serif;

--- a/context/brand-context/springer/scss/40-base/basic.scss
+++ b/context/brand-context/springer/scss/40-base/basic.scss
@@ -8,6 +8,10 @@ body {
 	line-height: 1.5;
 }
 
+* {
+	margin: 0;
+}
+
 a {
 	text-decoration: none;
 	color: #069;
@@ -56,27 +60,4 @@ img {
 button {
 	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
 	border-radius: 0;
-}
-
-/* accessible focus styles */
-
-h1:focus,
-h2:focus,
-h3:focus,
-h4:focus,
-h5:focus,
-p:focus,
-div:focus,
-ul:focus,
-ol:focus,
-li:focus,
-dl:focus,
-dt:focus,
-dd:focus,
-span:focus,
-i:focus,
-b:focus,
-em:focus,
-strong:focus {
-	outline: none;
 }

--- a/context/brand-context/springer/scss/40-base/typography.scss
+++ b/context/brand-context/springer/scss/40-base/typography.scss
@@ -1,11 +1,3 @@
-h1,
-h2,
-h3,
-h4{
-	line-height: 1.4;
-	margin-top: 0;
-}
-
 h1 {
 	@include u-h1;
 }
@@ -27,17 +19,36 @@ h6 {
 	@include u-h5;
 }
 
-ol,
-ul,
-dl,
-figure,
-blockquote {
-	margin-block: spacing(16);
+/* Spacing algorithm: */
+
+:is(p, ol, ul, dl, figure, blockquote, form, pre, table, img) + * {
+	margin-block-start: spacing(16);
 }
 
-:is(ol, ul, dl, figure, blockquote):last-child {
-	margin-block-end: 0;
+* + :is(h2, h3, h4, h5) {
+	margin-block-start: spacing(32);
 }
+
+:is(h3, h4, h5) + * {
+	margin-block-start: spacing(8);
+}
+
+h2 + * {
+	margin-block-start: spacing(16);
+}
+
+h1 + * {
+	margin-block-start: spacing(48);
+}
+
+/* Not applicable after hidden elements */
+[hidden] + *,
+[style*="display:none"] + *,
+[style*="display: none"] + * {
+	margin-block-start: 0;
+}
+
+/* end spacing algorithm */
 
 /* Basic lists should be aligned to the left */
 ul:not([class]),
@@ -48,18 +59,6 @@ ol:not([class]) {
 
 dd {
 	margin: 0;
-}
-
-p {
-	margin-block: spacing(8);
-}
-
-p:last-child {
-	margin-bottom: 0;
-}
-
-p:empty {
-	display: none;
 }
 
 cite {

--- a/context/brand-context/springer/scss/40-base/typography.scss
+++ b/context/brand-context/springer/scss/40-base/typography.scss
@@ -27,11 +27,16 @@ h6 {
 	@include u-h5;
 }
 
-p,
 ol,
 ul,
-dl {
-	margin-top: 0;
+dl,
+figure,
+blockquote {
+	margin-block: spacing(16);
+}
+
+:is(ol, ul, dl, figure, blockquote):last-child {
+	margin-block-end: 0;
 }
 
 /* Basic lists should be aligned to the left */
@@ -46,7 +51,7 @@ dd {
 }
 
 p {
-	margin-bottom: 1.5em;
+	margin-block: spacing(8);
 }
 
 p:last-child {


### PR DESCRIPTION
```
## 26.0.0 (2022-08-10)
    * BREAKING:
      * Springer: erroneous use of placeholders removed to fix cascade
      * Springer: new spacing algorithm for flow elements
    * Removal of `outline: none` for non-interactive elements (redundant)
```