### PR TITLE
Fixes `packages/packages` error when running full tokens build.

### DIFF
--- a/context/design-tokens/build-component.js
+++ b/context/design-tokens/build-component.js
@@ -48,31 +48,31 @@ function getStyleDictionaryConfig(brand, components) {
 
 console.log('Build started...');
 
-// the following array needs to be manually updated when more brand speicifc components are added to brands not on this list. Otherwise this will not build. This is why it is currently not part of
-[''].map(function (brand) {
+// // the following array needs to be manually updated when more brand speicifc components are added to brands not on this list. Otherwise this will not build. This is why it is currently not part of
+// [''].map(function (brand) {
 
-	let dir = `${__dirname}/components/${brand}`
-	const components = readdirSync(dir);
-	const brands = StyleDictionaryPackage.extend(getStyleDictionaryConfig(brand, components));
+// 	let dir = `${__dirname}/components/${brand}`
+// 	const components = readdirSync(dir);
+// 	const brands = StyleDictionaryPackage.extend(getStyleDictionaryConfig(brand, components));
 
-	brands.buildAllPlatforms();
+// 	brands.buildAllPlatforms();
 
-	components.map(component => {
-		let dir = `./toolkits/${brand}/packages/${component}/scss/00-tokens`
-		const files = readdirSync(dir);
+// 	components.map(component => {
+// 		let dir = `./toolkits/${brand}/packages/${component}/scss/00-tokens`
+// 		const files = readdirSync(dir);
 
-		files.map(file => {
-			let filePath = `${dir}/${file}`
-			let content = fs.readFileSync(filePath, 'utf8');
-			let sortedContent = content.split('\n').sort().join('\n');
-			fs.writeFileSync(filePath, sortedContent);
-			let date = new Date();
-			let dateString = date.toLocaleString();
-			let newContent = `// Created: ${dateString}\n// Source: design-tokens/componenets/${brand}/${component}/${brand}.json\n// DO NOT edit directly\n\n${sortedContent}`;
-			let addedContent = newContent.replace(/: \$/g, ': $tokens--');
-			fs.writeFileSync(filePath, addedContent);
-		})
-	});
+// 		files.map(file => {
+// 			let filePath = `${dir}/${file}`
+// 			let content = fs.readFileSync(filePath, 'utf8');
+// 			let sortedContent = content.split('\n').sort().join('\n');
+// 			fs.writeFileSync(filePath, sortedContent);
+// 			let date = new Date();
+// 			let dateString = date.toLocaleString();
+// 			let newContent = `// Created: ${dateString}\n// Source: design-tokens/componenets/${brand}/${component}/${brand}.json\n// DO NOT edit directly\n\n${sortedContent}`;
+// 			let addedContent = newContent.replace(/: \$/g, ': $tokens--');
+// 			fs.writeFileSync(filePath, addedContent);
+// 		})
+// 	});
 
-	console.log('\nEnd processing');
-});
+// 	console.log('\nEnd processing');
+// });

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:ci": "jest --passWithNoTests --runInBand",
     "tokens:alias": "npm run tokens:clean && npm run tokens:literal && node ./context/design-tokens/build-alias.js",
     "tokens:clean": "npx rimraf **/00-tokens/",
-    "tokens:components": "npm run tokens:global-components && npm run tokens:brand-components",
+    "tokens:components": "npm run tokens:global-components",
     "tokens:literal": "node ./context/design-tokens/build-literal.js",
     "tokens:global-components": "npm run tokens:clean && npm run tokens:literal && npm run tokens:alias && node ./context/design-tokens/build-component-global.js",
     "tokens:brand-components": "node ./context/design-tokens/build-component.js",


### PR DESCRIPTION
Because there are currently no brand specific components that make use of design tokens I had an empty `''` in the `build-component.js` file which would create a `package/package` folder in toolkits. 

This is a hotfix becuase I'm working on a better tokens workflow with #763. 

I have removed the brand components task from being run when running `npm run tokens:component`.

I have commented out the erroneous code. 