### PR TITLE
stop overflow on global-card

### DIFF
--- a/toolkits/global/packages/global-card/HISTORY.md
+++ b/toolkits/global/packages/global-card/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 8.3.2 (2022-09-13)
+    * `overflow: hidden`
+
 ## 8.3.1 (2022-08-11)
     * Activate hyphenation for German content
 

--- a/toolkits/global/packages/global-card/package.json
+++ b/toolkits/global/packages/global-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-card",
-  "version": "8.3.1",
+  "version": "8.3.2",
   "license": "MIT",
   "description": "card component",
   "keywords": [

--- a/toolkits/global/packages/global-card/scss/50-components/card.scss
+++ b/toolkits/global/packages/global-card/scss/50-components/card.scss
@@ -13,6 +13,7 @@
 	position: relative;
 	border: $card--border;
 	box-shadow: $card--box-shadow;
+	overflow: hidden;
 }
 
 .c-card--no-shape {


### PR DESCRIPTION
So... we hyphenate long German words where `de` is correctly set as the `lang` but... there are many pages that don't currently set the `lang` correctly, so this is damage control.