### PR TITLE
Sensible width and height for aria-hidden SVGs in core browser styles

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,4 +1,6 @@
 # History
+## 27.1.0 (2022-09-14)
+      * Sets a sensible default width and height for aria-hidden inline SVGs in the core styles to reduce the core experience looking broken
 ## 27.0.0 (2022-09-09)
     * BREAKING:
       * Springer Nature: Updates body font family to Merriweather Sans.

--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,6 +1,7 @@
 # History
 ## 27.1.0 (2022-09-14)
-      * Sets a sensible default width and height for aria-hidden inline SVGs in the core styles to reduce the core experience looking broken
+    * Abstracts shared styles from brand basic.css files into a default basic.scss file  
+    * Sets a sensible default width and height for aria-hidden inline SVGs in the core styles to reduce the core experience looking broken
 ## 27.0.0 (2022-09-09)
     * BREAKING:
       * Springer Nature: Updates body font family to Merriweather Sans.

--- a/context/brand-context/default/scss/40-base/basic.scss
+++ b/context/brand-context/default/scss/40-base/basic.scss
@@ -1,0 +1,28 @@
+body {
+	line-height: 1.5;
+}
+
+a {
+	text-decoration: none;
+}
+
+a:hover,
+a:focus {
+	text-decoration: underline;
+}
+
+button {
+	cursor: pointer;
+}
+
+img {
+	border: 0;
+	max-width: 100%;
+	height: auto;
+	vertical-align: middle;
+}
+
+svg[aria-hidden] {
+	width: 1rem;
+	height: 1rem;
+}

--- a/context/brand-context/default/scss/core.scss
+++ b/context/brand-context/default/scss/core.scss
@@ -5,3 +5,4 @@
  */
 
 @import '40-base/normalize';
+@import '40-base/basic';

--- a/context/brand-context/nature/scss/40-base/basic.scss
+++ b/context/brand-context/nature/scss/40-base/basic.scss
@@ -52,6 +52,11 @@ img {
 	vertical-align: middle;
 }
 
+svg[aria-hidden] {
+	width: 1rem;
+	height: 1rem;
+}
+
 button {
 	font-family: $context--font-family-sans;
 	border-radius: 0;

--- a/context/brand-context/nature/scss/40-base/basic.scss
+++ b/context/brand-context/nature/scss/40-base/basic.scss
@@ -3,22 +3,8 @@
  * Some default CSS styles
  */
 
-body {
-	line-height: 1.5;
-}
-
 a {
-	text-decoration: none;
 	color: color('blue');
-}
-
-a:hover,
-a:focus {
-	text-decoration: underline;
-}
-
-button {
-	cursor: pointer;
 }
 
 h1 {
@@ -43,18 +29,6 @@ cite {
 
 ins {
 	text-decoration: none;
-}
-
-img {
-	border: 0;
-	max-width: 100%;
-	height: auto;
-	vertical-align: middle;
-}
-
-svg[aria-hidden] {
-	width: 1rem;
-	height: 1rem;
 }
 
 button {

--- a/context/brand-context/nature/scss/core.scss
+++ b/context/brand-context/nature/scss/core.scss
@@ -12,4 +12,5 @@
 
 // 40-base
 @import '../../default/scss/40-base/normalize';
+@import '../../default/scss/40-base/basic';
 @import '40-base/basic';

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "27.0.0",
+  "version": "27.1.0",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/springer/scss/40-base/basic.scss
+++ b/context/brand-context/springer/scss/40-base/basic.scss
@@ -57,7 +57,13 @@ img {
 	vertical-align: middle;
 }
 
+svg[aria-hidden] {
+	width: 1rem;
+	height: 1rem;
+}
+
 button {
 	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
 	border-radius: 0;
 }
+

--- a/context/brand-context/springer/scss/40-base/basic.scss
+++ b/context/brand-context/springer/scss/40-base/basic.scss
@@ -5,7 +5,6 @@
 
 body {
 	font-size: .813rem;
-	line-height: 1.5;
 }
 
 * {
@@ -13,17 +12,7 @@ body {
 }
 
 a {
-	text-decoration: none;
 	color: #069;
-}
-
-a:hover,
-a:focus {
-	text-decoration: underline;
-}
-
-button {
-	cursor: pointer;
 }
 
 h1 {
@@ -48,18 +37,6 @@ cite {
 
 ins {
 	text-decoration: none;
-}
-
-img {
-	border: 0;
-	max-width: 100%;
-	height: auto;
-	vertical-align: middle;
-}
-
-svg[aria-hidden] {
-	width: 1rem;
-	height: 1rem;
 }
 
 button {

--- a/context/brand-context/springer/scss/core.scss
+++ b/context/brand-context/springer/scss/core.scss
@@ -12,4 +12,5 @@
 
 // 40-base
 @import '../../default/scss/40-base/normalize';
+@import '../../default/scss/40-base/basic';
 @import "40-base/basic";

--- a/context/brand-context/springernature/scss/40-base/basic.scss
+++ b/context/brand-context/springernature/scss/40-base/basic.scss
@@ -4,32 +4,9 @@
  */
 
 body {
-	line-height: 1.5;
 	font-family: $context--font-family-sans;
 }
 
 a {
-	text-decoration: none;
 	color: $context--link-color;
-}
-
-a:hover,
-a:focus {
-	text-decoration: underline;
-}
-
-button {
-	cursor: pointer;
-}
-
-img {
-	border: 0;
-	max-width: 100%;
-	height: auto;
-	vertical-align: middle;
-}
-
-svg[aria-hidden] {
-	width: 1rem;
-	height: 1rem;
 }

--- a/context/brand-context/springernature/scss/40-base/basic.scss
+++ b/context/brand-context/springernature/scss/40-base/basic.scss
@@ -28,3 +28,8 @@ img {
 	height: auto;
 	vertical-align: middle;
 }
+
+svg[aria-hidden] {
+	width: 1rem;
+	height: 1rem;
+}

--- a/context/brand-context/springernature/scss/core.scss
+++ b/context/brand-context/springernature/scss/core.scss
@@ -12,4 +12,5 @@
 
 // 40-base
 @import '../../default/scss/40-base/normalize';
+@import '../../default/scss/40-base/basic';
 @import '40-base/basic';


### PR DESCRIPTION
Thanks to @morgaan  for raising an issue in https://github.com/springernature/frontend-toolkits/pull/792 which highlighted the need for us to be setting a sensible default width and height for all decorative inline SVGs in our core styles.

In some cases we use inline SVGs on our sites and style them in our enhanced stylesheets. Those enhanced styles often set an appropriate width and height for the inline SVG. It makes sense to have a sensible default in the core styles, this prevent the core browser user experience from looking a bit broken (because of huge SVGs that have scaled to the size of their container).