### PR TITLE
updates brand context to version 28

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,6 +1,12 @@
 # History
+## 28.0.0 (2022-09-14)
+    * BREAKING:
+        * New universal block spacing (inter-element margin) for flow content
+    * block-spacing alias design tokens
+    * spacing applied to heading utility classes
+    * “accessible focus styles” removed (redundant `outline: none` on non-interactive elements)
 ## 27.1.0 (2022-09-14)
-    * Abstracts shared styles from brand basic.css files into a default basic.scss file  
+    * Abstracts shared styles from brand basic.css files into a default basic.scss file
     * Sets a sensible default width and height for aria-hidden inline SVGs in the core styles to reduce the core experience looking broken
 ## 27.0.0 (2022-09-09)
     * BREAKING:

--- a/context/brand-context/default/scss/00-tokens/_background.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_background.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 09 Sep 2022 10:53:10 GMT
+// Generated on Thu, 15 Sep 2022 10:03:31 GMT
 
 $tokens--background-page: #f8f8f8;
 $tokens--background-container: #ffffff;

--- a/context/brand-context/default/scss/00-tokens/_border.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_border.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 09 Sep 2022 10:53:10 GMT
+// Generated on Thu, 15 Sep 2022 10:03:31 GMT
 
 $tokens--border-color-primary: #222222;
 $tokens--border-color-input: #555555;

--- a/context/brand-context/default/scss/00-tokens/_breakpoints.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_breakpoints.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 09 Sep 2022 10:53:10 GMT
+// Generated on Thu, 15 Sep 2022 10:03:30 GMT
 
 $tokens--breakpoints-xs: 320px; // mobile
 $tokens--breakpoints-sm: 580px; // small tablet

--- a/context/brand-context/default/scss/00-tokens/_button.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_button.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 09 Sep 2022 10:53:10 GMT
+// Generated on Thu, 15 Sep 2022 10:03:31 GMT
 
 $tokens--button-background-primary-resting: #01324b;
 $tokens--button-background-primary-hover: #ffffff;

--- a/context/brand-context/default/scss/00-tokens/_color.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_color.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 09 Sep 2022 10:53:10 GMT
+// Generated on Thu, 15 Sep 2022 10:03:31 GMT
 
 $tokens--color-white: #ffffff;
 $tokens--color-black: #000000;

--- a/context/brand-context/default/scss/00-tokens/_font-weight.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_font-weight.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 09 Sep 2022 10:53:10 GMT
+// Generated on Thu, 15 Sep 2022 10:03:30 GMT
 
 $tokens--font-weight-light: 300; // normal
 $tokens--font-weight-normal: 400; // The normal, or ‘regular’, font weight.

--- a/context/brand-context/default/scss/00-tokens/_icon.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_icon.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 09 Sep 2022 10:53:10 GMT
+// Generated on Thu, 15 Sep 2022 10:03:31 GMT
 
 $tokens--icon-checkbox-checked-stroke: #ffffff;
 $tokens--icon-checkbox-checked-fill: #01324b;

--- a/context/brand-context/default/scss/00-tokens/_link.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_link.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 09 Sep 2022 10:53:10 GMT
+// Generated on Thu, 15 Sep 2022 10:03:31 GMT
 
 $tokens--link-color: #025e8d;
 $tokens--link-hover: #01324b;

--- a/context/brand-context/default/scss/00-tokens/_sizing.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_sizing.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 09 Sep 2022 10:53:10 GMT
+// Generated on Thu, 15 Sep 2022 10:03:30 GMT
 
 $tokens--sizing-relative-0: 0; // no spacing, zero.
 $tokens--sizing-relative-25: .0625; // .0625rem, 1px

--- a/context/brand-context/default/scss/00-tokens/_spacing.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_spacing.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 09 Sep 2022 10:53:10 GMT
+// Generated on Thu, 15 Sep 2022 10:03:30 GMT
 
 $tokens--spacing-relative-0: 0; // no spacing, zero.
 $tokens--spacing-relative-100: .25rem; // .25rem, 4px.

--- a/context/brand-context/default/scss/00-tokens/_state.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_state.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 09 Sep 2022 10:53:10 GMT
+// Generated on Thu, 15 Sep 2022 10:03:31 GMT
 
 $tokens--state-focus: #ffcc00;
 $tokens--state-error: #c40606;

--- a/context/brand-context/default/scss/00-tokens/_text.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_text.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 09 Sep 2022 10:53:10 GMT
+// Generated on Thu, 15 Sep 2022 10:03:31 GMT
 
 $tokens--text-primary: #000000;
 $tokens--text-secondary: #666666;

--- a/context/brand-context/default/scss/00-tokens/_typography.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_typography.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 09 Sep 2022 10:53:10 GMT
+// Generated on Thu, 15 Sep 2022 10:03:31 GMT
 
 $tokens--typography-heading-font-family: serif;
 $tokens--typography-heading-letter-spacing: 0.2rem;
@@ -20,3 +20,7 @@ $tokens--typography-heading-level-4-font-weight: 700;
 $tokens--typography-heading-level-5-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
 $tokens--typography-heading-level-5-font-size: 1.125rem;
 $tokens--typography-heading-level-5-font-weight: 700;
+$tokens--typography-block-spacing-small: .5rem;
+$tokens--typography-block-spacing-medium: 1rem;
+$tokens--typography-block-spacing-large: 2rem;
+$tokens--typography-block-spacing-x-large: 3rem;

--- a/context/brand-context/default/scss/00-tokens/_ui.variables.scss
+++ b/context/brand-context/default/scss/00-tokens/_ui.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 09 Sep 2022 10:53:10 GMT
+// Generated on Thu, 15 Sep 2022 10:03:31 GMT
 
 $tokens--ui-font-size: 1rem;
 $tokens--ui-focus-outline-color: #0088cc;

--- a/context/brand-context/default/scss/40-base/block-spacing.scss
+++ b/context/brand-context/default/scss/40-base/block-spacing.scss
@@ -1,0 +1,23 @@
+* {
+	margin-block: 0;
+}
+
+:is(p, ol, ul, dl, figure, blockquote, form, pre, table, img, video, aside, section, article)+* {
+	margin-block-start: $tokens--typography-block-spacing-medium;
+}
+
+*+ :is(h2, h3, h4, h5) {
+	margin-block-start: $tokens--typography-block-spacing-large;
+}
+
+:is(h3, h4, h5)+* {
+	margin-block-start: $tokens--typography-block-spacing-small;
+}
+
+h2+* {
+	margin-block-start: $tokens--typography-block-spacing-medium;
+}
+
+h1+* {
+	margin-block-start: $tokens--typography-block-spacing-x-large;
+}

--- a/context/brand-context/default/scss/40-base/typography.scss
+++ b/context/brand-context/default/scss/40-base/typography.scss
@@ -10,3 +10,32 @@ html {
 body {
 	font-size: $context--font-size-base;
 }
+
+/* spacing algorithm */
+
+:is(p, ol, ul, dl, figure, blockquote, form, pre, table, img)+* {
+	margin-block-start: spacing(16);
+}
+
+*+ :is(h2, h3, h4, h5) {
+	margin-block-start: spacing(32);
+}
+
+:is(h3, h4, h5)+* {
+	margin-block-start: spacing(8);
+}
+
+h2+* {
+	margin-block-start: spacing(16);
+}
+
+h1+* {
+	margin-block-start: spacing(48);
+}
+
+/* Not applicable after hidden elements */
+[hidden]+*,
+[style*="display:none"]+*,
+[style*="display: none"]+* {
+	margin-block-start: 0;
+}

--- a/context/brand-context/default/scss/60-utilities/typography.scss
+++ b/context/brand-context/default/scss/60-utilities/typography.scss
@@ -84,3 +84,19 @@
 .u-h4 {
 	@include u-h4();
 }
+
+*+ :is(.u-h2, .u-h3, .u-h4) {
+	margin-block-start: $tokens--typography-block-spacing-large;
+}
+
+:is(.u-h3, .u-h4)+* {
+	margin-block-start: $tokens--typography-block-spacing-small;
+}
+
+.u-h2+* {
+	margin-block-start: $tokens--typography-block-spacing-medium;
+}
+
+.u-h1+* {
+	margin-block-start: $tokens--typography-block-spacing-x-large;
+}

--- a/context/brand-context/default/scss/enhanced.scss
+++ b/context/brand-context/default/scss/enhanced.scss
@@ -5,3 +5,4 @@
 
 @import 'abstracts';
 @import '40-base/typography';
+@import '40-base/block-spacing';

--- a/context/brand-context/nature/scss/00-tokens/_illustration.variables.scss
+++ b/context/brand-context/nature/scss/00-tokens/_illustration.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 09 Sep 2022 10:53:10 GMT
+// Generated on Thu, 15 Sep 2022 10:03:31 GMT
 
 $tokens--illustration-background-001: #29303C;
 $tokens--illustration-background-002: #536179;

--- a/context/brand-context/nature/scss/00-tokens/_typography.variables.scss
+++ b/context/brand-context/nature/scss/00-tokens/_typography.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 09 Sep 2022 10:53:10 GMT
+// Generated on Thu, 15 Sep 2022 10:03:31 GMT
 
 $tokens--typography-heading-font-family: serif;
 $tokens--typography-heading-letter-spacing: 0.2rem;

--- a/context/brand-context/nature/scss/40-base/basic.scss
+++ b/context/brand-context/nature/scss/40-base/basic.scss
@@ -35,26 +35,3 @@ button {
 	font-family: $context--font-family-sans;
 	border-radius: 0;
 }
-
-/* accessible focus styles */
-
-h1:focus,
-h2:focus,
-h3:focus,
-h4:focus,
-h5:focus,
-p:focus,
-div:focus,
-ul:focus,
-ol:focus,
-li:focus,
-dl:focus,
-dt:focus,
-dd:focus,
-span:focus,
-i:focus,
-b:focus,
-em:focus,
-strong:focus {
-	outline: none;
-}

--- a/context/brand-context/nature/scss/40-base/layout.scss
+++ b/context/brand-context/nature/scss/40-base/layout.scss
@@ -1,4 +1,4 @@
-/*
+/**
  * Layout
  * Universal layout styles
  */
@@ -6,57 +6,29 @@
 html {
 	height: 100%;
 	overflow-y: scroll;
+	font-size: $context--font-size-default;
 }
 
 body {
 	min-height: 100%;
-	font-family: $context--font-family-sans;
-	line-height: 1.76;
-	color: greyscale();
-	background: greyscale(80);
+	font-family: $context--font-family-serif;
+	font-size: $context--font-size-base;
+	line-height: $context--line-height-base;
+	color: $context--primary-text-color;
+	background: $context--page-background-color;
+	letter-spacing: 0.01em;
 }
 
-figure {
-	margin: 0;
+html {
+	box-sizing: border-box;
 }
 
-body,
-div,
-dl,
-dt,
-dd,
-pre,
-code,
-form,
-fieldset,
-legend,
-input,
-button,
-textarea,
-p,
-blockquote,
-th,
-td {
-	margin: 0;
-	padding: 0;
-}
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-small {
-	margin: 0;
-	padding: 0;
+*,
+*:before,
+*:after {
+	box-sizing: inherit;
 }
 
 abbr[title] {
 	text-decoration: none;
-}
-
-[contenteditable],
-[tabindex="0"] {
-	@include u-focus-outline();
 }

--- a/context/brand-context/nature/scss/40-base/typography.scss
+++ b/context/brand-context/nature/scss/40-base/typography.scss
@@ -9,13 +9,6 @@
  * this is used for mainting vertical rhythm on the page
  */
 
-p,
-ul,
-ol {
-	margin-top: 0;
-	margin-bottom: 28px;
-}
-
 /*
  * Headings
  */

--- a/context/brand-context/nature/scss/enhanced.scss
+++ b/context/brand-context/nature/scss/enhanced.scss
@@ -17,3 +17,4 @@
 @import '40-base/tables';
 @import '../../default/scss/40-base/typography';
 @import '40-base/typography';
+@import '../../default/scss/40-base/block-spacing';

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "27.1.0",
+  "version": "28.0.0",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/springer/scss/00-tokens/_typography.variables.scss
+++ b/context/brand-context/springer/scss/00-tokens/_typography.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 09 Sep 2022 10:53:10 GMT
+// Generated on Thu, 15 Sep 2022 10:03:31 GMT
 
 $tokens--typography-heading-font-family: serif;
 $tokens--typography-heading-letter-spacing: 0.2rem;

--- a/context/brand-context/springer/scss/40-base/typography.scss
+++ b/context/brand-context/springer/scss/40-base/typography.scss
@@ -19,37 +19,6 @@ h6 {
 	@include u-h5;
 }
 
-/* Spacing algorithm: */
-
-:is(p, ol, ul, dl, figure, blockquote, form, pre, table, img) + * {
-	margin-block-start: spacing(16);
-}
-
-* + :is(h2, h3, h4, h5) {
-	margin-block-start: spacing(32);
-}
-
-:is(h3, h4, h5) + * {
-	margin-block-start: spacing(8);
-}
-
-h2 + * {
-	margin-block-start: spacing(16);
-}
-
-h1 + * {
-	margin-block-start: spacing(48);
-}
-
-/* Not applicable after hidden elements */
-[hidden] + *,
-[style*="display:none"] + *,
-[style*="display: none"] + * {
-	margin-block-start: 0;
-}
-
-/* end spacing algorithm */
-
 /* Basic lists should be aligned to the left */
 ul:not([class]),
 ol:not([class]) {

--- a/context/brand-context/springer/scss/enhanced.scss
+++ b/context/brand-context/springer/scss/enhanced.scss
@@ -14,3 +14,4 @@
 @import '40-base/links';
 @import '40-base/tables';
 @import '40-base/typography';
+@import '../../default/scss/40-base/block-spacing';

--- a/context/brand-context/springernature/scss/00-tokens/_breakpoints.variables.scss
+++ b/context/brand-context/springernature/scss/00-tokens/_breakpoints.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 09 Sep 2022 10:53:10 GMT
+// Generated on Thu, 15 Sep 2022 10:03:30 GMT
 
 $tokens--breakpoints-tablet-width: 480px; // tablet-width
 $tokens--breakpoints-tablet-wide-width: 768px; // tablet-wide-width

--- a/context/brand-context/springernature/scss/00-tokens/_typography.variables.scss
+++ b/context/brand-context/springernature/scss/00-tokens/_typography.variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 09 Sep 2022 10:53:10 GMT
+// Generated on Thu, 15 Sep 2022 10:03:31 GMT
 
 $tokens--typography-heading-font-family: serif;
 $tokens--typography-heading-letter-spacing: 0.2rem;

--- a/context/brand-context/springernature/scss/40-base/layout.scss
+++ b/context/brand-context/springernature/scss/40-base/layout.scss
@@ -29,42 +29,6 @@ html {
 	box-sizing: inherit;
 }
 
-figure {
-	margin: 0;
-}
-
-body,
-div,
-dl,
-dt,
-dd,
-pre,
-code,
-form,
-fieldset,
-legend,
-input,
-button,
-textarea,
-p,
-blockquote,
-th,
-td {
-	margin: 0;
-	padding: 0;
-}
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-small {
-	margin: 0;
-	padding: 0;
-}
-
 abbr[title] {
 	text-decoration: none;
 }

--- a/context/brand-context/springernature/scss/enhanced.scss
+++ b/context/brand-context/springernature/scss/enhanced.scss
@@ -15,3 +15,4 @@
 @import '40-base/links';
 @import '40-base/tables';
 @import '40-base/forms';
+@import '../../default/scss/40-base/block-spacing';

--- a/context/design-tokens/alias/default/typography/typography.json
+++ b/context/design-tokens/alias/default/typography/typography.json
@@ -81,6 +81,20 @@
 					"value": "{font-weight.bold.value}"
 				}
 			}
+		},
+		"block-spacing": {
+			"small": {
+				"value": "{spacing.relative.200}"
+			},
+			"medium": {
+				"value": "{spacing.relative.400}"
+			},
+			"large": {
+				"value": "{spacing.relative.800}"
+			},
+			"x-large": {
+				"value": "{spacing.relative.1200}"
+			}
 		}
 	}
 }


### PR DESCRIPTION
introduces block spacing tokens and Sass variables … a precursor (chicken or egg, ¯\_(ツ)_/¯) to allow #811 to not make Travis cry. 


*note:* 

All this work was created by @Heydon, but as there is a problem when needing to update the brand context whilst working on components we cannot put both changes in one PR … because Travis pulls down the version of brand-context from npm … if it doesn't exist it fails.
To try to get #811 at a point where it can be merged in, I've pulled out the various brand-context changes and made this PR … because of how the Travis CI is currently set up).