### PR TITLE
Global forms RC10

### DIFF
--- a/toolkits/global/packages/global-forms/HISTORY.md
+++ b/toolkits/global/packages/global-forms/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 5.0.0-rc.10 (2022-09-30)
+    * Removes margin-top from form labels used on pictogrpahic radios when in horizontal layout
+    * Fixes layout issue with display of error information for pictogrpahic radio groups
+
 ## 5.0.0-rc.9 (2022-09-28)
     * Increases thickness of pictographic radio icon borders to 2px
     * Bumps Brand Context to v28.1.0

--- a/toolkits/global/packages/global-forms/HISTORY.md
+++ b/toolkits/global/packages/global-forms/HISTORY.md
@@ -3,6 +3,7 @@
 ## 5.0.0-rc.10 (2022-09-30)
     * Removes margin-top from form labels used on pictographic radios when in horizontal layout
     * Fixes layout issue with display of error information for pictographic radio groups
+    * Supports `disabled` on `<option>` elements for `<select>`
 
 ## 5.0.0-rc.9 (2022-09-28)
     * Increases thickness of pictographic radio icon borders to 2px

--- a/toolkits/global/packages/global-forms/HISTORY.md
+++ b/toolkits/global/packages/global-forms/HISTORY.md
@@ -1,8 +1,8 @@
 # History
 
 ## 5.0.0-rc.10 (2022-09-30)
-    * Removes margin-top from form labels used on pictogrpahic radios when in horizontal layout
-    * Fixes layout issue with display of error information for pictogrpahic radio groups
+    * Removes margin-top from form labels used on pictographic radios when in horizontal layout
+    * Fixes layout issue with display of error information for pictographic radio groups
 
 ## 5.0.0-rc.9 (2022-09-28)
     * Increases thickness of pictographic radio icon borders to 2px

--- a/toolkits/global/packages/global-forms/demo/context.json
+++ b/toolkits/global/packages/global-forms/demo/context.json
@@ -158,12 +158,13 @@
 				"fields": [
 					{
 						"template": "globalFormRadios",
-						"label": "Rating",
+						"label": "Rating (with error)",
 						"groupDescription": "A scale of 5 feelings conveyed using images that range from terrible to great. The feelings represent how you feel about this page.",
 						"id": "radios-rating",
 						"name": "radios-rating",
 						"pictographic": true,
 						"boxed": true,
+						"error": "Please select one rating",
 						"inputs": [
 							{
 								"label": "Terrible",

--- a/toolkits/global/packages/global-forms/demo/dist/index.html
+++ b/toolkits/global/packages/global-forms/demo/dist/index.html
@@ -2180,8 +2180,16 @@ label + .c-forms__error,
 			<fieldset class="c-forms__fieldset">
 					<legend class="c-forms__legend"><h2>Pictographic Radios</h2></legend>
 					<div class="c-forms__field">
-							<fieldset class="c-forms__fieldset c-forms__field c-forms__radios" id="radios-rating" name="radios-rating" autocomplete="off">
-										<legend class="c-forms__label">Rating<span class="c-form__label--visually-hidden">. A scale of 5 feelings conveyed using images that range from terrible to great. The feelings represent how you feel about this page.</span></legend>
+							<fieldset class="c-forms__fieldset c-forms__field c-forms__radios" id="radios-rating" name="radios-rating" invalid="" aria-invalid="true" aria-describedby="error-radios-rating" autocomplete="off">
+										<legend class="c-forms__label">Rating (with error)<span class="c-form__label--visually-hidden">. A scale of 5 feelings conveyed using images that range from terrible to great. The feelings represent how you feel about this page.</span></legend>
+									<small class="c-forms__error" id="error-radios-rating">
+										<span class="c-forms__icon c-forms__icon--error">
+											<svg class="u-icon u-mr-4" width="22" height="22" aria-hidden="true" focusable="false">
+												<svg id="i-error" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg"><path d="m9 0c4.9705627 0 9 4.02943725 9 9 0 4.9705627-4.0294373 9-9 9-4.97056275 0-9-4.0294373-9-9 0-4.97056275 4.02943725-9 9-9zm2.8630343 4.71100931-2.8630343 2.86303426-2.86303426-2.86303426c-.39658757-.39658757-1.03281091-.39438847-1.4265779-.00062147-.39651227.39651226-.39348876 1.03246767.00062147 1.4265779l2.86303426 2.86303426-2.86303426 2.8630343c-.39658757.3965875-.39438847 1.0328109-.00062147 1.4265779.39651226.3965122 1.03246767.3934887 1.4265779-.0006215l2.86303426-2.8630343 2.8630343 2.8630343c.3965875.3965876 1.0328109.3943885 1.4265779.0006215.3965122-.3965123.3934887-1.0324677-.0006215-1.4265779l-2.8630343-2.8630343 2.8630343-2.86303426c.3965876-.39658757.3943885-1.03281091.0006215-1.4265779-.3965123-.39651227-1.0324677-.39348876-1.4265779.00062147z" fill="currentColor" fill-rule="evenodd"></path></svg>
+											</svg>
+										</span>
+										Please select one rating
+									</small>
 								<div class="c-forms__pictographic-radios">
 										<div class="c-forms__label c-forms__label--wrapper">
 											<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-terrible" name="radios-rating" value="Terrible" autocomplete="off">

--- a/toolkits/global/packages/global-forms/demo/dist/index.html
+++ b/toolkits/global/packages/global-forms/demo/dist/index.html
@@ -1733,7 +1733,7 @@ h1 + * {
   max-width: 70ch;
 }
 
-.c-forms__fieldset--pictographic-radios {
+.c-forms__pictographic-radios {
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -1741,8 +1741,12 @@ h1 + * {
 }
 
 @media only screen and (min-width: 320px) {
-  .c-forms__fieldset--pictographic-radios {
+  .c-forms__pictographic-radios {
     flex-direction: row;
+  }
+
+  .c-forms__pictographic-radios .c-forms__label + .c-forms__label {
+    margin-top: 0;
   }
 }
 * + .c-forms__error-summary,
@@ -2137,87 +2141,89 @@ label + .c-forms__error,
 			<fieldset class="c-forms__fieldset">
 					<legend class="c-forms__legend"><h2>Radios</h2></legend>
 					<div class="c-forms__field">
-							<fieldset class="c-forms__fieldset c-forms__field c-forms__radios " id="radios-animals" name="radios-animals" autocomplete="off">
+							<fieldset class="c-forms__fieldset c-forms__field c-forms__radios" id="radios-animals" name="radios-animals" autocomplete="off">
 										<legend class="c-forms__label">Animal<span class="c-form__label--visually-hidden"></span></legend>
-						
-									<div class="c-forms__label c-forms__label--wrapper">
-										<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-horse" name="radios-animals" value="Horse" autocomplete="off">
-											<label for="radio-horse" class="c-forms__label c-forms__label--inline c-forms__label--radio">Horse</label>
-									</div>
-									<div class="c-forms__label c-forms__label--wrapper">
-										<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-monkey" name="radios-animals" value="Monkey" autocomplete="off">
-											<label for="radio-monkey" class="c-forms__label c-forms__label--inline c-forms__label--radio">Monkey</label>
-											<fieldset class="c-forms__fieldset c-forms__sub-fields">
-													<div class="c-forms__field">
-														<label for="monkey-type" class="c-forms__label">
-															What type of monkey?
-																<small class="c-forms__hint">Chimps are not monkeys</small>
-														</label>
-															<small class="c-forms__error" id="error-monkey-type">
-																<span class="c-forms__icon c-forms__icon--error">
-																	<svg class="u-icon u-mr-4" width="22" height="22" aria-hidden="true" focusable="false">
-																		<svg id="i-error" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg"><path d="m9 0c4.9705627 0 9 4.02943725 9 9 0 4.9705627-4.0294373 9-9 9-4.97056275 0-9-4.0294373-9-9 0-4.97056275 4.02943725-9 9-9zm2.8630343 4.71100931-2.8630343 2.86303426-2.86303426-2.86303426c-.39658757-.39658757-1.03281091-.39438847-1.4265779-.00062147-.39651227.39651226-.39348876 1.03246767.00062147 1.4265779l2.86303426 2.86303426-2.86303426 2.8630343c-.39658757.3965875-.39438847 1.0328109-.00062147 1.4265779.39651226.3965122 1.03246767.3934887 1.4265779-.0006215l2.86303426-2.8630343 2.8630343 2.8630343c.3965875.3965876 1.0328109.3943885 1.4265779.0006215.3965122-.3965123.3934887-1.0324677-.0006215-1.4265779l-2.8630343-2.8630343 2.8630343-2.86303426c.3965876-.39658757.3943885-1.03281091.0006215-1.4265779-.3965123-.39651227-1.0324677-.39348876-1.4265779.00062147z" fill="currentColor" fill-rule="evenodd"></path></svg>
-																	</svg>
-																</span>
-																Choose a monkey already!
-															</small>
-														<input type="text" class="c-forms__input c-forms__input--text" id="monkey-type" name="monkey-type" invalid="" aria-invalid="true" aria-describedby="error-monkey-type" autocomplete="off">
-													</div>
-											</fieldset>
-									</div>
-									<div class="c-forms__label c-forms__label--wrapper">
-										<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-platypus" name="radios-animals" value="Platypus" checked="" autocomplete="off">
-											<label for="radio-platypus" class="c-forms__label c-forms__label--inline c-forms__label--radio">Platypus</label>
-									</div>
+								<div>
+										<div class="c-forms__label c-forms__label--wrapper">
+											<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-horse" name="radios-animals" value="Horse" autocomplete="off">
+												<label for="radio-horse" class="c-forms__label c-forms__label--inline c-forms__label--radio">Horse</label>
+										</div>
+										<div class="c-forms__label c-forms__label--wrapper">
+											<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-monkey" name="radios-animals" value="Monkey" autocomplete="off">
+												<label for="radio-monkey" class="c-forms__label c-forms__label--inline c-forms__label--radio">Monkey</label>
+												<fieldset class="c-forms__fieldset c-forms__sub-fields">
+														<div class="c-forms__field">
+															<label for="monkey-type" class="c-forms__label">
+																What type of monkey?
+																	<small class="c-forms__hint">Chimps are not monkeys</small>
+															</label>
+																<small class="c-forms__error" id="error-monkey-type">
+																	<span class="c-forms__icon c-forms__icon--error">
+																		<svg class="u-icon u-mr-4" width="22" height="22" aria-hidden="true" focusable="false">
+																			<svg id="i-error" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg"><path d="m9 0c4.9705627 0 9 4.02943725 9 9 0 4.9705627-4.0294373 9-9 9-4.97056275 0-9-4.0294373-9-9 0-4.97056275 4.02943725-9 9-9zm2.8630343 4.71100931-2.8630343 2.86303426-2.86303426-2.86303426c-.39658757-.39658757-1.03281091-.39438847-1.4265779-.00062147-.39651227.39651226-.39348876 1.03246767.00062147 1.4265779l2.86303426 2.86303426-2.86303426 2.8630343c-.39658757.3965875-.39438847 1.0328109-.00062147 1.4265779.39651226.3965122 1.03246767.3934887 1.4265779-.0006215l2.86303426-2.8630343 2.8630343 2.8630343c.3965875.3965876 1.0328109.3943885 1.4265779.0006215.3965122-.3965123.3934887-1.0324677-.0006215-1.4265779l-2.8630343-2.8630343 2.8630343-2.86303426c.3965876-.39658757.3943885-1.03281091.0006215-1.4265779-.3965123-.39651227-1.0324677-.39348876-1.4265779.00062147z" fill="currentColor" fill-rule="evenodd"></path></svg>
+																		</svg>
+																	</span>
+																	Choose a monkey already!
+																</small>
+															<input type="text" class="c-forms__input c-forms__input--text" id="monkey-type" name="monkey-type" invalid="" aria-invalid="true" aria-describedby="error-monkey-type" autocomplete="off">
+														</div>
+												</fieldset>
+										</div>
+										<div class="c-forms__label c-forms__label--wrapper">
+											<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-platypus" name="radios-animals" value="Platypus" checked="" autocomplete="off">
+												<label for="radio-platypus" class="c-forms__label c-forms__label--inline c-forms__label--radio">Platypus</label>
+										</div>
+								</div>
 							</fieldset>
 					</div>
 			</fieldset>
 			<fieldset class="c-forms__fieldset">
 					<legend class="c-forms__legend"><h2>Pictographic Radios</h2></legend>
 					<div class="c-forms__field">
-							<fieldset class="c-forms__fieldset c-forms__field c-forms__radios c-forms__fieldset--pictographic-radios" id="radios-rating" name="radios-rating" autocomplete="off">
+							<fieldset class="c-forms__fieldset c-forms__field c-forms__radios" id="radios-rating" name="radios-rating" autocomplete="off">
 										<legend class="c-forms__label">Rating<span class="c-form__label--visually-hidden">. A scale of 5 feelings conveyed using images that range from terrible to great. The feelings represent how you feel about this page.</span></legend>
-						
-									<div class="c-forms__label c-forms__label--wrapper">
-										<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-terrible" name="radios-rating" value="Terrible" autocomplete="off">
-											<label for="radio-terrible" class="c-forms__label c-forms__label--pictographic-radio c-forms__label--boxed-icon">
-												<svg xmlns="http://www.w3.org/2000/svg" fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false" viewBox="0 0 24 24"> <defs> <clipPath id="crya"> <path d="M24 0v24H0V0h24Z"></path> </clipPath> </defs> <g clip-path="url(#crya)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M6.5 20.4A10 10 0 1 0 2 12"></path> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M9 17c1-2.7 5-2.7 6 0"></path> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M2.7 18.3a2 2 0 0 1-.7-2.8c.4-.6 1.5-1.1 3.2-1.5.6 1.7.7 2.9.3 3.5a2 2 0 0 1-2.8.8ZM9 10l-2 1M17 11l-2-1"></path> </g> </svg>
-												<span class="c-form__label--visually-hidden">An image of a cartoon face that is crying.</span>
-												<span><span class="c-form__label--visually-hidden"> The value of this radio input is: </span>Terrible</span>
-											</label>
-									</div>
-									<div class="c-forms__label c-forms__label--wrapper">
-										<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-bad" name="radios-rating" value="Bad" autocomplete="off">
-											<label for="radio-bad" class="c-forms__label c-forms__label--pictographic-radio c-forms__label--boxed-icon">
-												<svg xmlns="http://www.w3.org/2000/svg" fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false" viewBox="0 0 24 24"> <defs> <clipPath id="frowna"> <path d="M24 0v24H0V0h24Z"></path> </clipPath> <clipPath id="frownb"> <path d="M1 0c.6 0 1 .4 1 1v2a1 1 0 1 1-2 0V1c0-.6.4-1 1-1Z"></path> </clipPath> </defs> <g clip-path="url(#frowna)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z"></path> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M9 17c1-2.7 5-2.7 6 0"></path> <g clip-path="url(#frownb)" transform="translate(8 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> <g clip-path="url(#frownb)" transform="translate(14 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> </g> </svg>
-												<span class="c-form__label--visually-hidden">An image of a cartoon face with a frown.</span>
-												<span class="c-form__label--visually-hidden"><span class="c-form__label--visually-hidden"> The value of this radio input is: </span>Bad</span>
-											</label>
-									</div>
-									<div class="c-forms__label c-forms__label--wrapper">
-										<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-ok" name="radios-rating" value="OK" autocomplete="off">
-											<label for="radio-ok" class="c-forms__label c-forms__label--pictographic-radio c-forms__label--boxed-icon">
-												<svg xmlns="http://www.w3.org/2000/svg" fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false" viewBox="0 0 24 24"> <defs> <clipPath id="neutrala"> <path d="M24 0v24H0V0h24Z"></path> </clipPath> <clipPath id="neutralb"> <path d="M1 0c.6 0 1 .4 1 1v2a1 1 0 1 1-2 0V1c0-.6.4-1 1-1Z"></path> </clipPath> </defs> <g clip-path="url(#neutrala)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z"></path> <g clip-path="url(#neutralb)" transform="translate(8 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> <g clip-path="url(#neutralb)" transform="translate(14 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M9 16h6"></path> </g> </svg>
-												<span class="c-form__label--visually-hidden">An image of a cartoon face with a neutral expression.</span>
-												<span class="c-form__label--visually-hidden"><span class="c-form__label--visually-hidden"> The value of this radio input is: </span>OK</span>
-											</label>
-									</div>
-									<div class="c-forms__label c-forms__label--wrapper">
-										<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-good" name="radios-rating" value="Good" autocomplete="off">
-											<label for="radio-good" class="c-forms__label c-forms__label--pictographic-radio c-forms__label--boxed-icon">
-												<svg xmlns="http://www.w3.org/2000/svg" fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false" viewBox="0 0 24 24"> <defs> <clipPath id="smilea"> <path d="M24 0v24H0V0h24Z"></path> </clipPath> <clipPath id="smileb"> <path d="M1 0c.6 0 1 .4 1 1v2a1 1 0 1 1-2 0V1c0-.6.4-1 1-1Z"></path> </clipPath> </defs> <g clip-path="url(#smilea)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z"></path> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M9 15c1 2.7 5 2.7 6 0"></path> <g clip-path="url(#smileb)" transform="translate(8 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> <g clip-path="url(#smileb)" transform="translate(14 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> </g> </svg>
-												<span class="c-form__label--visually-hidden">An image of a cartoon face with a smile.</span>
-												<span class="c-form__label--visually-hidden"><span class="c-form__label--visually-hidden"> The value of this radio input is: </span>Good</span>
-											</label>
-									</div>
-									<div class="c-forms__label c-forms__label--wrapper">
-										<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-great" name="radios-rating" value="Great" autocomplete="off">
-											<label for="radio-great" class="c-forms__label c-forms__label--pictographic-radio c-forms__label--boxed-icon">
-												<svg xmlns="http://www.w3.org/2000/svg" fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false" viewBox="0 0 24 24"> <defs> <clipPath id="grina"> <path d="M24 0v24H0V0h24Z"></path> </clipPath> </defs> <g clip-path="url(#grina)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z"></path> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M17.5 10v-.5a1.7 1.7 0 0 0-3.5 0v.5M10 10v-.5a1.7 1.7 0 0 0-3.5 0v.5M8 14c.5 5 7.5 5 8 0H8Z"></path> </g> </svg>
-												<span class="c-form__label--visually-hidden">An image of a cartoon face with an open mouth grin.</span>
-												<span><span class="c-form__label--visually-hidden"> The value of this radio input is: </span>Great</span>
-											</label>
-									</div>
+								<div class="c-forms__pictographic-radios">
+										<div class="c-forms__label c-forms__label--wrapper">
+											<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-terrible" name="radios-rating" value="Terrible" autocomplete="off">
+												<label for="radio-terrible" class="c-forms__label c-forms__label--pictographic-radio c-forms__label--boxed-icon">
+													<svg xmlns="http://www.w3.org/2000/svg" fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false" viewBox="0 0 24 24"> <defs> <clipPath id="crya"> <path d="M24 0v24H0V0h24Z"></path> </clipPath> </defs> <g clip-path="url(#crya)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M6.5 20.4A10 10 0 1 0 2 12"></path> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M9 17c1-2.7 5-2.7 6 0"></path> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M2.7 18.3a2 2 0 0 1-.7-2.8c.4-.6 1.5-1.1 3.2-1.5.6 1.7.7 2.9.3 3.5a2 2 0 0 1-2.8.8ZM9 10l-2 1M17 11l-2-1"></path> </g> </svg>
+													<span class="c-form__label--visually-hidden">An image of a cartoon face that is crying.</span>
+													<span><span class="c-form__label--visually-hidden"> The value of this radio input is: </span>Terrible</span>
+												</label>
+										</div>
+										<div class="c-forms__label c-forms__label--wrapper">
+											<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-bad" name="radios-rating" value="Bad" autocomplete="off">
+												<label for="radio-bad" class="c-forms__label c-forms__label--pictographic-radio c-forms__label--boxed-icon">
+													<svg xmlns="http://www.w3.org/2000/svg" fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false" viewBox="0 0 24 24"> <defs> <clipPath id="frowna"> <path d="M24 0v24H0V0h24Z"></path> </clipPath> <clipPath id="frownb"> <path d="M1 0c.6 0 1 .4 1 1v2a1 1 0 1 1-2 0V1c0-.6.4-1 1-1Z"></path> </clipPath> </defs> <g clip-path="url(#frowna)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z"></path> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M9 17c1-2.7 5-2.7 6 0"></path> <g clip-path="url(#frownb)" transform="translate(8 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> <g clip-path="url(#frownb)" transform="translate(14 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> </g> </svg>
+													<span class="c-form__label--visually-hidden">An image of a cartoon face with a frown.</span>
+													<span class="c-form__label--visually-hidden"><span class="c-form__label--visually-hidden"> The value of this radio input is: </span>Bad</span>
+												</label>
+										</div>
+										<div class="c-forms__label c-forms__label--wrapper">
+											<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-ok" name="radios-rating" value="OK" autocomplete="off">
+												<label for="radio-ok" class="c-forms__label c-forms__label--pictographic-radio c-forms__label--boxed-icon">
+													<svg xmlns="http://www.w3.org/2000/svg" fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false" viewBox="0 0 24 24"> <defs> <clipPath id="neutrala"> <path d="M24 0v24H0V0h24Z"></path> </clipPath> <clipPath id="neutralb"> <path d="M1 0c.6 0 1 .4 1 1v2a1 1 0 1 1-2 0V1c0-.6.4-1 1-1Z"></path> </clipPath> </defs> <g clip-path="url(#neutrala)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z"></path> <g clip-path="url(#neutralb)" transform="translate(8 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> <g clip-path="url(#neutralb)" transform="translate(14 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M9 16h6"></path> </g> </svg>
+													<span class="c-form__label--visually-hidden">An image of a cartoon face with a neutral expression.</span>
+													<span class="c-form__label--visually-hidden"><span class="c-form__label--visually-hidden"> The value of this radio input is: </span>OK</span>
+												</label>
+										</div>
+										<div class="c-forms__label c-forms__label--wrapper">
+											<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-good" name="radios-rating" value="Good" autocomplete="off">
+												<label for="radio-good" class="c-forms__label c-forms__label--pictographic-radio c-forms__label--boxed-icon">
+													<svg xmlns="http://www.w3.org/2000/svg" fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false" viewBox="0 0 24 24"> <defs> <clipPath id="smilea"> <path d="M24 0v24H0V0h24Z"></path> </clipPath> <clipPath id="smileb"> <path d="M1 0c.6 0 1 .4 1 1v2a1 1 0 1 1-2 0V1c0-.6.4-1 1-1Z"></path> </clipPath> </defs> <g clip-path="url(#smilea)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z"></path> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M9 15c1 2.7 5 2.7 6 0"></path> <g clip-path="url(#smileb)" transform="translate(8 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> <g clip-path="url(#smileb)" transform="translate(14 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> </g> </svg>
+													<span class="c-form__label--visually-hidden">An image of a cartoon face with a smile.</span>
+													<span class="c-form__label--visually-hidden"><span class="c-form__label--visually-hidden"> The value of this radio input is: </span>Good</span>
+												</label>
+										</div>
+										<div class="c-forms__label c-forms__label--wrapper">
+											<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-great" name="radios-rating" value="Great" autocomplete="off">
+												<label for="radio-great" class="c-forms__label c-forms__label--pictographic-radio c-forms__label--boxed-icon">
+													<svg xmlns="http://www.w3.org/2000/svg" fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false" viewBox="0 0 24 24"> <defs> <clipPath id="grina"> <path d="M24 0v24H0V0h24Z"></path> </clipPath> </defs> <g clip-path="url(#grina)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z"></path> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M17.5 10v-.5a1.7 1.7 0 0 0-3.5 0v.5M10 10v-.5a1.7 1.7 0 0 0-3.5 0v.5M8 14c.5 5 7.5 5 8 0H8Z"></path> </g> </svg>
+													<span class="c-form__label--visually-hidden">An image of a cartoon face with an open mouth grin.</span>
+													<span><span class="c-form__label--visually-hidden"> The value of this radio input is: </span>Great</span>
+												</label>
+										</div>
+								</div>
 							</fieldset>
 					</div>
 			</fieldset>

--- a/toolkits/global/packages/global-forms/package.json
+++ b/toolkits/global/packages/global-forms/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@springernature/global-forms",
-	"version": "5.0.0-rc.9",
+	"version": "5.0.0-rc.10",
 	"license": "MIT",
 	"description": "form component",
 	"keywords": [

--- a/toolkits/global/packages/global-forms/scss/50-components/_forms.scss
+++ b/toolkits/global/packages/global-forms/scss/50-components/_forms.scss
@@ -43,7 +43,7 @@
 	max-width: $global-forms-input-width-maximum;
 }
 
-.c-forms__fieldset--pictographic-radios {
+.c-forms__pictographic-radios {
 	display: flex;
 	flex-direction: column;
 	gap: $global-forms-pictographic-radio-spacing;
@@ -51,8 +51,12 @@
 }
 
 @include media-query('xs') {
-	.c-forms__fieldset--pictographic-radios {
+	.c-forms__pictographic-radios {
 		flex-direction: row;
+	}
+
+	.c-forms__pictographic-radios .c-forms__label + .c-forms__label {
+		margin-top: 0;
 	}
 }
 

--- a/toolkits/global/packages/global-forms/view/fields/globalFormRadios.hbs
+++ b/toolkits/global/packages/global-forms/view/fields/globalFormRadios.hbs
@@ -1,5 +1,5 @@
 {{#if inputs}}
-	<fieldset class="c-forms__fieldset c-forms__field c-forms__radios {{#if pictographic}}c-forms__fieldset--pictographic-radios{{/if}}" {{#unless legend}}{{#unless label}} role="presentation"{{/unless}}{{/unless}} {{> globalFormAttributes}}>
+	<fieldset class="c-forms__fieldset c-forms__field c-forms__radios" {{#unless legend}}{{#unless label}} role="presentation"{{/unless}}{{/unless}} {{> globalFormAttributes}}>
 		{{#if legend}}
 			<legend class="c-forms__label">{{legend}}<span class="c-form__label--visually-hidden">{{#if groupDescription}}. {{groupDescription}}{{/if}}</span></legend>
 		{{else}}
@@ -10,9 +10,10 @@
 		{{#if error}}
 			{{> globalFormError}}
 		{{/if}}
-
-		{{#each inputs}}
-			{{> globalFormRadio name=../name pictographic=../pictographic boxed=../boxed}}
-		{{/each}}
+		<div {{#if pictographic}}class="c-forms__pictographic-radios"{{/if}}>
+			{{#each inputs}}
+				{{> globalFormRadio name=../name pictographic=../pictographic boxed=../boxed}}
+			{{/each}}
+		</div>
 	</fieldset>
 {{/if}}

--- a/toolkits/global/packages/global-forms/view/fields/globalFormSelect.hbs
+++ b/toolkits/global/packages/global-forms/view/fields/globalFormSelect.hbs
@@ -11,6 +11,7 @@
 			<option
 				value="{{value}}"
 				{{#if selected}} selected{{/if}}
+				{{#if disabled}} disabled{{/if}}
 			>
 				{{label}}
 			</option>


### PR DESCRIPTION
```
## 5.0.0-rc.10 (2022-09-30)
    * Removes margin-top from form labels used on pictographic radios when in horizontal layout
    * Fixes layout issue with display of error information for pictographic radio groups
```