### PR TITLE
Link underlines by default and improved block spacing

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,5 +1,10 @@
 # History
 
+## 29.0.0 (2022-10-05)
+    * BREAKING:
+        * Link underlines by default
+    * Added component wrappers (`c-` elements) to block spacing algorithm
+
 ## 28.1.1 (2022-10-03)
     * PATCH: Move default abstract import into the brand abstracts file
         * Simplifies the process of compiling static component CSS

--- a/context/brand-context/default/scss/30-mixins/links.scss
+++ b/context/brand-context/default/scss/30-mixins/links.scss
@@ -14,11 +14,6 @@
 
 @mixin u-link-underline() {
 	text-decoration: underline;
-
-	&.hover,
-	&:hover {
-		text-decoration: none;
-	}
 }
 
 @mixin u-link-faux-block() {
@@ -33,7 +28,6 @@
 }
 
 @mixin u-link-interface() {
-	text-decoration: none;
 
 	&.active,
 	&:active,

--- a/context/brand-context/default/scss/40-base/basic.scss
+++ b/context/brand-context/default/scss/40-base/basic.scss
@@ -2,15 +2,6 @@ body {
 	line-height: 1.5;
 }
 
-a {
-	text-decoration: none;
-}
-
-a:hover,
-a:focus {
-	text-decoration: underline;
-}
-
 button {
 	cursor: pointer;
 }

--- a/context/brand-context/default/scss/40-base/block-spacing.scss
+++ b/context/brand-context/default/scss/40-base/block-spacing.scss
@@ -2,22 +2,23 @@
 	margin-block: 0;
 }
 
-:is(p, ol, ul, dl, figure, blockquote, form, pre, table, img, video, aside, section, article)+* {
+:is(p, ol, ul, dl, figure, blockquote, form, pre, table, img, video, aside, section, article) + *,
+[class*="c-"]:not([class*="__"]) + * {
 	margin-block-start: $tokens--typography-block-spacing-medium;
 }
 
-*+ :is(h2, h3, h4, h5) {
+* + :is(h2, h3, h4, h5) {
 	margin-block-start: $tokens--typography-block-spacing-large;
 }
 
-:is(h3, h4, h5)+* {
+:is(h3, h4, h5) + * {
 	margin-block-start: $tokens--typography-block-spacing-small;
 }
 
-h2+* {
+h2 + * {
 	margin-block-start: $tokens--typography-block-spacing-medium;
 }
 
-h1+* {
+h1 + * {
 	margin-block-start: $tokens--typography-block-spacing-x-large;
 }

--- a/context/brand-context/nature/scss/40-base/links.scss
+++ b/context/brand-context/nature/scss/40-base/links.scss
@@ -5,15 +5,11 @@
 
 a {
 	@include u-focus-outline();
-	text-decoration: none;
-	vertical-align: baseline;
-	color: color('blue');
-}
-
-a:hover {
 	text-decoration: underline;
 	-webkit-text-decoration-skip: skip;
 	text-decoration-skip-ink: auto;
+	vertical-align: baseline;
+	color: color('blue');
 }
 
 a:active {

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "28.1.1",
+  "version": "29.0.0",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/springer/scss/30-mixins/links.scss
+++ b/context/brand-context/springer/scss/30-mixins/links.scss
@@ -16,7 +16,6 @@
 	&.hover,
 	&:hover {
 		color: color('action-light');
-		text-decoration: none;
 	}
 
 	&.active,

--- a/context/brand-context/springernature/scss/30-mixins/links.scss
+++ b/context/brand-context/springernature/scss/30-mixins/links.scss
@@ -16,7 +16,6 @@
 	&.hover,
 	&:hover {
 		color: $context--link-hover-color;
-		text-decoration: none;
 	}
 
 	&.active,

--- a/toolkits/springer/packages/springer-listing/HISTORY.md
+++ b/toolkits/springer/packages/springer-listing/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 6.0.2 (2022-10-05)
+    * BUG: fixes SVGs not displaying correctly in demo
+
 ## 6.0.1 (2022-09-20)
     * BUG: fixes SVGs not displaying correctly in demo
 

--- a/toolkits/springer/packages/springer-listing/HISTORY.md
+++ b/toolkits/springer/packages/springer-listing/HISTORY.md
@@ -1,7 +1,7 @@
 # History
 
 ## 6.0.2 (2022-10-05)
-    * BUG: fixes SVGs not displaying correctly in demo
+    * Underline reinstated on title (see brand-context 29.0.0)
 
 ## 6.0.1 (2022-09-20)
     * BUG: fixes SVGs not displaying correctly in demo

--- a/toolkits/springer/packages/springer-listing/package.json
+++ b/toolkits/springer/packages/springer-listing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springer-listing",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "license": "MIT",
   "description": "Display of scannable content typically within a list",
   "keywords": [],

--- a/toolkits/springer/packages/springer-listing/scss/50-components/_listing.scss
+++ b/toolkits/springer/packages/springer-listing/scss/50-components/_listing.scss
@@ -29,10 +29,6 @@
 	margin-bottom: 0;
 }
 
-.c-listing__title a {
-	text-decoration: none;
-}
-
 .c-listing__authors {
 	color: #666;
 }


### PR DESCRIPTION
## Brand context

```
## 29.0.0 (2022-10-05)
    * BREAKING:
        * Link underlines by default
    * Added component wrappers (`c-` elements) to block spacing algorithm
```

## Springer listing

```
## 6.0.2 (2022-10-05)
    * Underline reinstated on title (see brand-context 29.0.0)
```