### PR TITLE
Removes default SVG sizing from core styles

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 29.0.1 (2022-10-11)
+    * PATCH: Removes default SVG sizing from core styles as it was overriding classname styles for icons and html width and height attributes
+
 ## 29.0.0 (2022-10-05)
     * BREAKING:
         * Link underlines by default

--- a/context/brand-context/default/scss/40-base/basic.scss
+++ b/context/brand-context/default/scss/40-base/basic.scss
@@ -12,8 +12,3 @@ img {
 	height: auto;
 	vertical-align: middle;
 }
-
-svg {
-	width: 1rem;
-	height: 1rem;
-}

--- a/context/brand-context/default/scss/40-base/basic.scss
+++ b/context/brand-context/default/scss/40-base/basic.scss
@@ -13,7 +13,7 @@ img {
 	vertical-align: middle;
 }
 
-svg[aria-hidden] {
+svg {
 	width: 1rem;
 	height: 1rem;
 }

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "29.0.0",
+  "version": "29.0.1",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],


### PR DESCRIPTION
The introduction of this style had oversights:

1. It has a higher specificity score than classnames because it is two selectors (an element selector and an attribute selector)
2. Having any default SVG styles for sizing means that html attributes cannot be used to size SVGs because the style always overrides the width and height html attributes

Therefore I think it should be removed