### PR TITLE
Default brand context: tighten block spacing selector for c-

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 29.0.3 (2022-10-12)
+    * PATCH: Change CSS selector for 'c-' used in block spacing to use the start with instead of the include pattern
+
 ## 29.0.2 (2022-10-12)
     * PATCH: Add a utility class for resetting `margin-block-start`  
 

--- a/context/brand-context/default/scss/40-base/block-spacing.scss
+++ b/context/brand-context/default/scss/40-base/block-spacing.scss
@@ -3,7 +3,7 @@
 }
 
 :is(p, ol, ul, dl, figure, blockquote, form, pre, table, img, video, aside, section, article) + *,
-[class*="c-"]:not([class*="__"]) + * {
+[class^="c-"]:not([class*="__"]) + * {
 	margin-block-start: $tokens--typography-block-spacing-medium;
 }
 

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "29.0.2",
+  "version": "29.0.3",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],


### PR DESCRIPTION
Ensures that the `margin-block-start` is only applied to classnames _starting with_ `c-` not _containing_ `c-`.