### PR TITLE
Patch brand-context 25.0.0

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,4 +1,9 @@
 # History
+## 25.1.0 (2022-10-21)
+    * PATCH: Patching old context version with the following:
+        * FEATURE: Updates link styles across brands
+        * FEATURE: Add new list type using marker
+        * FEATURE: Updates Springer Nature font
 ## 25.0.0 (2022-06-29)
     * UDPATES:
       * updates generated Sass from Design Tokens

--- a/context/brand-context/default/scss/30-mixins/links.scss
+++ b/context/brand-context/default/scss/30-mixins/links.scss
@@ -14,11 +14,6 @@
 
 @mixin u-link-underline() {
 	text-decoration: underline;
-
-	&.hover,
-	&:hover {
-		text-decoration: none;
-	}
 }
 
 @mixin u-link-faux-block() {
@@ -33,8 +28,6 @@
 }
 
 @mixin u-link-interface() {
-	text-decoration: none;
-
 	&.active,
 	&:active,
 	&.hover,

--- a/context/brand-context/default/scss/30-mixins/lists.scss
+++ b/context/brand-context/default/scss/30-mixins/lists.scss
@@ -1,3 +1,11 @@
+@mixin u-list-dash {
+	> ::marker {
+		content: '– ';
+		font-size: 1.2em;
+		line-height: 1;
+	}
+}
+
 @mixin u-list-reset {
 	list-style: none;
 	margin: 0;

--- a/context/brand-context/default/scss/60-utilities/lists.scss
+++ b/context/brand-context/default/scss/60-utilities/lists.scss
@@ -6,7 +6,7 @@
 	list-style-type: disc;
 }
 
-.u-list-style-dash > ::marker {
+.u-list-style-dash {
 	@include u-list-dash;
 }
 

--- a/context/brand-context/default/scss/60-utilities/lists.scss
+++ b/context/brand-context/default/scss/60-utilities/lists.scss
@@ -6,6 +6,10 @@
 	list-style-type: disc;
 }
 
+.u-list-style-dash > ::marker {
+	@include u-list-dash;
+}
+
 .u-list-style-none {
 	list-style-type: none;
 }

--- a/context/brand-context/nature/scss/40-base/basic.scss
+++ b/context/brand-context/nature/scss/40-base/basic.scss
@@ -8,17 +8,7 @@ body {
 }
 
 a {
-	text-decoration: none;
 	color: color('blue');
-}
-
-a:hover,
-a:focus {
-	text-decoration: underline;
-}
-
-button {
-	cursor: pointer;
 }
 
 h1 {

--- a/context/brand-context/nature/scss/40-base/links.scss
+++ b/context/brand-context/nature/scss/40-base/links.scss
@@ -5,15 +5,11 @@
 
 a {
 	@include u-focus-outline();
-	text-decoration: none;
-	vertical-align: baseline;
-	color: color('blue');
-}
-
-a:hover {
 	text-decoration: underline;
 	-webkit-text-decoration-skip: skip;
 	text-decoration-skip-ink: auto;
+	vertical-align: baseline;
+	color: color('blue');
 }
 
 a:active {

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "25.0.0",
+  "version": "25.1.0",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],

--- a/context/brand-context/springer/scss/30-mixins/links.scss
+++ b/context/brand-context/springer/scss/30-mixins/links.scss
@@ -16,7 +16,6 @@
 	&.hover,
 	&:hover {
 		color: color('action-light');
-		text-decoration: none;
 	}
 
 	&.active,

--- a/context/brand-context/springer/scss/40-base/basic.scss
+++ b/context/brand-context/springer/scss/40-base/basic.scss
@@ -9,17 +9,7 @@ body {
 }
 
 a {
-	text-decoration: none;
 	color: #069;
-}
-
-a:hover,
-a:focus {
-	text-decoration: underline;
-}
-
-button {
-	cursor: pointer;
 }
 
 h1 {

--- a/context/brand-context/springernature/scss/30-mixins/links.scss
+++ b/context/brand-context/springernature/scss/30-mixins/links.scss
@@ -16,7 +16,6 @@
 	&.hover,
 	&:hover {
 		color: $context--link-hover-color;
-		text-decoration: none;
 	}
 
 	&.active,

--- a/context/brand-context/springernature/scss/40-base/basic.scss
+++ b/context/brand-context/springernature/scss/40-base/basic.scss
@@ -4,8 +4,7 @@
  */
 
 body {
-	line-height: 1.5;
-	font-family: $context--font-family-serif;
+	font-family: $context--font-family-sans;
 }
 
 a {

--- a/context/brand-context/springernature/scss/40-base/basic.scss
+++ b/context/brand-context/springernature/scss/40-base/basic.scss
@@ -9,17 +9,7 @@ body {
 }
 
 a {
-	text-decoration: none;
 	color: $context--link-color;
-}
-
-a:hover,
-a:focus {
-	text-decoration: underline;
-}
-
-button {
-	cursor: pointer;
 }
 
 img {

--- a/context/brand-context/springernature/scss/40-base/layout.scss
+++ b/context/brand-context/springernature/scss/40-base/layout.scss
@@ -11,7 +11,6 @@ html {
 
 body {
 	min-height: 100%;
-	font-family: $context--font-family-serif;
 	font-size: $context--font-size-base;
 	line-height: $context--line-height-base;
 	color: $context--primary-text-color;


### PR DESCRIPTION
# DO NOT MERGE BACK TO MAIN BRANCH

Patches `brand-context@25.0.0` to `25.1.0` with features introduced in later versions as some products need to stay on this earlier version for now, but need the new features. Adds:

- Updates link styles across brands
- Add new list type using marker
- Updates Springer Nature font