### PR TITLE
Fix popup border color to be accessible

### DIFF
--- a/toolkits/global/packages/global-popup/HISTORY.md
+++ b/toolkits/global/packages/global-popup/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 5.1.1 (2022-10-25)
+    * Fix popup border to be acessible 
+
 ## 5.1.0 (2022-07-28)
     * UPDATE: brand-context v25.0.0
 

--- a/toolkits/global/packages/global-popup/package.json
+++ b/toolkits/global/packages/global-popup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-popup",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Builds and styles a popup that can be opened and closed",
   "license": "MIT",
   "brandContext": "^25.0.0"

--- a/toolkits/global/packages/global-popup/scss/10-settings/_default.scss
+++ b/toolkits/global/packages/global-popup/scss/10-settings/_default.scss
@@ -8,7 +8,7 @@ $popup--padding: spacing(16, 32, 16, 24);
 $popup--close-top: spacing(16);
 $popup--close-right: spacing(16);
 $popup--box-shadow: 0 0 5px 0 greyscale(50, 0.1);
-$popup--border-color: rgba(85, 85, 85);
+$popup--border-color: $t-border-color-primary;
 $popup--border-radius: spacing(2);
 $popup--background-color: #fff;
 $popup--zindex: 100;

--- a/toolkits/global/packages/global-popup/scss/10-settings/_default.scss
+++ b/toolkits/global/packages/global-popup/scss/10-settings/_default.scss
@@ -8,7 +8,7 @@ $popup--padding: spacing(16, 32, 16, 24);
 $popup--close-top: spacing(16);
 $popup--close-right: spacing(16);
 $popup--box-shadow: 0 0 5px 0 greyscale(50, 0.1);
-$popup--border-color: rgba(151, 191, 216, .3);
+$popup--border-color: rgba(85, 85, 85);
 $popup--border-radius: spacing(2);
 $popup--background-color: #fff;
 $popup--zindex: 100;


### PR DESCRIPTION
After a conversation with [Carlos Mucharaz in the #accessiblity channel](https://springernature.slack.com/archives/C9MS96R7T/p1665568412838009), we noticed that the border to the popup component is not accessible, having the minimum contrast ration less than 3:1. 
This PR changes the border color from `rgba(151, 191, 216, .3)` to use the token color `$t-border-color-primary`, a [core color for border](https://elements.springernature.com/springernature/styleguide/color#borders) that is compatible with all brands.