### PR TITLE
specifies the line height because of nature

### DIFF
--- a/toolkits/global/packages/global-footer/HISTORY.md
+++ b/toolkits/global/packages/global-footer/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 1.0.1 (2022-11-24)
+    * adds a line-height for the c-footer and all within its cascade.
+
 ## 0.1.0 (2022-10-28)
     * Initial commit
     * Replaces `global-corporate-footer` and any brand specific footers

--- a/toolkits/global/packages/global-footer/package.json
+++ b/toolkits/global/packages/global-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-footer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "description": "Global footer component",
   "keywords": [],

--- a/toolkits/global/packages/global-footer/scss/10-settings/default.scss
+++ b/toolkits/global/packages/global-footer/scss/10-settings/default.scss
@@ -8,6 +8,7 @@ $footer--vertical-rhythm: spacing(32);
 $footer--spacing-small: 8px;
 $footer--spacing-medium: 16px;
 $footer--spacing-large: 24px;
+$footer--line-height: 1.15;
 
 $footer--margin-bottom: spacing(0);
 $footer--border: 2px solid #fff;

--- a/toolkits/global/packages/global-footer/scss/50-components/footer.scss
+++ b/toolkits/global/packages/global-footer/scss/50-components/footer.scss
@@ -4,6 +4,7 @@
 	padding-top: $footer--padding-top;
 	padding-bottom: $footer--padding-bottom;
 	color: $footer--text-color;
+	line-height: $footer--line-height;
 }
 
 .c-footer__container {


### PR DESCRIPTION
because, currently, the elements site and the demos created for it make use of only the default context for global components it transpires that because nature.com has a line height of `1.76` on the `html` element whereas we would/could expect it to be `1.15` it looks massive.

This PR adds the line-height to the `c-footer` class which should override the html across brands so that it matches what has been the expectation (the `defautl` context)

