### PR TITLE
Adds the Global Customer Satisfaction Input component

### DIFF
--- a/context/design-tokens/components/global/global-customer-satisfaction-input/default.json
+++ b/context/design-tokens/components/global/global-customer-satisfaction-input/default.json
@@ -1,0 +1,110 @@
+{
+	"global-customer-satisfaction-input": {
+		"font": {
+			"family": {
+				"value": "{font-family.sans}"
+			}
+		},
+		"container": {
+			"padding": {
+				"value": "{spacing.absolute.400}"
+			},
+			"background": {
+				"color": {
+					"value": "{color.grayscale.300}"
+				}
+			}
+		},
+		"link": {
+			"margin": {
+				"value": "{spacing.absolute.200}"
+			},
+			"font": {
+				"size": {
+					"value": "16px"
+				}
+			}
+		},
+		"heading": {
+			"margin": {
+				"value": "{spacing.absolute.200}"
+			},
+			"font": {
+				"size": {
+					"value": "16px"
+				},
+				"weight": {
+					"value": "{font-weight.bold}"
+				}
+			}
+		},
+		"error": {
+			"margin": {
+				"value": "{spacing.absolute.200}"
+			}
+		},
+		"line-height": {
+			"value": "{line-height.tight}"
+		},
+		"message": {
+			"font": {
+				"size": {
+					"value": "16px"
+				}
+			},
+			"icon": {
+				"margin": {
+					"value": "{spacing.absolute.200}"
+				},
+				"size": {
+					"value": "{sizing.absolute.600}"
+				}
+			}
+		},
+		"radio": {
+			"spacing": {
+				"narrow": {
+					"value": "5px"
+				},
+				"desktop": {
+					"value": "{spacing.absolute.400}"
+				}
+			},
+			"label": {
+				"font": {
+					"size": {
+						"narrow": {
+							"value": "12px"
+						},
+						"desktop": {
+							"value": "14px"
+						}
+					}
+				}
+			},
+			"icon": {
+				"size": {
+					"narrow": {
+						"value": "21px"
+					},
+					"desktop": {
+						"value": "24px"
+					}
+				},
+				"spacing": {
+					"narrow": {
+						"value": "6px"
+					},
+					"desktop": {
+						"value": "8px"
+					}
+				},
+				"border": {
+					"radius": {
+						"value": "{border.radius.50}"
+					}
+				}
+			}
+		}
+	}
+}

--- a/toolkits/global/packages/global-customer-satisfaction-input/HISTORY.md
+++ b/toolkits/global/packages/global-customer-satisfaction-input/HISTORY.md
@@ -1,0 +1,4 @@
+# History
+
+## 0.0.1 (2022-12-01)
+    * Adds component

--- a/toolkits/global/packages/global-customer-satisfaction-input/README.md
+++ b/toolkits/global/packages/global-customer-satisfaction-input/README.md
@@ -1,0 +1,127 @@
+# Global Customer Satisfaction Input
+
+> **Warning**
+> This component is currently [an experimental version](https://github.com/springernature/frontend-elements-docs/blob/main/user-guide/versioning.md#component-state). Please do not use this component on production at this time.
+
+The Global Customer Satisfaction Input component is the frontend for an overall solution for gathering customer satisfaction feedback, the documentation for which can be found here: https://customer-satisfaction-survey.public.springernature.app/docs/introduction.
+
+The component comprises a set of 5 pictographic radio inputs used to collect ratings score data from our customers. It is a JavaScript dependent component. When a user interacts with the component an event is dispatched to `window.dataLayer` allowing ratings score data and context data scraped from the page to be sent to Google Tag Manager and Google Cloud Big Query. 
+
+## Usage
+This documents how to implement this component on your website. If your project does not use Elements yet you can still use this component, see refer to the `Projects that do not use Elements` section below.
+### Install
+Install the Global Customer Satisfaction Input package:
+```shell
+npm install @springernature/global-customer-satisfaction-input
+```
+You will also need to ensure you have its dependencies installed. These are Brand Context and Global Forms:
+
+> **Warning**
+> This component violates [the design system rule](https://github.com/springernature/frontend-elements-docs/blob/main/user-guide/dependencies.md#dependencies) that states a component must not have a dependency on another component. Please do not follow this pattern in any other component you are building.
+
+```shell
+npm install @springernature/brand-context@30.0.4
+```
+```shell
+npm install @springernature/global-forms@5.0.0
+```
+
+### Sass
+Include the necessary Sass files in your project in this order (if they are not already there!):
+```sass
+@import '@springernature/brand-context/[YOUR BRAND HERE]/scss/core.scss';
+@import '@springernature/brand-context/[YOUR BRAND HERE]/scss/enhanced.scss';
+@import '@springernature/global-forms/scss/00-tokens/default.tokens.scss';
+@import '@springernature/global-customer-satisfaction-input/scss/00-tokens/default.tokens.scss';
+@import '@springernature/global-customer-satisfaction-input/scss/30-mixins/customer-satisfaction-input-button';
+@import '@springernature/global-forms/scss/50-components/forms';
+@import '@springernature/global-customer-satisfaction-input/scss/50-components/customer-satisfaction-input';
+@import '@springernature/brand-context/default/scss/60-utilities/hiding.scss';
+@import '@springernature/brand-context/default/scss/60-utilities/spacing.scss';
+```
+
+### JavaScript
+Include the component JavaScript in your application bundle:
+```js
+import {customerSatisfactionInput} from '@springernature/global-customer-satisfaction-input';
+
+customerSatisfactionInput();
+```
+
+### HTML
+Consume the component's Handlebars view template found in the `/view/` directory
+
+If you are unable to consume view templates in your project you can still use this component. Use the component demo to generate the HTML. This can be done as follows:
+
+1. Edit the JSON data file found at `/demo/context.json` and define the data you need for your instance (see below Data section) 
+2. Run `npm run demo -- -p global-customer-satisfaction-input`
+3. Copy the `<aside>` and its contents from the generated demo file at `/demo/dist/index.html` and paste it into the relevant location in your project
+
+### Data
+A data model is required to render the component's view template. An example of the data model can be seen in the component's demo. This can be found at `/demo/context.json`.
+
+> **Note**
+> Some of the data for this component is considered static, should be copied as defined in this document and should **not** be edited. This concerns all data that is passed to the Global Forms component. See below section on Global Forms Data.
+
+#### Configuring the component
+The component can be configured using the following data properties:
+
+**userJourneys** (Mandatory)
+
+A string that represents the user journeys that are associated with the placement of the component.
+
+Currently, only the following values are permissible:
+* `get prepared to publish`
+* `get published`
+* `discover relevant scholarly content`
+* `manage my editorial work`
+* `manage my peer reviews`
+* `promote my work`
+* `evaluate the performance of scholarly work`
+* `manage an apc`
+* `buy something`
+* `access what i am entitled to`
+* `librarian get the information i need`
+* `librarian assess the performance and use of my portfolio`
+* `librarian buy something`
+
+> **Note**
+> Permissible values are managed in the component's javascript file found at: `/js/customer-satisfaction-input.js`. Please do not edit these without consultation with UXD (Niamh Walsh at the time of writing).
+
+Please refer to our guide on [choosing associated user journeys](https://customer-satisfaction-survey.public.springernature.app/docs/getting-started/choosing-associated-user-journeys).
+
+You may define multiple user journeys separated by commas e.g. `"userJourneys":"get published, content discovery"`. If a non-permissible value is entered an error will be logged to the browser console and data will not be sent to the Big Query database. Case handling has been implemented, ensuring any value is converted to lowercase prior to data being sent to Big Query.
+
+**headingLevel** (Mandatory)
+
+A string that represents the heading level number, e.g. `"headingLevel":"3"`. Please ensure the heading level defined is correct for the placement of the component on the page.
+
+**questionUrl** (Optional)
+
+A string that defines the link href for any survey you wish to link to after a user has submitted a rating, e.g. `"questionUrl": "https://www.surveymonkey.com/r/97W8JW7"`. A link will only display if both questionUrl and questionText have been defined.
+
+**questionText** (Optional)
+
+A string that defines the link text for any survey you wish to link to after a user has submitted a rating, e.g. `"questionText": "Tell us why"`. A link will only display if both questionUrl and questionText have been defined.
+
+**additionalInfo** (Optional)
+
+A string that can be used to define additional data that you would like to be captured with the user's rating. This property aims to future-proof this component to ensure we can capture additional meaning if needed.
+
+#### Global Forms Data (Mandatory)
+
+This component has a dependency on another component: [Global Forms](https://github.com/springernature/frontend-toolkits/tree/main/toolkits/global/packages/global-forms). See [package.json](https://github.com/springernature/frontend-toolkits/tree/main/toolkits/global/packages/global-customer-satisfaction-input/package.json#L10) which defines the version of Global Forms that this component is dependent on.
+
+The view template for Global Customer Satisfaction Input includes the Global Forms fieldset partial which requires a data model suitable for Global Forms. The data to support the Global Forms partial is considered static data. This can be found in `/demo/context.json` as the JSON object `"globalFormData"` and should be defined with the same names, structure and values in your project. The data is also provided [here in JSON](https://gist.github.com/benjclark/8c77fce1ab83a1c3fd8b9ed21be9f366) for your convenience.
+
+### Projects that do not use Elements
+
+If you do not use the Elements design system you are still able to use this component:
+
+1. You can copy the source files from this repository into your project.
+or
+2. You can generate a component demo using the editing `/demo/context.json` and using the command `npm run demo -- -p global-customer-satisfaction-input`. Then, copy the compiled code from `/demo/dist/index.html` in to your project.
+
+> **Warning**
+> These approaches are **not** preferred and should only be used in exceptional circumstances where Elements cannot be used in your application. If you use either of these approaches you **must** ensure you have adequate means of staying up to date with any new version releases for this component. 
+

--- a/toolkits/global/packages/global-customer-satisfaction-input/README.md
+++ b/toolkits/global/packages/global-customer-satisfaction-input/README.md
@@ -5,10 +5,12 @@
 
 The Global Customer Satisfaction Input component is the frontend for an overall solution for gathering customer satisfaction feedback, the documentation for which can be found here: https://customer-satisfaction-survey.public.springernature.app/docs/introduction.
 
-The component comprises a set of 5 pictographic radio inputs used to collect ratings score data from our customers. It is a JavaScript dependent component. When a user interacts with the component an event is dispatched to `window.dataLayer` allowing ratings score data and context data scraped from the page to be sent to Google Tag Manager and Google Cloud Big Query. 
+The component comprises a set of 5 pictographic radio inputs used to collect a satisfaction score from our customers. The user is able to submit one of the following scores: Awful, Bad, OK, Good, Great.
+
+It is a JavaScript dependent component. When a user interacts with the component an event is dispatched to `window.dataLayer` allowing customer satisfaction score data and context data scraped from the page to be sent to Google Tag Manager and Google Cloud Big Query. 
 
 ## Usage
-This documents how to implement this component on your website. If your project does not use Elements yet you can still use this component, see refer to the `Projects that do not use Elements` section below.
+This documents how to implement this component on your website. If your project does not use Elements you can still use this component, see refer to the `Projects that do not use Elements` section below.
 ### Install
 Install the Global Customer Satisfaction Input package:
 ```shell
@@ -98,15 +100,15 @@ A string that represents the heading level number, e.g. `"headingLevel":"3"`. Pl
 
 **questionUrl** (Optional)
 
-A string that defines the link href for any survey you wish to link to after a user has submitted a rating, e.g. `"questionUrl": "https://www.surveymonkey.com/r/97W8JW7"`. A link will only display if both questionUrl and questionText have been defined.
+A string that defines the link href for any survey you wish to link to after a user has submitted a customer satisfaction score, e.g. `"questionUrl": "https://www.surveymonkey.com/r/97W8JW7"`. A link will only display if both questionUrl and questionText have been defined.
 
 **questionText** (Optional)
 
-A string that defines the link text for any survey you wish to link to after a user has submitted a rating, e.g. `"questionText": "Tell us why"`. A link will only display if both questionUrl and questionText have been defined.
+A string that defines the link text for any survey you wish to link to after a user has submitted a customer satisfaction score, e.g. `"questionText": "Tell us why"`. A link will only display if both questionUrl and questionText have been defined.
 
 **additionalInfo** (Optional)
 
-A string that can be used to define additional data that you would like to be captured with the user's rating. This property aims to future-proof this component to ensure we can capture additional meaning if needed.
+A string that can be used to define additional data that you would like to be captured with the user's customer satisfaction score. This property aims to future-proof this component to ensure we can capture additional meaning if needed.
 
 #### Global Forms Data (Mandatory)
 

--- a/toolkits/global/packages/global-customer-satisfaction-input/__tests__/customer-satisfaction-input.spec.js
+++ b/toolkits/global/packages/global-customer-satisfaction-input/__tests__/customer-satisfaction-input.spec.js
@@ -1,0 +1,210 @@
+'use strict';
+import {customerSatisfactionInput} from '../js/index.js';
+
+const fixture = `
+<aside class="u-hide u-js-show" data-customer-satisfaction-input="" data-customer-satisfaction-input-user-journeys="get prepared to publish">
+	<form>
+		<fieldset>
+			<div>
+				<input type="radio" id="1" value="1" data-customer-satisfaction-input="radio">
+				<label for="1"></label>
+			</div>
+			<div>
+				<input type="radio" id="2" value="2" data-customer-satisfaction-input="radio">
+				<label for="2"></label>
+			</div>
+			<div>
+				<input type="radio" id="3" value="3" data-customer-satisfaction-input="radio">
+				<label for="3"></label>
+			</div>
+			<div>
+				<input type="radio" id="4" value="4" data-customer-satisfaction-input="radio">
+				<label for="4"></label>
+			</div>
+			<div>
+				<input type="radio" id="5" value="5" data-customer-satisfaction-input="radio">
+				<label for="5"></label>
+			</div>
+		</fieldset>
+		<button class="u-hide" type="submit"></button>
+		<div class="u-hide" data-customer-satisfaction-input="submit-message">
+			<a href="https://www.surveymonkey.com/1" data-customer-satisfaction-input="survey-link"></a>
+		</div>
+	</form>
+</aside>`;
+
+function createKeydownEvent(key) {
+	const event = new Event('keydown', {
+		bubbles: true
+	});
+	switch (key) {
+		case 'Enter':
+			event.key = 'Enter';
+			break;
+		case 'Space':
+			event.key = 'Space';
+			break;
+		default:
+			break;
+	}
+	return event;
+}
+
+describe('Global Customer Satisfaction Input', () => {
+	let aside, form, fieldset, button, label, input, message, surveyLink;
+
+	beforeEach(() => {
+		document.body.innerHTML = fixture;
+		window.dataLayer = [];
+		aside = document.querySelector('aside');
+		form = document.querySelector('form');
+		fieldset = document.querySelector('fieldset');
+		button = document.querySelector('button');
+		label = document.querySelector('label');
+		input = document.querySelector('input');
+		message = document.querySelector('[data-customer-satisfaction-input="submit-message"]');
+		surveyLink = document.querySelector('[data-customer-satisfaction-input="survey-link"]');
+		jest.spyOn(global.console, 'error').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		document.body.innerHTML = '';
+		global.console.error.mockRestore();
+	});
+
+	test('Should hide pictographic radios and display submit message if pictographic radio clicked and form submitted', () => {
+		expect(fieldset.classList.contains('u-hide')).toBe(false);
+		expect(message.classList.contains('u-hide')).toBe(true);
+		customerSatisfactionInput();
+		label.click();
+		button.click();
+		expect(fieldset.classList.contains('u-hide')).toBe(true);
+		expect(message.classList.contains('u-hide')).toBe(false);
+	});
+
+	test('Should hide pictographic radios and display submit message if pictographic radio selected form submitted by keyboard SPACE on submit button', () => {
+		expect(fieldset.classList.contains('u-hide')).toBe(false);
+		expect(message.classList.contains('u-hide')).toBe(true);
+		customerSatisfactionInput();
+		input.checked = true;
+		const keydownSpace = createKeydownEvent('Space');
+		button.dispatchEvent(keydownSpace);
+		expect(fieldset.classList.contains('u-hide')).toBe(true);
+		expect(message.classList.contains('u-hide')).toBe(false);
+		customerSatisfactionInput();
+	});
+
+	test('Should hide pictographic radios and display submit message if pictographic radio selected form submitted by keyboard ENTER on submit button', () => {
+		expect(fieldset.classList.contains('u-hide')).toBe(false);
+		expect(message.classList.contains('u-hide')).toBe(true);
+		customerSatisfactionInput();
+		input.checked = true;
+		const keydownEnter = createKeydownEvent('Enter');
+		button.dispatchEvent(keydownEnter);
+		expect(fieldset.classList.contains('u-hide')).toBe(true);
+		expect(message.classList.contains('u-hide')).toBe(false);
+		customerSatisfactionInput();
+	});
+
+	test('Should dispatch event to dataLayer if pictographic radio selected and form submitted', () => {
+		expect(window.dataLayer).toEqual([]);
+		customerSatisfactionInput();
+		label.click();
+		button.click();
+		const expectedValue =
+			[{
+				additionalInfo: null,
+				event: 'survey.track',
+				radioValue: '1',
+				userJourneys: 'get prepared to publish'
+			}];
+		expect(window.dataLayer).toEqual(expectedValue);
+	});
+
+	test('Should trim and lowercase user journey values before dispatching them in a dataLayer event', () => {
+		expect(window.dataLayer).toEqual([]);
+		aside.dataset.customerSatisfactionInputUserJourneys = ' GET PREPARED TO PUBLISH ';
+		customerSatisfactionInput();
+		label.click();
+		button.click();
+		const expectedValue =
+			[{
+				additionalInfo: null,
+				event: 'survey.track',
+				radioValue: '1',
+				userJourneys: 'get prepared to publish'
+			}];
+		expect(window.dataLayer).toEqual(expectedValue);
+	});
+
+	test('Should process comma separated user journey values correctly before dispatching them in a dataLayer event', () => {
+		expect(window.dataLayer).toEqual([]);
+		aside.dataset.customerSatisfactionInputUserJourneys = 'get prepared to publish, get published';
+		customerSatisfactionInput();
+		label.click();
+		button.click();
+		const expectedValue =
+			[{
+				additionalInfo: null,
+				event: 'survey.track',
+				radioValue: '1',
+				userJourneys: 'get prepared to publish,get published'
+			}];
+		expect(window.dataLayer).toEqual(expectedValue);
+	});
+
+	test('Should produce console error if no user journey parameter passed to component', () => {
+		aside.dataset.customerSatisfactionInputUserJourneys = '';
+		expect(fieldset.classList.contains('u-hide')).toBe(false);
+		expect(message.classList.contains('u-hide')).toBe(true);
+		customerSatisfactionInput();
+		label.click();
+		button.click();
+		expect(console.error).toBeCalledTimes(1);
+		expect(console.error).toBeCalledWith('Attempt to send Global Customer Satisfaction Input event failed. Value not found for User Journeys.');
+		// Also asserting that, from the user's perspective, it fails silently
+		expect(fieldset.classList.contains('u-hide')).toBe(true);
+		expect(message.classList.contains('u-hide')).toBe(false);
+	});
+
+	test('Should produce console error if impermissible user journey parameter passed to component', () => {
+		aside.dataset.customerSatisfactionInputUserJourneys = 'steve';
+		expect(fieldset.classList.contains('u-hide')).toBe(false);
+		expect(message.classList.contains('u-hide')).toBe(true);
+		customerSatisfactionInput();
+		label.click();
+		button.click();
+		expect(console.error).toBeCalledTimes(1);
+		expect(console.error).toBeCalledWith('Attempt to send Global Customer Satisfaction Input event failed. One or more of the user journeys provided are not permissible values.');
+		// Also asserting that, from the user's perspective, it fails silently
+		expect(fieldset.classList.contains('u-hide')).toBe(true);
+		expect(message.classList.contains('u-hide')).toBe(false);
+	});
+
+	test('Should produce console error if dataLayer does not exist', () => {
+		window.dataLayer = null;
+		expect(fieldset.classList.contains('u-hide')).toBe(false);
+		expect(message.classList.contains('u-hide')).toBe(true);
+		customerSatisfactionInput();
+		label.click();
+		button.click();
+		expect(console.error).toBeCalledTimes(1);
+		expect(console.error).toBeCalledWith('Attempt to send Global Customer Satisfaction Input event failed. window.dataLayer does not exist.');
+		// Also asserting that, from the user's perspective, it fails silently
+		expect(fieldset.classList.contains('u-hide')).toBe(true);
+		expect(message.classList.contains('u-hide')).toBe(false);
+	});
+
+	test('Should get the current location and join survey link', () => {
+		expect(surveyLink.href === 'https://www.surveymonkey.com/1').toBe(true);
+		customerSatisfactionInput();
+		expect(surveyLink.href === 'https://www.surveymonkey.com/1?location=http://localhost/').toBe(true);
+	})
+
+	test('Should generate URL parameters and append them to the survey link', () => {
+		expect(surveyLink.href === 'https://www.surveymonkey.com/1').toBe(true);
+		window.location.href = 'http://localhost/?shafkjsahfh'
+		customerSatisfactionInput();
+		expect(surveyLink.href === 'https://www.surveymonkey.com/1?location=http://localhost/').toBe(true);
+	})
+});

--- a/toolkits/global/packages/global-customer-satisfaction-input/demo/context.json
+++ b/toolkits/global/packages/global-customer-satisfaction-input/demo/context.json
@@ -1,0 +1,245 @@
+{
+	"customerSatisfactionInputData1": {
+		"userJourneys": "get prepared to publish",
+		"headingLevel": "3",
+		"questionUrl": "https://www.surveymonkey.com/r/97W8JW7",
+		"questionText": "Tell us why",
+		"globalFormData": {
+			"fields": [
+				{
+					"template": "globalFormRadios",
+					"error": "Please select one rating",
+					"label": "Rating",
+					"groupDescription": "A scale of 5 feelings conveyed using images that range from awful to great. The feelings represent how you feel about your experience today.",
+					"id": "customer-satisfaction-input-radios1",
+					"name": "customer-satisfaction-input-radios",
+					"pictographic": true,
+					"boxed": true,
+					"inputs": [
+						{
+							"label": "Awful",
+							"value": "1",
+							"id": "radio-awful1",
+							"svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"transparent\" stroke=\"currentColor\" aria-hidden=\"true\" focusable=\"false\"> <clipPath id=\"a\"> <path d=\"M24 0v24H0V0z\"></path> </clipPath> <g stroke-width=\"1.8\" clip-path=\"url(#a)\"> <path d=\"M12 22c5.5228475 0 10-4.4771525 10-10S17.5228475 2 12 2 2 6.4771525 2 12s4.4771525 10 10 10z\" stroke-miterlimit=\"10\"></path> <g stroke-linecap=\"round\"> <path d=\"M8 17c.5-5.33333333 7.5-5.33333333 8 0z\" stroke-linejoin=\"round\"></path> <path d=\"m9 9-2 1M17 10l-2-1\" stroke-miterlimit=\"10\"></path> </g> </g></svg>",
+							"showLabel": true,
+							"imageDescription": "An image of a cartoon face that is very unhappy.",
+							"dataAttrs": {
+								"customer-satisfaction-input": "radio"
+							}
+						},
+						{
+							"label": "Bad",
+							"value": "2",
+							"id": "radio-bad1",
+							"svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"transparent\" stroke=\"currentColor\" aria-hidden=\"true\" focusable=\"false\" viewBox=\"0 0 24 24\"> <defs> <clipPath id=\"frowna\"> <path d=\"M24 0v24H0V0h24Z\"/> </clipPath> <clipPath id=\"frownb\"> <path d=\"M1 0c.6 0 1 .4 1 1v2a1 1 0 1 1-2 0V1c0-.6.4-1 1-1Z\"/> </clipPath> </defs> <g clip-path=\"url(#frowna)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"1.8\" stroke-linejoin=\"round\" d=\"M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z\"/> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"1.8\" stroke-linejoin=\"round\" d=\"M9 17c1-2.7 5-2.7 6 0\"/> <g clip-path=\"url(#frownb)\" transform=\"translate(8 8)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"2\" stroke-linejoin=\"round\" d=\"M0 0h2v4H0V0z\"/> </g> <g clip-path=\"url(#frownb)\" transform=\"translate(14 8)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"2\" stroke-linejoin=\"round\" d=\"M0 0h2v4H0V0z\"/> </g> </g> </svg>",
+							"showLabel":  true,
+							"imageDescription": "An image of a cartoon face with a frown.",
+							"dataAttrs": {
+								"customer-satisfaction-input": "radio"
+							}
+						},
+						{
+							"label": "OK",
+							"value": "3",
+							"id": "radio-ok1",
+							"svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"transparent\" stroke=\"currentColor\" aria-hidden=\"true\" focusable=\"false\" viewBox=\"0 0 24 24\"> <defs> <clipPath id=\"neutrala\"> <path d=\"M24 0v24H0V0h24Z\"/> </clipPath> <clipPath id=\"neutralb\"> <path d=\"M1 0c.6 0 1 .4 1 1v2a1 1 0 1 1-2 0V1c0-.6.4-1 1-1Z\"/> </clipPath> </defs> <g clip-path=\"url(#neutrala)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"1.8\" stroke-linejoin=\"round\" d=\"M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z\"/> <g clip-path=\"url(#neutralb)\" transform=\"translate(8 8)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"2\" stroke-linejoin=\"round\" d=\"M0 0h2v4H0V0z\"/> </g> <g clip-path=\"url(#neutralb)\" transform=\"translate(14 8)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"2\" stroke-linejoin=\"round\" d=\"M0 0h2v4H0V0z\"/> </g> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"1.8\" stroke-linejoin=\"round\" d=\"M9 16h6\"/> </g> </svg>",
+							"showLabel":  true,
+							"imageDescription": "An image of a cartoon face with a neutral expression.",
+							"dataAttrs": {
+								"customer-satisfaction-input": "radio"
+							}
+						},
+						{
+							"label": "Good",
+							"value": "4",
+							"id": "radio-good1",
+							"svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"transparent\" stroke=\"currentColor\"  aria-hidden=\"true\" focusable=\"false\" viewBox=\"0 0 24 24\"> <defs> <clipPath id=\"smilea\"> <path d=\"M24 0v24H0V0h24Z\"/> </clipPath> <clipPath id=\"smileb\"> <path d=\"M1 0c.6 0 1 .4 1 1v2a1 1 0 1 1-2 0V1c0-.6.4-1 1-1Z\"/> </clipPath> </defs> <g clip-path=\"url(#smilea)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"1.8\" stroke-linejoin=\"round\" d=\"M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z\"/> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"1.8\" stroke-linejoin=\"round\" d=\"M9 15c1 2.7 5 2.7 6 0\"/> <g clip-path=\"url(#smileb)\" transform=\"translate(8 8)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"2\" stroke-linejoin=\"round\" d=\"M0 0h2v4H0V0z\"/> </g> <g clip-path=\"url(#smileb)\" transform=\"translate(14 8)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"2\" stroke-linejoin=\"round\" d=\"M0 0h2v4H0V0z\"/> </g> </g> </svg>",
+							"showLabel":  true,
+							"imageDescription": "An image of a cartoon face with a smile.",
+							"dataAttrs": {
+								"customer-satisfaction-input": "radio"
+							}
+						},
+						{
+							"label": "Great",
+							"value": "5",
+							"id": "radio-great1",
+							"svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"transparent\" stroke=\"currentColor\" aria-hidden=\"true\" focusable=\"false\" viewBox=\"0 0 24 24\"> <defs> <clipPath id=\"grina\"> <path d=\"M24 0v24H0V0h24Z\"/> </clipPath> </defs> <g clip-path=\"url(#grina)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"1.8\" stroke-linejoin=\"round\" d=\"M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z\"/> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"1.8\" stroke-linejoin=\"round\" d=\"M17.5 10v-.5a1.7 1.7 0 0 0-3.5 0v.5M10 10v-.5a1.7 1.7 0 0 0-3.5 0v.5M8 14c.5 5 7.5 5 8 0H8Z\"/> </g> </svg>",
+							"showLabel":  true,
+							"imageDescription": "An image of a cartoon face with an open mouth grin.",
+							"dataAttrs": {
+								"customer-satisfaction-input": "radio"
+							}
+						}
+					]
+				}
+			]
+		}
+	},
+	"customerSatisfactionInputData2": {
+		"userJourneys": "get published",
+		"headingLevel": "3",
+		"questionUrl": "https://www.surveymonkey.com/r/97W8JW7",
+		"questionText": "Tell us why",
+		"globalFormData": {
+			"fields": [
+				{
+					"template": "globalFormRadios",
+					"error": "Please select one rating",
+					"label": "Rating",
+					"groupDescription": "A scale of 5 feelings conveyed using images that range from awful to great. The feelings represent how you feel about your experience today.",
+					"id": "customer-satisfaction-input-radios2",
+					"name": "customer-satisfaction-input-radios",
+					"pictographic": true,
+					"boxed": true,
+					"inputs": [
+						{
+							"label": "Awful",
+							"value": "1",
+							"id": "radio-awful2",
+							"svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"transparent\" stroke=\"currentColor\" aria-hidden=\"true\" focusable=\"false\"> <clipPath id=\"a\"> <path d=\"M24 0v24H0V0z\"></path> </clipPath> <g stroke-width=\"1.8\" clip-path=\"url(#a)\"> <path d=\"M12 22c5.5228475 0 10-4.4771525 10-10S17.5228475 2 12 2 2 6.4771525 2 12s4.4771525 10 10 10z\" stroke-miterlimit=\"10\"></path> <g stroke-linecap=\"round\"> <path d=\"M8 17c.5-5.33333333 7.5-5.33333333 8 0z\" stroke-linejoin=\"round\"></path> <path d=\"m9 9-2 1M17 10l-2-1\" stroke-miterlimit=\"10\"></path> </g> </g></svg>",
+							"showLabel": true,
+							"imageDescription": "An image of a cartoon face that is very unhappy.",
+							"dataAttrs": {
+								"customer-satisfaction-input": "radio"
+							}
+						},
+						{
+							"label": "Bad",
+							"value": "2",
+							"id": "radio-bad2",
+							"svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"transparent\" stroke=\"currentColor\" aria-hidden=\"true\" focusable=\"false\" viewBox=\"0 0 24 24\"> <defs> <clipPath id=\"frowna2\"> <path d=\"M24 0v24H0V0h24Z\"/> </clipPath> <clipPath id=\"frownb2\"> <path d=\"M1 0c.6 0 1 .4 1 1v2a1 1 0 1 1-2 0V1c0-.6.4-1 1-1Z\"/> </clipPath> </defs> <g clip-path=\"url(#frowna2)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"1.8\" stroke-linejoin=\"round\" d=\"M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z\"/> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"1.8\" stroke-linejoin=\"round\" d=\"M9 17c1-2.7 5-2.7 6 0\"/> <g clip-path=\"url(#frownb2)\" transform=\"translate(8 8)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"2\" stroke-linejoin=\"round\" d=\"M0 0h2v4H0V0z\"/> </g> <g clip-path=\"url(#frownb2)\" transform=\"translate(14 8)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"2\" stroke-linejoin=\"round\" d=\"M0 0h2v4H0V0z\"/> </g> </g> </svg>",
+							"showLabel":  true,
+							"imageDescription": "An image of a cartoon face with a frown.",
+							"dataAttrs": {
+								"customer-satisfaction-input": "radio"
+							}
+						},
+						{
+							"label": "OK",
+							"value": "3",
+							"id": "radio-ok2",
+							"svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"transparent\" stroke=\"currentColor\" aria-hidden=\"true\" focusable=\"false\" viewBox=\"0 0 24 24\"> <defs> <clipPath id=\"neutrala2\"> <path d=\"M24 0v24H0V0h24Z\"/> </clipPath> <clipPath id=\"neutralb2\"> <path d=\"M1 0c.6 0 1 .4 1 1v2a1 1 0 1 1-2 0V1c0-.6.4-1 1-1Z\"/> </clipPath> </defs> <g clip-path=\"url(#neutrala2)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"1.8\" stroke-linejoin=\"round\" d=\"M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z\"/> <g clip-path=\"url(#neutralb2)\" transform=\"translate(8 8)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"2\" stroke-linejoin=\"round\" d=\"M0 0h2v4H0V0z\"/> </g> <g clip-path=\"url(#neutralb2)\" transform=\"translate(14 8)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"2\" stroke-linejoin=\"round\" d=\"M0 0h2v4H0V0z\"/> </g> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"1.8\" stroke-linejoin=\"round\" d=\"M9 16h6\"/> </g> </svg>",
+							"showLabel":  true,
+							"imageDescription": "An image of a cartoon face with a neutral expression.",
+							"dataAttrs": {
+								"customer-satisfaction-input": "radio"
+							}
+						},
+						{
+							"label": "Good",
+							"value": "4",
+							"id": "radio-good2",
+							"svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"transparent\" stroke=\"currentColor\"  aria-hidden=\"true\" focusable=\"false\" viewBox=\"0 0 24 24\"> <defs> <clipPath id=\"smilea2\"> <path d=\"M24 0v24H0V0h24Z\"/> </clipPath> <clipPath id=\"smileb2\"> <path d=\"M1 0c.6 0 1 .4 1 1v2a1 1 0 1 1-2 0V1c0-.6.4-1 1-1Z\"/> </clipPath> </defs> <g clip-path=\"url(#smilea2)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"1.8\" stroke-linejoin=\"round\" d=\"M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z\"/> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"1.8\" stroke-linejoin=\"round\" d=\"M9 15c1 2.7 5 2.7 6 0\"/> <g clip-path=\"url(#smileb2)\" transform=\"translate(8 8)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"2\" stroke-linejoin=\"round\" d=\"M0 0h2v4H0V0z\"/> </g> <g clip-path=\"url(#smileb2)\" transform=\"translate(14 8)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"2\" stroke-linejoin=\"round\" d=\"M0 0h2v4H0V0z\"/> </g> </g> </svg>",
+							"showLabel":  true,
+							"imageDescription": "An image of a cartoon face with a smile.",
+							"dataAttrs": {
+								"customer-satisfaction-input": "radio"
+							}
+						},
+						{
+							"label": "Great",
+							"value": "5",
+							"id": "radio-great2",
+							"svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"transparent\" stroke=\"currentColor\" aria-hidden=\"true\" focusable=\"false\" viewBox=\"0 0 24 24\"> <defs> <clipPath id=\"grina2\"> <path d=\"M24 0v24H0V0h24Z\"/> </clipPath> </defs> <g clip-path=\"url(#grina2)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"1.8\" stroke-linejoin=\"round\" d=\"M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z\"/> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"1.8\" stroke-linejoin=\"round\" d=\"M17.5 10v-.5a1.7 1.7 0 0 0-3.5 0v.5M10 10v-.5a1.7 1.7 0 0 0-3.5 0v.5M8 14c.5 5 7.5 5 8 0H8Z\"/> </g> </svg>",
+							"showLabel":  true,
+							"imageDescription": "An image of a cartoon face with an open mouth grin.",
+							"dataAttrs": {
+								"customer-satisfaction-input": "radio"
+							}
+						}
+					]
+				}
+			]
+		}
+	},
+	"customerSatisfactionInputData3": {
+		"userJourneys": "Get Prepared to Publish, Get Published",
+		"headingLevel": "3",
+		"questionUrl": "https://www.surveymonkey.com/r/97W8JW7",
+		"questionText": "Tell us why",
+		"additionalInfo": "AB test version B",
+		"globalFormData": {
+			"fields": [
+				{
+					"template": "globalFormRadios",
+					"error": "Please select one rating",
+					"label": "Rating",
+					"groupDescription": "A scale of 5 feelings conveyed using images that range from awful to great. The feelings represent how you feel about your experience today.",
+					"id": "customer-satisfaction-input-radios3",
+					"name": "customer-satisfaction-input-radios",
+					"pictographic": true,
+					"boxed": true,
+					"inputs": [
+						{
+							"label": "Awful",
+							"value": "1",
+							"id": "radio-awful3",
+							"svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"transparent\" stroke=\"currentColor\" aria-hidden=\"true\" focusable=\"false\"> <clipPath id=\"a\"> <path d=\"M24 0v24H0V0z\"></path> </clipPath> <g stroke-width=\"1.8\" clip-path=\"url(#a)\"> <path d=\"M12 22c5.5228475 0 10-4.4771525 10-10S17.5228475 2 12 2 2 6.4771525 2 12s4.4771525 10 10 10z\" stroke-miterlimit=\"10\"></path> <g stroke-linecap=\"round\"> <path d=\"M8 17c.5-5.33333333 7.5-5.33333333 8 0z\" stroke-linejoin=\"round\"></path> <path d=\"m9 9-2 1M17 10l-2-1\" stroke-miterlimit=\"10\"></path> </g> </g></svg>",
+							"showLabel": true,
+							"imageDescription": "An image of a cartoon face that is very unhappy.",
+							"dataAttrs": {
+								"customer-satisfaction-input": "radio"
+							}
+						},
+						{
+							"label": "Bad",
+							"value": "2",
+							"id": "radio-bad3",
+							"svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"transparent\" stroke=\"currentColor\" aria-hidden=\"true\" focusable=\"false\" viewBox=\"0 0 24 24\"> <defs> <clipPath id=\"frowna3\"> <path d=\"M24 0v24H0V0h24Z\"/> </clipPath> <clipPath id=\"frownb3\"> <path d=\"M1 0c.6 0 1 .4 1 1v2a1 1 0 1 1-2 0V1c0-.6.4-1 1-1Z\"/> </clipPath> </defs> <g clip-path=\"url(#frowna3)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"1.8\" stroke-linejoin=\"round\" d=\"M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z\"/> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"1.8\" stroke-linejoin=\"round\" d=\"M9 17c1-2.7 5-2.7 6 0\"/> <g clip-path=\"url(#frownb3)\" transform=\"translate(8 8)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"3\" stroke-linejoin=\"round\" d=\"M0 0h2v4H0V0z\"/> </g> <g clip-path=\"url(#frownb3)\" transform=\"translate(14 8)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"3\" stroke-linejoin=\"round\" d=\"M0 0h2v4H0V0z\"/> </g> </g> </svg>",
+							"showLabel":  true,
+							"imageDescription": "An image of a cartoon face with a frown.",
+							"dataAttrs": {
+								"customer-satisfaction-input": "radio"
+							}
+						},
+						{
+							"label": "OK",
+							"value": "3",
+							"id": "radio-ok3",
+							"svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"transparent\" stroke=\"currentColor\" aria-hidden=\"true\" focusable=\"false\" viewBox=\"0 0 24 24\"> <defs> <clipPath id=\"neutrala3\"> <path d=\"M24 0v24H0V0h24Z\"/> </clipPath> <clipPath id=\"neutralb3\"> <path d=\"M1 0c.6 0 1 .4 1 1v2a1 1 0 1 1-2 0V1c0-.6.4-1 1-1Z\"/> </clipPath> </defs> <g clip-path=\"url(#neutrala3)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"1.8\" stroke-linejoin=\"round\" d=\"M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z\"/> <g clip-path=\"url(#neutralb3)\" transform=\"translate(8 8)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"3\" stroke-linejoin=\"round\" d=\"M0 0h2v4H0V0z\"/> </g> <g clip-path=\"url(#neutralb3)\" transform=\"translate(14 8)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"3\" stroke-linejoin=\"round\" d=\"M0 0h2v4H0V0z\"/> </g> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"1.8\" stroke-linejoin=\"round\" d=\"M9 16h6\"/> </g> </svg>",
+							"showLabel":  true,
+							"imageDescription": "An image of a cartoon face with a neutral expression.",
+							"dataAttrs": {
+								"customer-satisfaction-input": "radio"
+							}
+						},
+						{
+							"label": "Good",
+							"value": "4",
+							"id": "radio-good3",
+							"svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"transparent\" stroke=\"currentColor\"  aria-hidden=\"true\" focusable=\"false\" viewBox=\"0 0 24 24\"> <defs> <clipPath id=\"smilea3\"> <path d=\"M24 0v24H0V0h24Z\"/> </clipPath> <clipPath id=\"smileb3\"> <path d=\"M1 0c.6 0 1 .4 1 1v2a1 1 0 1 1-2 0V1c0-.6.4-1 1-1Z\"/> </clipPath> </defs> <g clip-path=\"url(#smilea3)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"1.8\" stroke-linejoin=\"round\" d=\"M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z\"/> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"1.8\" stroke-linejoin=\"round\" d=\"M9 15c1 2.7 5 2.7 6 0\"/> <g clip-path=\"url(#smileb3)\" transform=\"translate(8 8)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"3\" stroke-linejoin=\"round\" d=\"M0 0h2v4H0V0z\"/> </g> <g clip-path=\"url(#smileb3)\" transform=\"translate(14 8)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"3\" stroke-linejoin=\"round\" d=\"M0 0h2v4H0V0z\"/> </g> </g> </svg>",
+							"showLabel":  true,
+							"imageDescription": "An image of a cartoon face with a smile.",
+							"dataAttrs": {
+								"customer-satisfaction-input": "radio"
+							}
+						},
+						{
+							"label": "Great",
+							"value": "5",
+							"id": "radio-great3",
+							"svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"transparent\" stroke=\"currentColor\" aria-hidden=\"true\" focusable=\"false\" viewBox=\"0 0 24 24\"> <defs> <clipPath id=\"grina3\"> <path d=\"M24 0v24H0V0h24Z\"/> </clipPath> </defs> <g clip-path=\"url(#grina3)\"> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"1.8\" stroke-linejoin=\"round\" d=\"M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z\"/> <path stroke-linecap=\"round\" stroke-miterlimit=\"10\" stroke-width=\"1.8\" stroke-linejoin=\"round\" d=\"M17.5 10v-.5a1.7 1.7 0 0 0-3.5 0v.5M10 10v-.5a1.7 1.7 0 0 0-3.5 0v.5M8 14c.5 5 7.5 5 8 0H8Z\"/> </g> </svg>",
+							"showLabel":  true,
+							"imageDescription": "An image of a cartoon face with an open mouth grin.",
+							"dataAttrs": {
+								"customer-satisfaction-input": "radio"
+							}
+						}
+					]
+				}
+			]
+		}
+	},
+	"dynamicPartials": {
+		"customerSatisfactionInput": "./toolkits/global/packages/global-customer-satisfaction-input/view/customerSatisfactionInput.hbs",
+		"globalFormField": "./toolkits/global/packages/global-customer-satisfaction-input/node_modules/@springernature/global-forms/view/globalFormField.hbs",
+		"globalFormFieldset": "./toolkits/global/packages/global-customer-satisfaction-input/node_modules/@springernature/global-forms/view/globalFormFieldset.hbs",
+		"globalFormLabel": "./toolkits/global/packages/global-customer-satisfaction-input/node_modules/@springernature/global-forms/view/globalFormLabel.hbs",
+		"globalFormAttributes": "./toolkits/global/packages/global-customer-satisfaction-input/node_modules/@springernature/global-forms/view/globalFormAttributes.hbs",
+		"globalFormRadios": "./toolkits/global/packages/global-customer-satisfaction-input/node_modules/@springernature/global-forms/view/fields/globalFormRadios.hbs",
+		"globalFormRadio": "./toolkits/global/packages/global-customer-satisfaction-input/node_modules/@springernature/global-forms/view/fields/globalFormRadio.hbs",
+		"globalFormIconError": "./toolkits/global/packages/global-customer-satisfaction-input/node_modules/@springernature/global-forms/view/globalFormIconError.hbs",
+		"globalFormError": "./toolkits/global/packages/global-customer-satisfaction-input/node_modules/@springernature/global-forms/view/globalFormError.hbs"
+	}
+}

--- a/toolkits/global/packages/global-customer-satisfaction-input/demo/dist/index.html
+++ b/toolkits/global/packages/global-customer-satisfaction-input/demo/dist/index.html
@@ -1,0 +1,2531 @@
+<!DOCTYPE html><html lang="en"><head>
+		<script>
+    		(function(e){var t=e.documentElement,n=e.implementation;t.className='js';})(document)
+		</script>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<title>@springernature/global-customer-satisfaction-input</title>
+		<style>
+			@charset "UTF-8";
+/**
+ * Core
+ * Styles for all pages, included on pages that
+ * both do and dont cut the mustard, keep to a minimum
+ */
+/**
+ * Abstracts
+ * Sass tools, helper files, variables, functions, mixins and other config files
+ * These files don’t output any CSS when compiled
+ */
+/**
+ * Abstracts
+ * Sass tools, helper files, variables, functions, mixins and other config files
+ * These files don’t output any CSS when compiled
+ */
+/**
+ * Breakpoints
+ * Shared media query values
+ */
+/**
+ * Colors
+ * Maps for color values & greyscale settings
+ *
+ */
+/**
+ * Shared colors
+ * Applicable to all brands and not to be overwritten
+ *
+ */
+/**
+ * Typography
+ * Font settings
+ */
+/**
+ *  Button settings
+ *  Default
+ *
+ */
+/**
+ * Return a greyscale color based on $context--greyscale-base
+ *
+ * @param {Integer} $val - lightness value between $context--greyscale-min and $context--greyscale-max
+ * @param {Float} $opacity - opacity value between 0.1 and 1, to one decimal place
+ *
+ */
+/**
+ * Return a color from a color palette
+ *
+ * @param {String} $name - name of the color to insert
+ * @param {Arglist} $keys - 0 to 2 paramaters defining map and opacity
+ *
+ */
+/**
+ * Returns either a dark or light foreground color when given the background color
+ *
+ * @param {Integer|String} $bgcolor - number for grays, string for colors
+ * @param {Map} $map - the color map to use
+ *
+ */
+/**
+ * Calculates the sRGB luma of a colour
+ * @private
+ *
+ * @param {*} $c - Color value
+ *
+ * https://lnikki.la/articles/sass-better-colour-based-on-brightness/
+ * http://robots.thoughtbot.com/closer-look-color-lightness
+ *
+ */
+/**
+ * Style
+ * Cosmetic styling settings
+ *
+ */
+/**
+ * Return a greyscale color based on $context--greyscale-base
+ *
+ * @param {Integer} $val - lightness value between $context--greyscale-min and $context--greyscale-max
+ * @param {Float} $opacity - opacity value between 0.1 and 1, to one decimal place
+ *
+ */
+/**
+ * Return a color from a color palette
+ *
+ * @param {String} $name - name of the color to insert
+ * @param {Arglist} $keys - 0 to 2 paramaters defining map and opacity
+ *
+ */
+/**
+ * Returns either a dark or light foreground color when given the background color
+ *
+ * @param {Integer|String} $bgcolor - number for grays, string for colors
+ * @param {Map} $map - the color map to use
+ *
+ */
+/**
+ * Calculates the sRGB luma of a colour
+ * @private
+ *
+ * @param {*} $c - Color value
+ *
+ * https://lnikki.la/articles/sass-better-colour-based-on-brightness/
+ * http://robots.thoughtbot.com/closer-look-color-lightness
+ *
+ */
+/**
+ * Return a greyscale color based on $context--greyscale-base
+ *
+ * @param {Integer} $val - lightness value between $context--greyscale-min and $context--greyscale-max
+ * @param {Float} $opacity - opacity value between 0.1 and 1, to one decimal place
+ *
+ */
+/**
+ * Return a color from a color palette
+ *
+ * @param {String} $name - name of the color to insert
+ * @param {Arglist} $keys - 0 to 2 paramaters defining map and opacity
+ *
+ */
+/**
+ * Returns either a dark or light foreground color when given the background color
+ *
+ * @param {Integer|String} $bgcolor - number for grays, string for colors
+ * @param {Map} $map - the color map to use
+ *
+ */
+/**
+ * Calculates the sRGB luma of a colour
+ * @private
+ *
+ * @param {*} $c - Color value
+ *
+ * https://lnikki.la/articles/sass-better-colour-based-on-brightness/
+ * http://robots.thoughtbot.com/closer-look-color-lightness
+ *
+ */
+/**
+ * Map deep get
+ * @author Hugo Giraudel
+ * @private
+ *
+ * @param {Map} $map - Map
+ * @param {Arglist} $keys - Key chain
+ * @return {*} - Desired value
+ *
+ */
+/**
+ * Map key get
+ * Check if a key exists in a map, return it
+ * @private
+ *
+ * @param {Map} $map - Map
+ * @param {String} $value - Key name
+ * @return {*} - Key name, if found
+ *
+ */
+/**
+ * Style mixins
+ *
+ */
+/**
+ * Breakpoints
+ * Media query helper
+ * @group 30-mixins
+ */
+/**
+ * Colour palette
+ *
+ */
+/**
+ * Color and gray scales
+ *
+ */
+/**
+ * Style
+ * Cosmetic styling settings
+ *
+ */
+/**
+ *  Button settings
+ *  Springer
+ *
+ */
+/**
+ * Generates utility classnames for base and each breakpoint
+ *
+ * Example:
+ * @include class-stack('u-text-right') would output
+ * u-text-right { @content }
+ * @include media-query('xs') { u-text-right-at-lt-xs { @content } }
+ *
+ */
+/**
+ * Default link style
+ *
+ */
+/**
+ * Alternative link color
+ *
+ */
+/**
+ * Deemphasised link color
+ *
+ */
+/**
+ * Unvisited
+ *
+ */
+/**
+ * Link like
+ * Style non-links to look like links
+ * Remember to add aria
+ *
+ */
+/*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
+/* Document
+   ========================================================================== */
+/**
+ * 1. Correct the line height in all browsers.
+ * 2. Prevent adjustments of font size after orientation changes in iOS.
+ */
+html {
+  line-height: 1.15; /* 1 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+}
+
+/* Sections
+   ========================================================================== */
+/**
+ * Remove the margin in all browsers.
+ */
+body {
+  margin: 0;
+}
+
+/**
+ * Render the `main` element consistently in IE.
+ */
+main {
+  display: block;
+}
+
+/**
+ * Correct the font size and margin on `h1` elements within `section` and
+ * `article` contexts in Chrome, Firefox, and Safari.
+ */
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/* Grouping content
+   ========================================================================== */
+/**
+ * 1. Add the correct box sizing in Firefox.
+ * 2. Show the overflow in Edge and IE.
+ */
+hr {
+  box-sizing: content-box; /* 1 */
+  height: 0; /* 1 */
+  overflow: visible; /* 2 */
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+pre {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/* Text-level semantics
+   ========================================================================== */
+/**
+ * Remove the gray background on active links in IE 10.
+ */
+a {
+  background-color: transparent;
+}
+
+/**
+ * 1. Remove the bottom border in Chrome 57-
+ * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
+ */
+abbr[title] {
+  border-bottom: none; /* 1 */
+  text-decoration: underline; /* 2 */
+  text-decoration: underline dotted; /* 2 */
+}
+
+/**
+ * Add the correct font weight in Chrome, Edge, and Safari.
+ */
+b,
+strong {
+  font-weight: bolder;
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+code,
+kbd,
+samp {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/**
+ * Add the correct font size in all browsers.
+ */
+small {
+  font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` elements from affecting the line height in
+ * all browsers.
+ */
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/* Embedded content
+   ========================================================================== */
+/**
+ * Remove the border on images inside links in IE 10.
+ */
+img {
+  border-style: none;
+}
+
+/* Forms
+   ========================================================================== */
+/**
+ * 1. Change the font styles in all browsers.
+ * 2. Remove the margin in Firefox and Safari.
+ */
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit; /* 1 */
+  font-size: 100%; /* 1 */
+  line-height: 1.15; /* 1 */
+  margin: 0; /* 2 */
+}
+
+/**
+ * Show the overflow in IE.
+ * 1. Show the overflow in Edge.
+ */
+button,
+input { /* 1 */
+  overflow: visible;
+}
+
+/**
+ * Remove the inheritance of text transform in Edge, Firefox, and IE.
+ * 1. Remove the inheritance of text transform in Firefox.
+ */
+button,
+select { /* 1 */
+  text-transform: none;
+}
+
+/**
+ * Correct the inability to style clickable types in iOS and Safari.
+ */
+button,
+[type=button],
+[type=reset],
+[type=submit] {
+  -webkit-appearance: button;
+}
+
+/**
+ * Remove the inner border and padding in Firefox.
+ */
+button::-moz-focus-inner,
+[type=button]::-moz-focus-inner,
+[type=reset]::-moz-focus-inner,
+[type=submit]::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+/**
+ * Restore the focus styles unset by the previous rule.
+ */
+button:-moz-focusring,
+[type=button]:-moz-focusring,
+[type=reset]:-moz-focusring,
+[type=submit]:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+/**
+ * Correct the padding in Firefox.
+ */
+fieldset {
+  padding: 0.35em 0.75em 0.625em;
+}
+
+/**
+ * 1. Correct the text wrapping in Edge and IE.
+ * 2. Correct the color inheritance from `fieldset` elements in IE.
+ * 3. Remove the padding so developers are not caught out when they zero out
+ *    `fieldset` elements in all browsers.
+ */
+legend {
+  box-sizing: border-box; /* 1 */
+  color: inherit; /* 2 */
+  display: table; /* 1 */
+  max-width: 100%; /* 1 */
+  padding: 0; /* 3 */
+  white-space: normal; /* 1 */
+}
+
+/**
+ * Add the correct vertical alignment in Chrome, Firefox, and Opera.
+ */
+progress {
+  vertical-align: baseline;
+}
+
+/**
+ * Remove the default vertical scrollbar in IE 10+.
+ */
+textarea {
+  overflow: auto;
+}
+
+/**
+ * 1. Add the correct box sizing in IE 10.
+ * 2. Remove the padding in IE 10.
+ */
+[type=checkbox],
+[type=radio] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Correct the cursor style of increment and decrement buttons in Chrome.
+ */
+[type=number]::-webkit-inner-spin-button,
+[type=number]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * 1. Correct the odd appearance in Chrome and Safari.
+ * 2. Correct the outline style in Safari.
+ */
+[type=search] {
+  -webkit-appearance: textfield; /* 1 */
+  outline-offset: -2px; /* 2 */
+}
+
+/**
+ * Remove the inner padding in Chrome and Safari on macOS.
+ */
+[type=search]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * 1. Correct the inability to style clickable types in iOS and Safari.
+ * 2. Change font properties to `inherit` in Safari.
+ */
+::-webkit-file-upload-button {
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
+}
+
+/* Interactive
+   ========================================================================== */
+/*
+ * Add the correct display in Edge, IE 10+, and Firefox.
+ */
+details {
+  display: block;
+}
+
+/*
+ * Add the correct display in all browsers.
+ */
+summary {
+  display: list-item;
+}
+
+/* Misc
+   ========================================================================== */
+/**
+ * Add the correct display in IE 10+.
+ */
+template {
+  display: none;
+}
+
+/**
+ * Add the correct display in IE 10.
+ */
+[hidden] {
+  display: none;
+}
+
+body {
+  line-height: 1.5;
+}
+
+button {
+  cursor: pointer;
+}
+
+img {
+  border: 0;
+  max-width: 100%;
+  height: auto;
+  vertical-align: middle;
+}
+
+/**
+ * Basic
+ * Some default CSS styles
+ */
+body {
+  font-size: 0.813rem;
+}
+
+* {
+  margin: 0;
+}
+
+a {
+  color: #069;
+}
+
+h1 {
+  font-size: 1.875rem;
+}
+
+h2 {
+  font-size: 1.5rem;
+}
+
+h3 {
+  font-size: 1.0625rem;
+}
+
+h4 {
+  font-size: 0.875rem;
+}
+
+cite {
+  font-style: normal;
+}
+
+ins {
+  text-decoration: none;
+}
+
+button {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  border-radius: 0;
+}
+
+/**
+ * Enhanced
+ * Bootstrap the rest of the styles on cut the mustard
+ */
+/**
+ * Abstracts
+ * Sass tools, helper files, variables, functions, mixins and other config files
+ * These files don’t output any CSS when compiled
+ */
+/**
+ * Abstracts
+ * Sass tools, helper files, variables, functions, mixins and other config files
+ * These files don’t output any CSS when compiled
+ */
+/**
+ * Breakpoints
+ * Shared media query values
+ */
+/**
+ * Colors
+ * Maps for color values & greyscale settings
+ *
+ */
+/**
+ * Shared colors
+ * Applicable to all brands and not to be overwritten
+ *
+ */
+/**
+ * Typography
+ * Font settings
+ */
+/**
+ *  Button settings
+ *  Default
+ *
+ */
+/**
+ * Return a greyscale color based on $context--greyscale-base
+ *
+ * @param {Integer} $val - lightness value between $context--greyscale-min and $context--greyscale-max
+ * @param {Float} $opacity - opacity value between 0.1 and 1, to one decimal place
+ *
+ */
+/**
+ * Return a color from a color palette
+ *
+ * @param {String} $name - name of the color to insert
+ * @param {Arglist} $keys - 0 to 2 paramaters defining map and opacity
+ *
+ */
+/**
+ * Returns either a dark or light foreground color when given the background color
+ *
+ * @param {Integer|String} $bgcolor - number for grays, string for colors
+ * @param {Map} $map - the color map to use
+ *
+ */
+/**
+ * Calculates the sRGB luma of a colour
+ * @private
+ *
+ * @param {*} $c - Color value
+ *
+ * https://lnikki.la/articles/sass-better-colour-based-on-brightness/
+ * http://robots.thoughtbot.com/closer-look-color-lightness
+ *
+ */
+/**
+ * Style
+ * Cosmetic styling settings
+ *
+ */
+/**
+ * Return a greyscale color based on $context--greyscale-base
+ *
+ * @param {Integer} $val - lightness value between $context--greyscale-min and $context--greyscale-max
+ * @param {Float} $opacity - opacity value between 0.1 and 1, to one decimal place
+ *
+ */
+/**
+ * Return a color from a color palette
+ *
+ * @param {String} $name - name of the color to insert
+ * @param {Arglist} $keys - 0 to 2 paramaters defining map and opacity
+ *
+ */
+/**
+ * Returns either a dark or light foreground color when given the background color
+ *
+ * @param {Integer|String} $bgcolor - number for grays, string for colors
+ * @param {Map} $map - the color map to use
+ *
+ */
+/**
+ * Calculates the sRGB luma of a colour
+ * @private
+ *
+ * @param {*} $c - Color value
+ *
+ * https://lnikki.la/articles/sass-better-colour-based-on-brightness/
+ * http://robots.thoughtbot.com/closer-look-color-lightness
+ *
+ */
+/**
+ * Return a greyscale color based on $context--greyscale-base
+ *
+ * @param {Integer} $val - lightness value between $context--greyscale-min and $context--greyscale-max
+ * @param {Float} $opacity - opacity value between 0.1 and 1, to one decimal place
+ *
+ */
+/**
+ * Return a color from a color palette
+ *
+ * @param {String} $name - name of the color to insert
+ * @param {Arglist} $keys - 0 to 2 paramaters defining map and opacity
+ *
+ */
+/**
+ * Returns either a dark or light foreground color when given the background color
+ *
+ * @param {Integer|String} $bgcolor - number for grays, string for colors
+ * @param {Map} $map - the color map to use
+ *
+ */
+/**
+ * Calculates the sRGB luma of a colour
+ * @private
+ *
+ * @param {*} $c - Color value
+ *
+ * https://lnikki.la/articles/sass-better-colour-based-on-brightness/
+ * http://robots.thoughtbot.com/closer-look-color-lightness
+ *
+ */
+/**
+ * Map deep get
+ * @author Hugo Giraudel
+ * @private
+ *
+ * @param {Map} $map - Map
+ * @param {Arglist} $keys - Key chain
+ * @return {*} - Desired value
+ *
+ */
+/**
+ * Map key get
+ * Check if a key exists in a map, return it
+ * @private
+ *
+ * @param {Map} $map - Map
+ * @param {String} $value - Key name
+ * @return {*} - Key name, if found
+ *
+ */
+/**
+ * Style mixins
+ *
+ */
+/**
+ * Breakpoints
+ * Media query helper
+ * @group 30-mixins
+ */
+/**
+ * Colour palette
+ *
+ */
+/**
+ * Color and gray scales
+ *
+ */
+/**
+ * Style
+ * Cosmetic styling settings
+ *
+ */
+/**
+ *  Button settings
+ *  Springer
+ *
+ */
+/**
+ * Generates utility classnames for base and each breakpoint
+ *
+ * Example:
+ * @include class-stack('u-text-right') would output
+ * u-text-right { @content }
+ * @include media-query('xs') { u-text-right-at-lt-xs { @content } }
+ *
+ */
+/**
+ * Default link style
+ *
+ */
+/**
+ * Alternative link color
+ *
+ */
+/**
+ * Deemphasised link color
+ *
+ */
+/**
+ * Unvisited
+ *
+ */
+/**
+ * Link like
+ * Style non-links to look like links
+ * Remember to add aria
+ *
+ */
+button {
+  line-height: inherit;
+}
+
+button:focus,
+input:focus,
+select:focus,
+textarea:focus {
+  outline: 4px solid #ffcc00;
+}
+
+input[type=file]:focus-within {
+  outline: 4px solid #ffcc00;
+}
+
+button:disabled:focus,
+input:disabled:focus,
+select:disabled:focus,
+textarea:disabled:focus {
+  outline: none;
+}
+
+label {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+}
+
+/*
+ * Layout
+ * Universal layout styles
+ */
+html {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  height: 100%;
+  overflow-y: scroll;
+  font-size: 100%;
+  box-sizing: border-box;
+  color: #333333;
+  line-height: 1.6180339888;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: subpixel-antialiased;
+}
+
+*,
+*:before,
+*:after {
+  box-sizing: inherit;
+}
+
+body {
+  max-width: 100%;
+  min-height: 100%;
+  background: #fcfcfc;
+  font-size: 1.125rem; /* fixes chrome rems bug - http://stackoverflow.com/questions/20099844/chrome-not-respecting-rem-font-size-on-body-tag */
+}
+
+figure {
+  margin: 0;
+}
+
+body,
+div,
+dl,
+dt,
+dd,
+pre,
+code,
+form,
+fieldset,
+legend,
+input,
+button,
+textarea,
+p,
+th,
+td {
+  margin: 0;
+  padding: 0;
+}
+
+abbr[title] {
+  text-decoration: none;
+}
+
+[contenteditable]:focus,
+[tabindex="0"]:focus {
+  outline: 4px solid #ffcc00;
+}
+
+a {
+  color: #004b83;
+  text-decoration: underline;
+  text-decoration-skip-ink: auto;
+}
+a.visited, a:visited {
+  color: #a345c9;
+}
+a.hover, a:hover {
+  color: #0061a9;
+}
+a.active, a:active {
+  color: #003b84;
+  text-decoration: none;
+}
+a.focus, a:focus {
+  outline: 4px solid #ffcc00;
+}
+a > img {
+  vertical-align: middle;
+}
+
+table {
+  border: 1px solid #a6a6a6;
+  width: 100%;
+  margin-bottom: 32px;
+}
+
+th,
+td {
+  font-size: 1rem;
+  border: 1px solid #a6a6a6;
+  padding: 0.3em 0.6em;
+  vertical-align: top;
+}
+
+th {
+  background: #e6e6e6;
+  text-align: left;
+}
+
+h1 {
+  font-style: normal;
+  line-height: 1.4;
+  font-size: 2.25rem;
+  font-size: min(max(1.75rem, 4vw), 2.25rem);
+  font-family: Georgia, Palatino, serif;
+  font-weight: 400;
+}
+h1 a.active, h1 a:active, h1 a.hover, h1 a:hover {
+  text-decoration: underline;
+  text-decoration-skip-ink: auto;
+}
+
+h2 {
+  font-style: normal;
+  line-height: 1.4;
+  font-size: 1.75rem;
+  font-size: min(max(1.5rem, 3.5vw), 1.75rem);
+  font-family: Georgia, Palatino, serif;
+  font-weight: 400;
+}
+h2 a.active, h2 a:active, h2 a.hover, h2 a:hover {
+  text-decoration: underline;
+  text-decoration-skip-ink: auto;
+}
+
+h3 {
+  font-style: normal;
+  line-height: 1.4;
+  font-size: 1.5rem;
+  font-size: min(max(1.25rem, 3vw), 1.5rem);
+  font-family: Georgia, Palatino, serif;
+  font-weight: 400;
+}
+h3 a.active, h3 a:active, h3 a.hover, h3 a:hover {
+  text-decoration: underline;
+  text-decoration-skip-ink: auto;
+}
+
+h4 {
+  font-style: normal;
+  line-height: 1.4;
+  font-size: 1.25rem;
+  font-size: min(max(1.125rem, 2.5vw), 1.25rem);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  font-weight: 700;
+}
+h4 a.active, h4 a:active, h4 a.hover, h4 a:hover {
+  text-decoration: underline;
+  text-decoration-skip-ink: auto;
+}
+
+h5,
+h6 {
+  font-style: normal;
+  line-height: 1.4;
+  font-size: 1.125rem;
+  font-size: min(max(1rem, 2.5vw), 1.125rem);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  font-weight: 700;
+}
+h5 a.active, h5 a:active, h5 a.hover, h5 a:hover,
+h6 a.active,
+h6 a:active,
+h6 a.hover,
+h6 a:hover {
+  text-decoration: underline;
+  text-decoration-skip-ink: auto;
+}
+
+/* Basic lists should be aligned to the left */
+ul:not([class]),
+ol:not([class]) {
+  /* Allow for bullet itself */
+  padding-left: 0.9em;
+}
+
+dd {
+  margin: 0;
+}
+
+cite {
+  font-style: normal;
+}
+
+* {
+  margin-block: 0;
+}
+
+:is(p, ol, ul, dl, figure, blockquote, form, pre, table, img, video, aside, section, article) + *,
+[class^=c-]:not([class*=__]) + * {
+  margin-block-start: 1rem;
+}
+
+* + :is(h2, h3, h4, h5) {
+  margin-block-start: 2rem;
+}
+
+:is(h3, h4, h5) + * {
+  margin-block-start: 0.5rem;
+}
+
+h2 + * {
+  margin-block-start: 1rem;
+}
+
+h1 + * {
+  margin-block-start: 3rem;
+}
+
+.c-forms__label,
+.c-forms__hint,
+.c-forms__error,
+.c-forms__legend {
+  display: block;
+}
+
+.c-forms__hint,
+.c-forms__error {
+  font-weight: normal;
+}
+
+.c-forms__input-container {
+  position: relative;
+}
+
+.c-forms__fieldset,
+.c-forms__error-summary,
+.c-forms__field,
+.c-forms__field * {
+  line-height: 1.4;
+}
+
+.c-forms__field,
+.c-forms__error-summary {
+  font-size: 1rem;
+}
+
+.c-forms__field small {
+  font-size: inherit;
+}
+
+.c-forms__fieldset,
+.c-forms__legend {
+  padding: 0;
+  border: 0;
+}
+
+.c-forms__error-summary,
+.c-forms__input-container,
+.c-forms__field {
+  max-width: 70ch;
+}
+
+.c-forms__inline-fields {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: var(--global-form-inline-gap, 0.5rem);
+}
+
+.c-forms__inline-fields--nowrap {
+  flex-wrap: nowrap;
+}
+
+.c-forms__inline-fields .c-forms__field--globalFormText {
+  /* ↓ Make it max out the available space with a super high value */
+  flex-grow: 666;
+}
+
+.c-forms__inline-fields .c-forms__input {
+  height: 100%;
+}
+
+.c-forms__pictographic-radios {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+@media only screen and (min-width: 320px) {
+  .c-forms__pictographic-radios {
+    flex-direction: row;
+  }
+  .c-forms__pictographic-radios .c-forms__label + .c-forms__label {
+    margin-top: 0;
+  }
+}
+* + .c-forms__error-summary,
+* + .c-forms__fieldset,
+* + .c-forms__field {
+  margin-top: 1.5rem;
+}
+
+.c-forms__inline-fields * {
+  margin: 0;
+}
+
+.c-forms__field .u-visually-hidden + * {
+  margin-top: 0;
+}
+
+.c-forms__legend * {
+  margin: 0;
+}
+
+.c-forms__input {
+  box-sizing: border-box;
+  border: 1px solid;
+  color: #000000;
+  width: 100%;
+  padding: 0.5rem 0.5rem;
+  background-color: #ffffff;
+  font-weight: 400;
+}
+
+* + .c-forms__input,
+* + .c-forms__input-container {
+  margin-top: 0.25rem;
+}
+
+.c-forms__input:focus {
+  outline: 3px solid #0088cc;
+}
+
+.c-forms__input[invalid] {
+  border-color: #c40606;
+  border-width: 2px;
+}
+
+.c-forms__input[disabled] {
+  cursor: not-allowed;
+  border-color: #dadada;
+}
+
+.c-forms__label {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #000000;
+  padding: 0;
+}
+
+.c-forms__label + .c-forms__label {
+  margin-top: 0.25rem;
+}
+
+.c-forms__hint {
+  font-weight: 400;
+  margin-top: 0.25rem;
+  color: #666666;
+}
+
+.c-forms__error {
+  color: #c40606;
+  display: flex;
+  align-items: flex-start;
+}
+
+label + .c-forms__error,
+.c-forms__error + label {
+  margin-top: 0.25rem;
+}
+
+.c-forms__error .c-forms__icon {
+  color: #c40606;
+}
+
+.c-forms__icon svg {
+  height: 1rem;
+  width: 1rem;
+  vertical-align: calc((0.5rem / 8) * -1);
+  overflow: visible;
+  pointer-events: none;
+}
+
+.c-forms__input--select {
+  cursor: pointer;
+  appearance: none;
+  padding-right: 1.5rem;
+}
+
+.c-forms__input-container--select .c-forms__icon {
+  position: absolute;
+  right: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+
+.c-forms__input--radio,
+.c-forms__input--checkbox,
+.c-form__label--visually-hidden {
+  /* hide visually, not to assistive tech */
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.c-forms__label--inline {
+  display: flex;
+  align-items: center;
+  font-weight: 400;
+  cursor: pointer;
+  padding: 0;
+}
+
+.c-forms__label--inline::before {
+  content: "";
+  flex-shrink: 0;
+  width: 1.5rem;
+  height: 1.5rem;
+  background-color: #ffffff;
+  border: 2px solid #999999;
+  margin-right: 0.5rem;
+}
+
+.c-forms__label--pictographic-radio {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 400;
+  cursor: pointer;
+}
+
+@media only screen and (min-width: 320px) {
+  .c-forms__label--pictographic-radio {
+    flex-direction: column;
+    justify-content: space-between;
+  }
+}
+.c-forms__label--pictographic-radio svg {
+  box-sizing: content-box;
+  flex: 0 0 auto;
+  width: var(--forms--pictographic-radio-icon-size, 4rem);
+  height: var(--forms--pictographic-radio-icon-size, 4rem);
+  fill: #ffffff;
+  stroke: #01324b;
+  background-color: #ffffff;
+}
+
+:checked + .c-forms__label--pictographic-radio svg {
+  fill: #01324b;
+  background-color: #01324b;
+  stroke: #ffffff;
+}
+
+.c-forms__label--boxed-icon svg {
+  padding: 0.5rem;
+  border: 2px solid #999999;
+}
+
+:checked + .c-forms__label--boxed-icon svg {
+  border-color: #ffffff;
+}
+
+:focus + .c-forms__label--pictographic-radio svg,
+.c-forms__label--pictographic-radio:hover svg {
+  box-shadow: 0 0 0 3px #0088cc;
+}
+
+:checked + .c-forms__label--inline::before {
+  border-color: #01324b;
+}
+
+:focus + .c-forms__label--inline::before {
+  box-shadow: 0 0 0 3px #0088cc;
+}
+
+.c-forms__label--radio::before {
+  border-radius: 50%;
+}
+
+.c-forms__label--checkbox::before {
+  border-radius: 0.125em;
+}
+
+[invalid] + .c-forms__label--checkbox::before {
+  border-color: #c40606;
+}
+
+:checked + .c-forms__label--radio::before {
+  background: radial-gradient(#01324b 0%, #01324b 40%, #fff 40%);
+}
+
+:checked + .c-forms__label--checkbox::before {
+  background-color: #01324b;
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" stroke-width="3" stroke="white" stroke-linejoin="round" fill="none" stroke-linecap="round" viewBox="0 0 20 20"><path d="M4.5,11 10,15 16,5"></path></svg>');
+  border-color: #01324b;
+  background-size: 100%;
+  background-repeat: none;
+  background-position: center;
+}
+
+.c-forms__sub-fields {
+  margin-top: 0.25rem;
+  margin-left: calc(1.5rem / 4);
+  padding-top: 1.5rem;
+  padding-left: 1.5rem;
+  position: relative;
+  display: none;
+}
+
+.c-forms__sub-fields::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: calc(1.5rem / 2);
+  background-color: #dadada;
+  border-radius: 4px;
+}
+
+:checked ~ .c-forms__sub-fields {
+  display: block;
+}
+
+.c-forms__error-summary {
+  background-color: #ffffff;
+  box-sizing: border-box;
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  color: #c40606;
+  border: 1px solid #dadada;
+  border-bottom: 4px solid #c40606;
+}
+
+.c-forms__error-summary .c-forms__icon svg {
+  width: 2rem;
+  height: 2rem;
+}
+
+.c-forms__error-summary-errors {
+  padding: 0;
+  margin-bottom: 0;
+  margin-top: 0.5rem;
+  list-style: none;
+}
+
+.c-forms__error-summary-errors a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.c-forms__error-summary-title {
+  color: initial;
+  font-weight: bold;
+}
+
+.c-forms__error-summary-errors li + li {
+  margin-top: 0.25rem;
+}
+
+html {
+  box-sizing: border-box;
+}
+
+* {
+  box-sizing: inherit;
+}
+
+.c-page-layout {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  min-height: 100vh;
+  grid-template-columns: 1fr;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  max-width: 1280px;
+}
+
+.c-page-layout__header,
+.c-page-layout__main,
+.c-page-layout__sidebar,
+.c-page-layout__footer {
+  border: 1px dashed #ccc;
+  min-height: 100px;
+  width: 100%;
+}
+
+.c-page-layout__container {
+  margin: 0 auto;
+  padding: 0 16px;
+}
+
+.c-page-layout__main {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 64px;
+}
+
+.c-page-layout__sidebar {
+  flex-grow: 1;
+  flex-basis: 454px;
+}
+
+.c-page-layout__main > :not(.c-page-layout__sidebar) {
+  flex-basis: 0;
+  flex-grow: 999;
+  min-width: 53%;
+}
+
+.c-customer-satisfaction-input {
+  padding: 16px;
+  background-color: #f3f3f3;
+  overflow: hidden;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+}
+
+.c-customer-satisfaction-input__container {
+  display: flex;
+  justify-content: center;
+}
+
+.c-customer-satisfaction-input__heading {
+  margin: 0 0 8px !important;
+  font-family: inherit !important;
+  font-size: 16px !important;
+  line-height: 1.4 !important;
+  font-weight: 700 !important;
+}
+
+.c-customer-satisfaction-input__submit-message div {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+}
+
+.c-customer-satisfaction-input__submit-message svg {
+  width: 24px;
+  height: 24px;
+  margin-right: 8px;
+}
+
+.c-customer-satisfaction-input__submit-message p {
+  margin: 0;
+  line-height: 1.4;
+  font-family: inherit;
+  font-size: 16px;
+}
+
+.c-customer-satisfaction-input__button {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: white;
+  border-radius: 32px;
+  border: 4px solid white;
+  box-shadow: 0 0 0 1px #01324b;
+  color: #01324b;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.3;
+  margin: 8px 0 0 0;
+  padding: 8px 16px;
+  text-decoration: none;
+  transition: all 0.2s;
+  width: 100%;
+}
+.c-customer-satisfaction-input__button:hover {
+  color: white;
+  background-color: #01324b;
+  border: 4px solid #01324b;
+  box-shadow: none;
+}
+.c-customer-satisfaction-input__button:focus {
+  border: 4px solid #ffcc00;
+  box-shadow: none;
+  outline: none;
+}
+
+.c-customer-satisfaction-input a {
+  display: inline-block;
+  margin-top: 8px;
+  font-family: inherit;
+  font-size: 16px;
+}
+
+.c-customer-satisfaction-input__visually-hidden,
+.c-customer-satisfaction-input legend.c-forms__label {
+  /* hide visually, not to assistive tech */
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+/* Override Global Forms Styles */
+.c-customer-satisfaction-input .c-forms__label--pictographic-radio svg {
+  width: 21px;
+  height: 21px;
+  padding: 6px;
+  border-radius: 2px;
+}
+
+.c-customer-satisfaction-input .c-forms__pictographic-radios {
+  gap: 5px;
+  justify-content: center;
+}
+
+.c-customer-satisfaction-input .c-forms__label {
+  font-family: inherit;
+  font-size: 12px;
+}
+
+@media only screen and (min-width: 540px) {
+  .c-customer-satisfaction-input .c-forms__label--pictographic-radio svg {
+    width: 24px;
+    height: 24px;
+    padding: 8px;
+  }
+  .c-customer-satisfaction-input .c-forms__pictographic-radios {
+    gap: 16px;
+  }
+  .c-customer-satisfaction-input .c-forms__label {
+    font-size: 14px;
+  }
+}
+.c-customer-satisfaction-input .c-forms__fieldset--pictographic-radios {
+  justify-content: center;
+}
+
+.c-customer-satisfaction-input .c-forms__label + .c-forms__label {
+  margin-top: 0;
+}
+
+.c-customer-satisfaction-input .c-forms__fieldset {
+  margin: 0;
+}
+
+.c-customer-satisfaction-input .c-forms__error {
+  display: none;
+  margin-bottom: 8px;
+}
+
+.c-customer-satisfaction-input--show-error .c-forms__error {
+  display: flex;
+}
+
+.u-display-none {
+  display: none;
+}
+
+/* hide from both screenreaders and browsers */
+.u-hide,
+.js .u-js-hide {
+  display: none;
+  visibility: hidden;
+}
+
+/* show to both screenreaders and browsers */
+.u-show,
+.js .u-js-show {
+  display: block;
+  visibility: visible;
+}
+
+.u-show-inline,
+.js .u-js-show-inline {
+  display: inline;
+  visibility: visible;
+}
+
+/* hide only visually, but have it available for screenreaders */
+.u-visually-hidden,
+.js .u-js-visually-hidden {
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  height: 1px;
+  margin: -100%;
+  overflow: hidden;
+  padding: 0;
+  position: absolute !important;
+  width: 1px;
+}
+.u-visually-hidden--off,
+.js .u-js-visually-hidden--off {
+  border: 0;
+  clip: initial;
+  height: auto;
+  margin: 0;
+  overflow: auto;
+  padding: 0;
+  position: relative;
+  width: auto;
+}
+
+/* make invisible but retain dimensions */
+.u-invisible {
+  visibility: hidden;
+}
+
+/* hide only the text, keep element visible */
+.u-hide-text,
+.js .u-js-hide-text {
+  text-indent: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  direction: ltr;
+  vertical-align: bottom;
+}
+
+/* hiding overflow */
+.u-hide-overflow {
+  overflow: hidden;
+}
+
+@media print {
+  .u-hide-print {
+    display: none;
+  }
+}
+/**
+ * media-query hiding
+ * intentionally avoids 'max' and 'range' to prevent bloat
+ */
+@media only screen and (min-width: 320px) {
+  .u-hide-at-xs,
+.js .u-js-hide-at-xs {
+    display: none;
+    visibility: hidden;
+  }
+  .u-show-at-xs,
+.js .u-js-show-at-xs {
+    display: block;
+    visibility: visible;
+  }
+}
+@media only screen and (min-width: 540px) {
+  .u-hide-at-sm,
+.js .u-js-hide-at-sm {
+    display: none;
+    visibility: hidden;
+  }
+  .u-show-at-sm,
+.js .u-js-show-at-sm {
+    display: block;
+    visibility: visible;
+  }
+}
+@media only screen and (min-width: 768px) {
+  .u-hide-at-md,
+.js .u-js-hide-at-md {
+    display: none;
+    visibility: hidden;
+  }
+  .u-show-at-md,
+.js .u-js-show-at-md {
+    display: block;
+    visibility: visible;
+  }
+}
+@media only screen and (min-width: 1024px) {
+  .u-hide-at-lg,
+.js .u-js-hide-at-lg {
+    display: none;
+    visibility: hidden;
+  }
+  .u-show-at-lg,
+.js .u-js-show-at-lg {
+    display: block;
+    visibility: visible;
+  }
+}
+@media only screen and (min-width: 1220px) {
+  .u-hide-at-xl,
+.js .u-js-hide-at-xl {
+    display: none;
+    visibility: hidden;
+  }
+  .u-show-at-xl,
+.js .u-js-show-at-xl {
+    display: block;
+    visibility: visible;
+  }
+}
+.u-ma-0 {
+  margin: 0;
+}
+
+.u-ma-2 {
+  margin: 2px;
+}
+
+.u-ma-4 {
+  margin: 4px;
+}
+
+.u-ma-8 {
+  margin: 8px;
+}
+
+.u-ma-16 {
+  margin: 16px;
+}
+
+.u-ma-24 {
+  margin: 24px;
+}
+
+.u-ma-32 {
+  margin: 32px;
+}
+
+.u-ma-48 {
+  margin: 48px;
+}
+
+.u-ma-64 {
+  margin: 64px;
+}
+
+.u-ma-auto {
+  margin: auto;
+}
+
+.u-mt-0 {
+  margin-top: 0;
+}
+
+.u-mt-2 {
+  margin-top: 2px;
+}
+
+.u-mt-4 {
+  margin-top: 4px;
+}
+
+.u-mt-8 {
+  margin-top: 8px;
+}
+
+.u-mt-16 {
+  margin-top: 16px;
+}
+
+.u-mt-24 {
+  margin-top: 24px;
+}
+
+.u-mt-32 {
+  margin-top: 32px;
+}
+
+.u-mt-48 {
+  margin-top: 48px;
+}
+
+.u-mt-64 {
+  margin-top: 64px;
+}
+
+.u-mt-auto {
+  margin-top: auto;
+}
+
+.u-mr-0 {
+  margin-right: 0;
+}
+
+.u-mr-2 {
+  margin-right: 2px;
+}
+
+.u-mr-4 {
+  margin-right: 4px;
+}
+
+.u-mr-8 {
+  margin-right: 8px;
+}
+
+.u-mr-16 {
+  margin-right: 16px;
+}
+
+.u-mr-24 {
+  margin-right: 24px;
+}
+
+.u-mr-32 {
+  margin-right: 32px;
+}
+
+.u-mr-48 {
+  margin-right: 48px;
+}
+
+.u-mr-64 {
+  margin-right: 64px;
+}
+
+.u-mr-auto {
+  margin-right: auto;
+}
+
+.u-mb-0 {
+  margin-bottom: 0;
+}
+
+.u-mb-2 {
+  margin-bottom: 2px;
+}
+
+.u-mb-4 {
+  margin-bottom: 4px;
+}
+
+.u-mb-8 {
+  margin-bottom: 8px;
+}
+
+.u-mb-16 {
+  margin-bottom: 16px;
+}
+
+.u-mb-24 {
+  margin-bottom: 24px;
+}
+
+.u-mb-32 {
+  margin-bottom: 32px;
+}
+
+.u-mb-48 {
+  margin-bottom: 48px;
+}
+
+.u-mb-64 {
+  margin-bottom: 64px;
+}
+
+.u-mb-auto {
+  margin-bottom: auto;
+}
+
+.u-ml-0 {
+  margin-left: 0;
+}
+
+.u-ml-2 {
+  margin-left: 2px;
+}
+
+.u-ml-4 {
+  margin-left: 4px;
+}
+
+.u-ml-8 {
+  margin-left: 8px;
+}
+
+.u-ml-16 {
+  margin-left: 16px;
+}
+
+.u-ml-24 {
+  margin-left: 24px;
+}
+
+.u-ml-32 {
+  margin-left: 32px;
+}
+
+.u-ml-48 {
+  margin-left: 48px;
+}
+
+.u-ml-64 {
+  margin-left: 64px;
+}
+
+.u-ml-auto {
+  margin-left: auto;
+}
+
+.u-pa-0 {
+  padding: 0;
+}
+
+.u-pa-2 {
+  padding: 2px;
+}
+
+.u-pa-4 {
+  padding: 4px;
+}
+
+.u-pa-8 {
+  padding: 8px;
+}
+
+.u-pa-16 {
+  padding: 16px;
+}
+
+.u-pa-24 {
+  padding: 24px;
+}
+
+.u-pa-32 {
+  padding: 32px;
+}
+
+.u-pa-48 {
+  padding: 48px;
+}
+
+.u-pa-64 {
+  padding: 64px;
+}
+
+.u-pt-0 {
+  padding-top: 0;
+}
+
+.u-pt-2 {
+  padding-top: 2px;
+}
+
+.u-pt-4 {
+  padding-top: 4px;
+}
+
+.u-pt-8 {
+  padding-top: 8px;
+}
+
+.u-pt-16 {
+  padding-top: 16px;
+}
+
+.u-pt-24 {
+  padding-top: 24px;
+}
+
+.u-pt-32 {
+  padding-top: 32px;
+}
+
+.u-pt-48 {
+  padding-top: 48px;
+}
+
+.u-pt-64 {
+  padding-top: 64px;
+}
+
+.u-pr-0 {
+  padding-right: 0;
+}
+
+.u-pr-2 {
+  padding-right: 2px;
+}
+
+.u-pr-4 {
+  padding-right: 4px;
+}
+
+.u-pr-8 {
+  padding-right: 8px;
+}
+
+.u-pr-16 {
+  padding-right: 16px;
+}
+
+.u-pr-24 {
+  padding-right: 24px;
+}
+
+.u-pr-32 {
+  padding-right: 32px;
+}
+
+.u-pr-48 {
+  padding-right: 48px;
+}
+
+.u-pr-64 {
+  padding-right: 64px;
+}
+
+.u-pb-0 {
+  padding-bottom: 0;
+}
+
+.u-pb-2 {
+  padding-bottom: 2px;
+}
+
+.u-pb-4 {
+  padding-bottom: 4px;
+}
+
+.u-pb-8 {
+  padding-bottom: 8px;
+}
+
+.u-pb-16 {
+  padding-bottom: 16px;
+}
+
+.u-pb-24 {
+  padding-bottom: 24px;
+}
+
+.u-pb-32 {
+  padding-bottom: 32px;
+}
+
+.u-pb-48 {
+  padding-bottom: 48px;
+}
+
+.u-pb-64 {
+  padding-bottom: 64px;
+}
+
+.u-pl-0 {
+  padding-left: 0;
+}
+
+.u-pl-2 {
+  padding-left: 2px;
+}
+
+.u-pl-4 {
+  padding-left: 4px;
+}
+
+.u-pl-8 {
+  padding-left: 8px;
+}
+
+.u-pl-16 {
+  padding-left: 16px;
+}
+
+.u-pl-24 {
+  padding-left: 24px;
+}
+
+.u-pl-32 {
+  padding-left: 32px;
+}
+
+.u-pl-48 {
+  padding-left: 48px;
+}
+
+.u-pl-64 {
+  padding-left: 64px;
+}
+		</style>
+	</head>
+	<body style="padding:2%">
+		<h1>Global Customer Satisfaction Input Demo</h1>
+<p>Below is a dummy page that demonstrates the page locations this component was designed for:</p>
+<div class="c-page-layout">
+	<div class="c-page-layout__header c-page-layout__container">
+		<header>
+			<h2>Header</h2>
+		</header>
+	</div>
+	<div class="c-page-layout__body c-page-layout__container">
+		<div class="c-page-layout__main">
+			<div class="c-page-layout__container">
+				<h1>Main content</h1>
+				<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut gravida scelerisque dolor, sit amet fermentum leo suscipit vel. Vivamus euismod scelerisque ex, in malesuada turpis sagittis mattis. Donec fringilla, lacus quis malesuada fermentum, mauris leo sodales dolor, id mollis mauris justo nec mi. Duis eget ullamcorper lectus. Maecenas dictum non metus ac suscipit. Sed congue aliquet dui sit amet bibendum. Suspendisse ac nisi condimentum, aliquet velit eu, tempor felis. Nunc viverra ornare massa, id rhoncus sem congue vitae. Fusce faucibus a metus nec molestie. Praesent metus augue, faucibus nec erat quis, tempor dapibus nulla. Integer viverra, neque malesuada facilisis porttitor, nisl ipsum pulvinar eros, lacinia commodo metus dui vitae quam. Phasellus tincidunt quis magna in laoreet.</p>
+				<p>Donec commodo placerat turpis, et aliquet neque aliquet id. Maecenas nibh libero, tristique ornare iaculis non, placerat a urna. Nulla eu pharetra ex. Nunc auctor sem et ligula imperdiet tincidunt. Donec ut neque posuere, tempus justo quis, iaculis neque. Pellentesque venenatis sapien eu quam tincidunt pretium. Ut sapien turpis, semper a urna quis, pulvinar eleifend lectus. Nulla sed diam molestie, mattis nibh volutpat, ultricies lectus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Duis ut ultricies nunc. Proin sed imperdiet nunc, non blandit turpis. Quisque eget nisi eget risus fringilla facilisis sit amet vitae odio.</p>
+				<p>Aliquam sed fermentum dui. Vestibulum vitae iaculis sem. Praesent porta tellus nibh. Aenean at ex id enim varius tincidunt. Etiam mi risus, ornare commodo augue vel, varius tempor neque. Mauris eget lectus imperdiet, sagittis mauris id, rutrum est. Nam eu aliquet ligula. Integer venenatis quam eget scelerisque finibus. Integer maximus massa ac mauris mattis elementum. Nulla a sagittis nisi. Suspendisse ac magna bibendum, bibendum ex a, bibendum neque. Integer ac venenatis quam, vel volutpat tellus. Phasellus dictum nunc in metus placerat, vel rutrum nibh sollicitudin. Duis vel scelerisque sapien, vitae molestie odio.</p>
+				<p>Vestibulum risus enim, rutrum vitae leo vel, luctus congue odio. Nam felis massa, volutpat sit amet sodales id, mattis quis dolor. Fusce feugiat diam vitae libero dapibus, ac suscipit velit bibendum. Praesent sodales ante justo, in dapibus mauris rhoncus efficitur. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Integer eu consectetur ante, id sagittis metus. Integer at fringilla mi, non suscipit velit.</p>
+					<aside class="u-hide u-js-show c-customer-satisfaction-input" data-customer-satisfaction-input="" data-customer-satisfaction-input-user-journeys="get published">
+						<div class="c-customer-satisfaction-input__container">
+							<form class="c-customer-satisfaction-input__form">
+								<h3 class="c-customer-satisfaction-input__heading">How was your experience today?</h3>
+									<div class="c-forms__fieldset">
+											<div class="c-forms__field c-forms__field--globalFormRadios">
+													<fieldset class="c-forms__fieldset c-forms__field c-forms__radios" id="customer-satisfaction-input-radios2" name="customer-satisfaction-input-radios" invalid="" aria-invalid="true" aria-describedby="error-customer-satisfaction-input-radios2" required="" aria-required="true" autocomplete="off">
+																<legend class="c-forms__label">Rating<span class="c-form__label--visually-hidden">. A scale of 5 feelings conveyed using images that range from awful to great. The feelings represent how you feel about your experience today.</span></legend>
+															<small class="c-forms__error" id="error-customer-satisfaction-input-radios2">
+																<span class="c-forms__icon c-forms__icon--error">
+																	<svg class="u-icon u-mr-4" width="22" height="22" aria-hidden="true" focusable="false">
+																		<svg id="i-error" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg"><path d="m9 0c4.9705627 0 9 4.02943725 9 9 0 4.9705627-4.0294373 9-9 9-4.97056275 0-9-4.0294373-9-9 0-4.97056275 4.02943725-9 9-9zm2.8630343 4.71100931-2.8630343 2.86303426-2.86303426-2.86303426c-.39658757-.39658757-1.03281091-.39438847-1.4265779-.00062147-.39651227.39651226-.39348876 1.03246767.00062147 1.4265779l2.86303426 2.86303426-2.86303426 2.8630343c-.39658757.3965875-.39438847 1.0328109-.00062147 1.4265779.39651226.3965122 1.03246767.3934887 1.4265779-.0006215l2.86303426-2.8630343 2.8630343 2.8630343c.3965875.3965876 1.0328109.3943885 1.4265779.0006215.3965122-.3965123.3934887-1.0324677-.0006215-1.4265779l-2.8630343-2.8630343 2.8630343-2.86303426c.3965876-.39658757.3943885-1.03281091.0006215-1.4265779-.3965123-.39651227-1.0324677-.39348876-1.4265779.00062147z" fill="currentColor" fill-rule="evenodd"></path></svg>
+																	</svg>
+																</span>
+																Please select one rating
+															</small>
+														<div class="c-forms__pictographic-radios">
+																<div class="c-forms__label c-forms__label--wrapper">
+																	<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-awful2" name="customer-satisfaction-input-radios" value="1" required="" aria-required="true" autocomplete="off" data-customer-satisfaction-input="radio">
+																		<label for="radio-awful2" class="c-forms__label c-forms__label--pictographic-radio c-forms__label--boxed-icon">
+																			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false"> <clipPath id="a"> <path d="M24 0v24H0V0z"></path> </clipPath> <g stroke-width="1.8" clip-path="url(#a)"> <path d="M12 22c5.5228475 0 10-4.4771525 10-10S17.5228475 2 12 2 2 6.4771525 2 12s4.4771525 10 10 10z" stroke-miterlimit="10"></path> <g stroke-linecap="round"> <path d="M8 17c.5-5.33333333 7.5-5.33333333 8 0z" stroke-linejoin="round"></path> <path d="m9 9-2 1M17 10l-2-1" stroke-miterlimit="10"></path> </g> </g></svg>
+																			<span class="c-form__label--visually-hidden">An image of a cartoon face that is very unhappy.</span>
+																			<span><span class="c-form__label--visually-hidden"> The value of this radio input is: </span>Awful</span>
+																		</label>
+																</div>
+																<div class="c-forms__label c-forms__label--wrapper">
+																	<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-bad2" name="customer-satisfaction-input-radios" value="2" required="" aria-required="true" autocomplete="off" data-customer-satisfaction-input="radio">
+																		<label for="radio-bad2" class="c-forms__label c-forms__label--pictographic-radio c-forms__label--boxed-icon">
+																			<svg xmlns="http://www.w3.org/2000/svg" fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false" viewBox="0 0 24 24"> <defs> <clipPath id="frowna2"> <path d="M24 0v24H0V0h24Z"></path> </clipPath> <clipPath id="frownb2"> <path d="M1 0c.6 0 1 .4 1 1v2a1 1 0 1 1-2 0V1c0-.6.4-1 1-1Z"></path> </clipPath> </defs> <g clip-path="url(#frowna2)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z"></path> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M9 17c1-2.7 5-2.7 6 0"></path> <g clip-path="url(#frownb2)" transform="translate(8 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> <g clip-path="url(#frownb2)" transform="translate(14 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> </g> </svg>
+																			<span class="c-form__label--visually-hidden">An image of a cartoon face with a frown.</span>
+																			<span><span class="c-form__label--visually-hidden"> The value of this radio input is: </span>Bad</span>
+																		</label>
+																</div>
+																<div class="c-forms__label c-forms__label--wrapper">
+																	<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-ok2" name="customer-satisfaction-input-radios" value="3" required="" aria-required="true" autocomplete="off" data-customer-satisfaction-input="radio">
+																		<label for="radio-ok2" class="c-forms__label c-forms__label--pictographic-radio c-forms__label--boxed-icon">
+																			<svg xmlns="http://www.w3.org/2000/svg" fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false" viewBox="0 0 24 24"> <defs> <clipPath id="neutrala2"> <path d="M24 0v24H0V0h24Z"></path> </clipPath> <clipPath id="neutralb2"> <path d="M1 0c.6 0 1 .4 1 1v2a1 1 0 1 1-2 0V1c0-.6.4-1 1-1Z"></path> </clipPath> </defs> <g clip-path="url(#neutrala2)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z"></path> <g clip-path="url(#neutralb2)" transform="translate(8 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> <g clip-path="url(#neutralb2)" transform="translate(14 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M9 16h6"></path> </g> </svg>
+																			<span class="c-form__label--visually-hidden">An image of a cartoon face with a neutral expression.</span>
+																			<span><span class="c-form__label--visually-hidden"> The value of this radio input is: </span>OK</span>
+																		</label>
+																</div>
+																<div class="c-forms__label c-forms__label--wrapper">
+																	<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-good2" name="customer-satisfaction-input-radios" value="4" required="" aria-required="true" autocomplete="off" data-customer-satisfaction-input="radio">
+																		<label for="radio-good2" class="c-forms__label c-forms__label--pictographic-radio c-forms__label--boxed-icon">
+																			<svg xmlns="http://www.w3.org/2000/svg" fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false" viewBox="0 0 24 24"> <defs> <clipPath id="smilea2"> <path d="M24 0v24H0V0h24Z"></path> </clipPath> <clipPath id="smileb2"> <path d="M1 0c.6 0 1 .4 1 1v2a1 1 0 1 1-2 0V1c0-.6.4-1 1-1Z"></path> </clipPath> </defs> <g clip-path="url(#smilea2)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z"></path> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M9 15c1 2.7 5 2.7 6 0"></path> <g clip-path="url(#smileb2)" transform="translate(8 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> <g clip-path="url(#smileb2)" transform="translate(14 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> </g> </svg>
+																			<span class="c-form__label--visually-hidden">An image of a cartoon face with a smile.</span>
+																			<span><span class="c-form__label--visually-hidden"> The value of this radio input is: </span>Good</span>
+																		</label>
+																</div>
+																<div class="c-forms__label c-forms__label--wrapper">
+																	<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-great2" name="customer-satisfaction-input-radios" value="5" required="" aria-required="true" autocomplete="off" data-customer-satisfaction-input="radio">
+																		<label for="radio-great2" class="c-forms__label c-forms__label--pictographic-radio c-forms__label--boxed-icon">
+																			<svg xmlns="http://www.w3.org/2000/svg" fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false" viewBox="0 0 24 24"> <defs> <clipPath id="grina2"> <path d="M24 0v24H0V0h24Z"></path> </clipPath> </defs> <g clip-path="url(#grina2)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z"></path> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M17.5 10v-.5a1.7 1.7 0 0 0-3.5 0v.5M10 10v-.5a1.7 1.7 0 0 0-3.5 0v.5M8 14c.5 5 7.5 5 8 0H8Z"></path> </g> </svg>
+																			<span class="c-form__label--visually-hidden">An image of a cartoon face with an open mouth grin.</span>
+																			<span><span class="c-form__label--visually-hidden"> The value of this radio input is: </span>Great</span>
+																		</label>
+																</div>
+														</div>
+													</fieldset>
+											</div>
+									</div>
+								<button class="c-customer-satisfaction-input__button" type="submit">Send feedback</button>
+								<div class="u-hide c-customer-satisfaction-input__submit-message" data-customer-satisfaction-input="submit-message">
+									<div>
+										<svg xmlns="http://www.w3.org/2000/svg" id="i-circle-tick" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="#00a79d"><path d="M10 0a10 10 0 1 0 0 20 10 10 0 0 0 0-20Z"></path><path d="M15 5.5a1 1 0 0 0-.8.4l-5.4 6-3.1-2.6a1 1 0 0 0-1.5.1 1 1 0 0 0 .2 1.5l3.9 3.4c.4.3 1 .3 1.4-.1l6-7c.4-.4.4-1 0-1.5a1 1 0 0 0-.8-.2Z" fill="#fff"></path></svg>
+										<p>Thank you for your feedback.</p>
+									</div>
+											<a href="https://www.surveymonkey.com/r/97W8JW7" data-customer-satisfaction-input="survey-link" target="_blank" rel="noopener">Tell us why (opens in a new tab)</a>
+								</div>
+							</form>
+						</div>
+					</aside>
+			</div>
+			<div class="c-page-layout__sidebar c-page-layout__container">
+				<h2>Sidebar content</h2>
+				<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam porta, nunc vel dignissim pulvinar, turpis sem sodales nibh, sed tincidunt quam dui ac lectus. Fusce tempor tempor elit, a finibus tellus vulputate non. In at felis vitae urna vestibulum gravida. Nam sed justo massa. Sed nec facilisis sem, sed eleifend.</p>
+				<p>Sed euismod libero in est dignissim placerat. Cras in ipsum sit amet diam malesuada convallis hendrerit vel tortor.</p>
+					<aside class="u-hide u-js-show c-customer-satisfaction-input" data-customer-satisfaction-input="" data-customer-satisfaction-input-user-journeys="get prepared to publish">
+						<div class="c-customer-satisfaction-input__container">
+							<form class="c-customer-satisfaction-input__form">
+								<h3 class="c-customer-satisfaction-input__heading">How was your experience today?</h3>
+									<div class="c-forms__fieldset">
+											<div class="c-forms__field c-forms__field--globalFormRadios">
+													<fieldset class="c-forms__fieldset c-forms__field c-forms__radios" id="customer-satisfaction-input-radios1" name="customer-satisfaction-input-radios" invalid="" aria-invalid="true" aria-describedby="error-customer-satisfaction-input-radios1" required="" aria-required="true" autocomplete="off">
+																<legend class="c-forms__label">Rating<span class="c-form__label--visually-hidden">. A scale of 5 feelings conveyed using images that range from awful to great. The feelings represent how you feel about your experience today.</span></legend>
+															<small class="c-forms__error" id="error-customer-satisfaction-input-radios1">
+																<span class="c-forms__icon c-forms__icon--error">
+																	<svg class="u-icon u-mr-4" width="22" height="22" aria-hidden="true" focusable="false">
+																		<svg id="i-error" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg"><path d="m9 0c4.9705627 0 9 4.02943725 9 9 0 4.9705627-4.0294373 9-9 9-4.97056275 0-9-4.0294373-9-9 0-4.97056275 4.02943725-9 9-9zm2.8630343 4.71100931-2.8630343 2.86303426-2.86303426-2.86303426c-.39658757-.39658757-1.03281091-.39438847-1.4265779-.00062147-.39651227.39651226-.39348876 1.03246767.00062147 1.4265779l2.86303426 2.86303426-2.86303426 2.8630343c-.39658757.3965875-.39438847 1.0328109-.00062147 1.4265779.39651226.3965122 1.03246767.3934887 1.4265779-.0006215l2.86303426-2.8630343 2.8630343 2.8630343c.3965875.3965876 1.0328109.3943885 1.4265779.0006215.3965122-.3965123.3934887-1.0324677-.0006215-1.4265779l-2.8630343-2.8630343 2.8630343-2.86303426c.3965876-.39658757.3943885-1.03281091.0006215-1.4265779-.3965123-.39651227-1.0324677-.39348876-1.4265779.00062147z" fill="currentColor" fill-rule="evenodd"></path></svg>
+																	</svg>
+																</span>
+																Please select one rating
+															</small>
+														<div class="c-forms__pictographic-radios">
+																<div class="c-forms__label c-forms__label--wrapper">
+																	<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-awful1" name="customer-satisfaction-input-radios" value="1" required="" aria-required="true" autocomplete="off" data-customer-satisfaction-input="radio">
+																		<label for="radio-awful1" class="c-forms__label c-forms__label--pictographic-radio c-forms__label--boxed-icon">
+																			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false"> <clipPath id="a"> <path d="M24 0v24H0V0z"></path> </clipPath> <g stroke-width="1.8" clip-path="url(#a)"> <path d="M12 22c5.5228475 0 10-4.4771525 10-10S17.5228475 2 12 2 2 6.4771525 2 12s4.4771525 10 10 10z" stroke-miterlimit="10"></path> <g stroke-linecap="round"> <path d="M8 17c.5-5.33333333 7.5-5.33333333 8 0z" stroke-linejoin="round"></path> <path d="m9 9-2 1M17 10l-2-1" stroke-miterlimit="10"></path> </g> </g></svg>
+																			<span class="c-form__label--visually-hidden">An image of a cartoon face that is very unhappy.</span>
+																			<span><span class="c-form__label--visually-hidden"> The value of this radio input is: </span>Awful</span>
+																		</label>
+																</div>
+																<div class="c-forms__label c-forms__label--wrapper">
+																	<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-bad1" name="customer-satisfaction-input-radios" value="2" required="" aria-required="true" autocomplete="off" data-customer-satisfaction-input="radio">
+																		<label for="radio-bad1" class="c-forms__label c-forms__label--pictographic-radio c-forms__label--boxed-icon">
+																			<svg xmlns="http://www.w3.org/2000/svg" fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false" viewBox="0 0 24 24"> <defs> <clipPath id="frowna"> <path d="M24 0v24H0V0h24Z"></path> </clipPath> <clipPath id="frownb"> <path d="M1 0c.6 0 1 .4 1 1v2a1 1 0 1 1-2 0V1c0-.6.4-1 1-1Z"></path> </clipPath> </defs> <g clip-path="url(#frowna)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z"></path> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M9 17c1-2.7 5-2.7 6 0"></path> <g clip-path="url(#frownb)" transform="translate(8 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> <g clip-path="url(#frownb)" transform="translate(14 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> </g> </svg>
+																			<span class="c-form__label--visually-hidden">An image of a cartoon face with a frown.</span>
+																			<span><span class="c-form__label--visually-hidden"> The value of this radio input is: </span>Bad</span>
+																		</label>
+																</div>
+																<div class="c-forms__label c-forms__label--wrapper">
+																	<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-ok1" name="customer-satisfaction-input-radios" value="3" required="" aria-required="true" autocomplete="off" data-customer-satisfaction-input="radio">
+																		<label for="radio-ok1" class="c-forms__label c-forms__label--pictographic-radio c-forms__label--boxed-icon">
+																			<svg xmlns="http://www.w3.org/2000/svg" fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false" viewBox="0 0 24 24"> <defs> <clipPath id="neutrala"> <path d="M24 0v24H0V0h24Z"></path> </clipPath> <clipPath id="neutralb"> <path d="M1 0c.6 0 1 .4 1 1v2a1 1 0 1 1-2 0V1c0-.6.4-1 1-1Z"></path> </clipPath> </defs> <g clip-path="url(#neutrala)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z"></path> <g clip-path="url(#neutralb)" transform="translate(8 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> <g clip-path="url(#neutralb)" transform="translate(14 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M9 16h6"></path> </g> </svg>
+																			<span class="c-form__label--visually-hidden">An image of a cartoon face with a neutral expression.</span>
+																			<span><span class="c-form__label--visually-hidden"> The value of this radio input is: </span>OK</span>
+																		</label>
+																</div>
+																<div class="c-forms__label c-forms__label--wrapper">
+																	<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-good1" name="customer-satisfaction-input-radios" value="4" required="" aria-required="true" autocomplete="off" data-customer-satisfaction-input="radio">
+																		<label for="radio-good1" class="c-forms__label c-forms__label--pictographic-radio c-forms__label--boxed-icon">
+																			<svg xmlns="http://www.w3.org/2000/svg" fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false" viewBox="0 0 24 24"> <defs> <clipPath id="smilea"> <path d="M24 0v24H0V0h24Z"></path> </clipPath> <clipPath id="smileb"> <path d="M1 0c.6 0 1 .4 1 1v2a1 1 0 1 1-2 0V1c0-.6.4-1 1-1Z"></path> </clipPath> </defs> <g clip-path="url(#smilea)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z"></path> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M9 15c1 2.7 5 2.7 6 0"></path> <g clip-path="url(#smileb)" transform="translate(8 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> <g clip-path="url(#smileb)" transform="translate(14 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> </g> </svg>
+																			<span class="c-form__label--visually-hidden">An image of a cartoon face with a smile.</span>
+																			<span><span class="c-form__label--visually-hidden"> The value of this radio input is: </span>Good</span>
+																		</label>
+																</div>
+																<div class="c-forms__label c-forms__label--wrapper">
+																	<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-great1" name="customer-satisfaction-input-radios" value="5" required="" aria-required="true" autocomplete="off" data-customer-satisfaction-input="radio">
+																		<label for="radio-great1" class="c-forms__label c-forms__label--pictographic-radio c-forms__label--boxed-icon">
+																			<svg xmlns="http://www.w3.org/2000/svg" fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false" viewBox="0 0 24 24"> <defs> <clipPath id="grina"> <path d="M24 0v24H0V0h24Z"></path> </clipPath> </defs> <g clip-path="url(#grina)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z"></path> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M17.5 10v-.5a1.7 1.7 0 0 0-3.5 0v.5M10 10v-.5a1.7 1.7 0 0 0-3.5 0v.5M8 14c.5 5 7.5 5 8 0H8Z"></path> </g> </svg>
+																			<span class="c-form__label--visually-hidden">An image of a cartoon face with an open mouth grin.</span>
+																			<span><span class="c-form__label--visually-hidden"> The value of this radio input is: </span>Great</span>
+																		</label>
+																</div>
+														</div>
+													</fieldset>
+											</div>
+									</div>
+								<button class="c-customer-satisfaction-input__button" type="submit">Send feedback</button>
+								<div class="u-hide c-customer-satisfaction-input__submit-message" data-customer-satisfaction-input="submit-message">
+									<div>
+										<svg xmlns="http://www.w3.org/2000/svg" id="i-circle-tick" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="#00a79d"><path d="M10 0a10 10 0 1 0 0 20 10 10 0 0 0 0-20Z"></path><path d="M15 5.5a1 1 0 0 0-.8.4l-5.4 6-3.1-2.6a1 1 0 0 0-1.5.1 1 1 0 0 0 .2 1.5l3.9 3.4c.4.3 1 .3 1.4-.1l6-7c.4-.4.4-1 0-1.5a1 1 0 0 0-.8-.2Z" fill="#fff"></path></svg>
+										<p>Thank you for your feedback.</p>
+									</div>
+											<a href="https://www.surveymonkey.com/r/97W8JW7" data-customer-satisfaction-input="survey-link" target="_blank" rel="noopener">Tell us why (opens in a new tab)</a>
+								</div>
+							</form>
+						</div>
+					</aside>
+			</div>
+		</div>
+	</div>
+		<aside class="u-hide u-js-show c-customer-satisfaction-input" data-customer-satisfaction-input="" data-customer-satisfaction-input-user-journeys="Get Prepared to Publish, Get Published" data-customer-satisfaction-input-additional-info="AB test version B">
+			<div class="c-customer-satisfaction-input__container">
+				<form class="c-customer-satisfaction-input__form">
+					<h3 class="c-customer-satisfaction-input__heading">How was your experience today?</h3>
+						<div class="c-forms__fieldset">
+								<div class="c-forms__field c-forms__field--globalFormRadios">
+										<fieldset class="c-forms__fieldset c-forms__field c-forms__radios" id="customer-satisfaction-input-radios3" name="customer-satisfaction-input-radios" invalid="" aria-invalid="true" aria-describedby="error-customer-satisfaction-input-radios3" required="" aria-required="true" autocomplete="off">
+													<legend class="c-forms__label">Rating<span class="c-form__label--visually-hidden">. A scale of 5 feelings conveyed using images that range from awful to great. The feelings represent how you feel about your experience today.</span></legend>
+												<small class="c-forms__error" id="error-customer-satisfaction-input-radios3">
+													<span class="c-forms__icon c-forms__icon--error">
+														<svg class="u-icon u-mr-4" width="22" height="22" aria-hidden="true" focusable="false">
+															<svg id="i-error" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg"><path d="m9 0c4.9705627 0 9 4.02943725 9 9 0 4.9705627-4.0294373 9-9 9-4.97056275 0-9-4.0294373-9-9 0-4.97056275 4.02943725-9 9-9zm2.8630343 4.71100931-2.8630343 2.86303426-2.86303426-2.86303426c-.39658757-.39658757-1.03281091-.39438847-1.4265779-.00062147-.39651227.39651226-.39348876 1.03246767.00062147 1.4265779l2.86303426 2.86303426-2.86303426 2.8630343c-.39658757.3965875-.39438847 1.0328109-.00062147 1.4265779.39651226.3965122 1.03246767.3934887 1.4265779-.0006215l2.86303426-2.8630343 2.8630343 2.8630343c.3965875.3965876 1.0328109.3943885 1.4265779.0006215.3965122-.3965123.3934887-1.0324677-.0006215-1.4265779l-2.8630343-2.8630343 2.8630343-2.86303426c.3965876-.39658757.3943885-1.03281091.0006215-1.4265779-.3965123-.39651227-1.0324677-.39348876-1.4265779.00062147z" fill="currentColor" fill-rule="evenodd"></path></svg>
+														</svg>
+													</span>
+													Please select one rating
+												</small>
+											<div class="c-forms__pictographic-radios">
+													<div class="c-forms__label c-forms__label--wrapper">
+														<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-awful3" name="customer-satisfaction-input-radios" value="1" required="" aria-required="true" autocomplete="off" data-customer-satisfaction-input="radio">
+															<label for="radio-awful3" class="c-forms__label c-forms__label--pictographic-radio c-forms__label--boxed-icon">
+																<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false"> <clipPath id="a"> <path d="M24 0v24H0V0z"></path> </clipPath> <g stroke-width="1.8" clip-path="url(#a)"> <path d="M12 22c5.5228475 0 10-4.4771525 10-10S17.5228475 2 12 2 2 6.4771525 2 12s4.4771525 10 10 10z" stroke-miterlimit="10"></path> <g stroke-linecap="round"> <path d="M8 17c.5-5.33333333 7.5-5.33333333 8 0z" stroke-linejoin="round"></path> <path d="m9 9-2 1M17 10l-2-1" stroke-miterlimit="10"></path> </g> </g></svg>
+																<span class="c-form__label--visually-hidden">An image of a cartoon face that is very unhappy.</span>
+																<span><span class="c-form__label--visually-hidden"> The value of this radio input is: </span>Awful</span>
+															</label>
+													</div>
+													<div class="c-forms__label c-forms__label--wrapper">
+														<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-bad3" name="customer-satisfaction-input-radios" value="2" required="" aria-required="true" autocomplete="off" data-customer-satisfaction-input="radio">
+															<label for="radio-bad3" class="c-forms__label c-forms__label--pictographic-radio c-forms__label--boxed-icon">
+																<svg xmlns="http://www.w3.org/2000/svg" fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false" viewBox="0 0 24 24"> <defs> <clipPath id="frowna3"> <path d="M24 0v24H0V0h24Z"></path> </clipPath> <clipPath id="frownb3"> <path d="M1 0c.6 0 1 .4 1 1v2a1 1 0 1 1-2 0V1c0-.6.4-1 1-1Z"></path> </clipPath> </defs> <g clip-path="url(#frowna3)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z"></path> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M9 17c1-2.7 5-2.7 6 0"></path> <g clip-path="url(#frownb3)" transform="translate(8 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="3" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> <g clip-path="url(#frownb3)" transform="translate(14 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="3" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> </g> </svg>
+																<span class="c-form__label--visually-hidden">An image of a cartoon face with a frown.</span>
+																<span><span class="c-form__label--visually-hidden"> The value of this radio input is: </span>Bad</span>
+															</label>
+													</div>
+													<div class="c-forms__label c-forms__label--wrapper">
+														<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-ok3" name="customer-satisfaction-input-radios" value="3" required="" aria-required="true" autocomplete="off" data-customer-satisfaction-input="radio">
+															<label for="radio-ok3" class="c-forms__label c-forms__label--pictographic-radio c-forms__label--boxed-icon">
+																<svg xmlns="http://www.w3.org/2000/svg" fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false" viewBox="0 0 24 24"> <defs> <clipPath id="neutrala3"> <path d="M24 0v24H0V0h24Z"></path> </clipPath> <clipPath id="neutralb3"> <path d="M1 0c.6 0 1 .4 1 1v2a1 1 0 1 1-2 0V1c0-.6.4-1 1-1Z"></path> </clipPath> </defs> <g clip-path="url(#neutrala3)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z"></path> <g clip-path="url(#neutralb3)" transform="translate(8 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="3" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> <g clip-path="url(#neutralb3)" transform="translate(14 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="3" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M9 16h6"></path> </g> </svg>
+																<span class="c-form__label--visually-hidden">An image of a cartoon face with a neutral expression.</span>
+																<span><span class="c-form__label--visually-hidden"> The value of this radio input is: </span>OK</span>
+															</label>
+													</div>
+													<div class="c-forms__label c-forms__label--wrapper">
+														<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-good3" name="customer-satisfaction-input-radios" value="4" required="" aria-required="true" autocomplete="off" data-customer-satisfaction-input="radio">
+															<label for="radio-good3" class="c-forms__label c-forms__label--pictographic-radio c-forms__label--boxed-icon">
+																<svg xmlns="http://www.w3.org/2000/svg" fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false" viewBox="0 0 24 24"> <defs> <clipPath id="smilea3"> <path d="M24 0v24H0V0h24Z"></path> </clipPath> <clipPath id="smileb3"> <path d="M1 0c.6 0 1 .4 1 1v2a1 1 0 1 1-2 0V1c0-.6.4-1 1-1Z"></path> </clipPath> </defs> <g clip-path="url(#smilea3)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z"></path> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M9 15c1 2.7 5 2.7 6 0"></path> <g clip-path="url(#smileb3)" transform="translate(8 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="3" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> <g clip-path="url(#smileb3)" transform="translate(14 8)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="3" stroke-linejoin="round" d="M0 0h2v4H0V0z"></path> </g> </g> </svg>
+																<span class="c-form__label--visually-hidden">An image of a cartoon face with a smile.</span>
+																<span><span class="c-form__label--visually-hidden"> The value of this radio input is: </span>Good</span>
+															</label>
+													</div>
+													<div class="c-forms__label c-forms__label--wrapper">
+														<input class="c-forms__input c-forms__input--radio" type="radio" id="radio-great3" name="customer-satisfaction-input-radios" value="5" required="" aria-required="true" autocomplete="off" data-customer-satisfaction-input="radio">
+															<label for="radio-great3" class="c-forms__label c-forms__label--pictographic-radio c-forms__label--boxed-icon">
+																<svg xmlns="http://www.w3.org/2000/svg" fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false" viewBox="0 0 24 24"> <defs> <clipPath id="grina3"> <path d="M24 0v24H0V0h24Z"></path> </clipPath> </defs> <g clip-path="url(#grina3)"> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z"></path> <path stroke-linecap="round" stroke-miterlimit="10" stroke-width="1.8" stroke-linejoin="round" d="M17.5 10v-.5a1.7 1.7 0 0 0-3.5 0v.5M10 10v-.5a1.7 1.7 0 0 0-3.5 0v.5M8 14c.5 5 7.5 5 8 0H8Z"></path> </g> </svg>
+																<span class="c-form__label--visually-hidden">An image of a cartoon face with an open mouth grin.</span>
+																<span><span class="c-form__label--visually-hidden"> The value of this radio input is: </span>Great</span>
+															</label>
+													</div>
+											</div>
+										</fieldset>
+								</div>
+						</div>
+					<button class="c-customer-satisfaction-input__button" type="submit">Send feedback</button>
+					<div class="u-hide c-customer-satisfaction-input__submit-message" data-customer-satisfaction-input="submit-message">
+						<div>
+							<svg xmlns="http://www.w3.org/2000/svg" id="i-circle-tick" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="#00a79d"><path d="M10 0a10 10 0 1 0 0 20 10 10 0 0 0 0-20Z"></path><path d="M15 5.5a1 1 0 0 0-.8.4l-5.4 6-3.1-2.6a1 1 0 0 0-1.5.1 1 1 0 0 0 .2 1.5l3.9 3.4c.4.3 1 .3 1.4-.1l6-7c.4-.4.4-1 0-1.5a1 1 0 0 0-.8-.2Z" fill="#fff"></path></svg>
+							<p>Thank you for your feedback.</p>
+						</div>
+								<a href="https://www.surveymonkey.com/r/97W8JW7" data-customer-satisfaction-input="survey-link" target="_blank" rel="noopener">Tell us why (opens in a new tab)</a>
+					</div>
+				</form>
+			</div>
+		</aside>
+	<div class="c-page-layout__footer c-page-layout__container">
+		<footer>
+			<h2>Footer</h2>
+		</footer>
+	</div>
+</div>
+<script>window.dataLayer=[{"foo":"bar"}]</script>
+
+		<script>
+			(function () {
+  'use strict';
+
+  function _classCallCheck(instance, Constructor) {
+    if (!(instance instanceof Constructor)) {
+      throw new TypeError("Cannot call a class as a function");
+    }
+  }
+
+  function _defineProperties(target, props) {
+    for (var i = 0; i < props.length; i++) {
+      var descriptor = props[i];
+      descriptor.enumerable = descriptor.enumerable || false;
+      descriptor.configurable = true;
+      if ("value" in descriptor) descriptor.writable = true;
+      Object.defineProperty(target, descriptor.key, descriptor);
+    }
+  }
+
+  function _createClass(Constructor, protoProps, staticProps) {
+    if (protoProps) _defineProperties(Constructor.prototype, protoProps);
+    if (staticProps) _defineProperties(Constructor, staticProps);
+    Object.defineProperty(Constructor, "prototype", {
+      writable: false
+    });
+    return Constructor;
+  }
+
+  var CustomerSatisfactionInput = /*#__PURE__*/function () {
+    function CustomerSatisfactionInput(aside) {
+      _classCallCheck(this, CustomerSatisfactionInput);
+
+      this._aside = aside;
+      this._form = this._aside.querySelector('form');
+      this._formRadioFieldset = this._form.querySelector('fieldset');
+      this._formRadios = Array.from(this._form.querySelectorAll('[data-customer-satisfaction-input="radio"]'));
+      this._surveyLink = this._form.querySelector('[data-customer-satisfaction-input="survey-link"]');
+      this._surveyLink.href = this._getSurveyLinkHref();
+      this._submitButton = this._form.querySelector('button[type="submit"]');
+      this._submitMessage = this._form.querySelector('[data-customer-satisfaction-input="submit-message"]');
+      this._permissibleUserJourneys = ['get prepared to publish', 'get published', 'discover relevant scholarly content', 'manage my editorial work', 'manage my peer reviews', 'promote my work', 'evaluate the performance of scholarly work', 'manage an apc', 'buy something', 'access what i am entitled to', 'librarian get the information i need', 'librarian assess the performance and use of my portfolio', 'librarian buy something'];
+
+      this._bindEvents();
+    }
+
+    _createClass(CustomerSatisfactionInput, [{
+      key: "_getCheckedRadioValue",
+      value: function _getCheckedRadioValue() {
+        return this._formRadios.find(function (element) {
+          return element.checked;
+        }).value;
+      }
+    }, {
+      key: "_getSurveyLinkHref",
+      value: function _getSurveyLinkHref() {
+        return this._surveyLink.href + '?location=' + window.location.href.split('?')[0];
+      }
+    }, {
+      key: "_getUserJourneys",
+      value: function _getUserJourneys() {
+        var _this = this;
+
+        if (!this._aside.dataset.customerSatisfactionInputUserJourneys) {
+          console.error('Attempt to send Global Customer Satisfaction Input event failed. Value not found for User Journeys.');
+          return;
+        }
+
+        var userJourneyStrings = this._aside.dataset.customerSatisfactionInputUserJourneys.split(',');
+
+        var sanitisedUserJourneyStrings = userJourneyStrings.map(function (string) {
+          return string.trim().toLowerCase();
+        });
+        var containsPermissibleUserJourneys = sanitisedUserJourneyStrings.every(function (string) {
+          return _this._permissibleUserJourneys.includes(string);
+        });
+
+        if (containsPermissibleUserJourneys) {
+          return sanitisedUserJourneyStrings.join(',');
+        }
+
+        console.error('Attempt to send Global Customer Satisfaction Input event failed. One or more of the user journeys provided are not permissible values.');
+        return false;
+      }
+    }, {
+      key: "_dispatchDataLayerEvent",
+      value: function _dispatchDataLayerEvent(radioValue) {
+        if (!window.dataLayer) {
+          console.error('Attempt to send Global Customer Satisfaction Input event failed. window.dataLayer does not exist.');
+          return;
+        }
+
+        var userJourneys = this._getUserJourneys();
+
+        if (userJourneys && radioValue) {
+          window.dataLayer.push({
+            // this event name corresponds to the GTM trigger setup for this solution
+            event: 'survey.track',
+            userJourneys: userJourneys,
+            radioValue: radioValue,
+            additionalInfo: this._aside.dataset.customerSatisfactionInputAdditionalInfo || null
+          });
+        }
+      }
+    }, {
+      key: "_displayMessage",
+      value: function _displayMessage() {
+        this._submitButton.classList.add('u-hide');
+
+        this._formRadioFieldset.classList.add('u-hide');
+
+        this._submitMessage.classList.remove('u-hide');
+      }
+    }, {
+      key: "_bindEvents",
+      value: function _bindEvents() {
+        var _this2 = this;
+
+        this._form.addEventListener('submit', function (event) {
+          event.preventDefault();
+          event.stopPropagation();
+        });
+
+        ['click', 'keydown'].forEach(function (eventType) {
+          _this2._submitButton.addEventListener(eventType, function (event) {
+            if (/Enter|Space/.test(event.key) || event.type === 'click') {
+              event.preventDefault();
+              event.stopPropagation();
+
+              var validForm = _this2._validateForm();
+
+              if (validForm) {
+                _this2._dispatchDataLayerEvent(_this2._getCheckedRadioValue());
+
+                _this2._displayMessage();
+
+                return;
+              }
+
+              _this2._displayError();
+            }
+          });
+        });
+      }
+    }, {
+      key: "_validateForm",
+      value: function _validateForm() {
+        return this._formRadios.some(function (element) {
+          return element.checked;
+        });
+      }
+    }, {
+      key: "_displayError",
+      value: function _displayError() {
+        if (this._form.classList.contains('c-customer-satisfaction-input--show-error')) {
+          return;
+        }
+
+        this._form.classList.add('c-customer-satisfaction-input--show-error');
+      }
+    }]);
+
+    return CustomerSatisfactionInput;
+  }();
+
+  var init = function init() {
+    var asides = document.querySelectorAll('aside[data-customer-satisfaction-input]');
+    asides.forEach(function (aside) {
+      /* eslint-disable no-new */
+      new CustomerSatisfactionInput(aside);
+      /* eslint-enable no-new */
+    });
+  };
+
+  init();
+
+})();
+
+		</script>
+	
+</body></html>

--- a/toolkits/global/packages/global-customer-satisfaction-input/demo/index.hbs
+++ b/toolkits/global/packages/global-customer-satisfaction-input/demo/index.hbs
@@ -1,0 +1,40 @@
+<h1>Global Customer Satisfaction Input Demo</h1>
+<p>Below is a dummy page that demonstrates the page locations this component was designed for:</p>
+<div class="c-page-layout">
+	<div class="c-page-layout__header c-page-layout__container">
+		<header>
+			<h2>Header</h2>
+		</header>
+	</div>
+	<div class="c-page-layout__body c-page-layout__container">
+		<div class="c-page-layout__main">
+			<div class="c-page-layout__container">
+				<h1>Main content</h1>
+				<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut gravida scelerisque dolor, sit amet fermentum leo suscipit vel. Vivamus euismod scelerisque ex, in malesuada turpis sagittis mattis. Donec fringilla, lacus quis malesuada fermentum, mauris leo sodales dolor, id mollis mauris justo nec mi. Duis eget ullamcorper lectus. Maecenas dictum non metus ac suscipit. Sed congue aliquet dui sit amet bibendum. Suspendisse ac nisi condimentum, aliquet velit eu, tempor felis. Nunc viverra ornare massa, id rhoncus sem congue vitae. Fusce faucibus a metus nec molestie. Praesent metus augue, faucibus nec erat quis, tempor dapibus nulla. Integer viverra, neque malesuada facilisis porttitor, nisl ipsum pulvinar eros, lacinia commodo metus dui vitae quam. Phasellus tincidunt quis magna in laoreet.</p>
+				<p>Donec commodo placerat turpis, et aliquet neque aliquet id. Maecenas nibh libero, tristique ornare iaculis non, placerat a urna. Nulla eu pharetra ex. Nunc auctor sem et ligula imperdiet tincidunt. Donec ut neque posuere, tempus justo quis, iaculis neque. Pellentesque venenatis sapien eu quam tincidunt pretium. Ut sapien turpis, semper a urna quis, pulvinar eleifend lectus. Nulla sed diam molestie, mattis nibh volutpat, ultricies lectus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Duis ut ultricies nunc. Proin sed imperdiet nunc, non blandit turpis. Quisque eget nisi eget risus fringilla facilisis sit amet vitae odio.</p>
+				<p>Aliquam sed fermentum dui. Vestibulum vitae iaculis sem. Praesent porta tellus nibh. Aenean at ex id enim varius tincidunt. Etiam mi risus, ornare commodo augue vel, varius tempor neque. Mauris eget lectus imperdiet, sagittis mauris id, rutrum est. Nam eu aliquet ligula. Integer venenatis quam eget scelerisque finibus. Integer maximus massa ac mauris mattis elementum. Nulla a sagittis nisi. Suspendisse ac magna bibendum, bibendum ex a, bibendum neque. Integer ac venenatis quam, vel volutpat tellus. Phasellus dictum nunc in metus placerat, vel rutrum nibh sollicitudin. Duis vel scelerisque sapien, vitae molestie odio.</p>
+				<p>Vestibulum risus enim, rutrum vitae leo vel, luctus congue odio. Nam felis massa, volutpat sit amet sodales id, mattis quis dolor. Fusce feugiat diam vitae libero dapibus, ac suscipit velit bibendum. Praesent sodales ante justo, in dapibus mauris rhoncus efficitur. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Integer eu consectetur ante, id sagittis metus. Integer at fringilla mi, non suscipit velit.</p>
+				{{#with customerSatisfactionInputData2}}
+					{{> customerSatisfactionInput }}
+				{{/with}}
+			</div>
+			<div class="c-page-layout__sidebar c-page-layout__container">
+				<h2>Sidebar content</h2>
+				<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam porta, nunc vel dignissim pulvinar, turpis sem sodales nibh, sed tincidunt quam dui ac lectus. Fusce tempor tempor elit, a finibus tellus vulputate non. In at felis vitae urna vestibulum gravida. Nam sed justo massa. Sed nec facilisis sem, sed eleifend.</p>
+				<p>Sed euismod libero in est dignissim placerat. Cras in ipsum sit amet diam malesuada convallis hendrerit vel tortor.</p>
+				{{#with customerSatisfactionInputData1}}
+					{{> customerSatisfactionInput }}
+				{{/with}}
+			</div>
+		</div>
+	</div>
+	{{#with customerSatisfactionInputData3}}
+		{{> customerSatisfactionInput }}
+	{{/with}}
+	<div class="c-page-layout__footer c-page-layout__container">
+		<footer>
+			<h2>Footer</h2>
+		</footer>
+	</div>
+</div>
+<script>window.dataLayer=[{"foo":"bar"}]</script>

--- a/toolkits/global/packages/global-customer-satisfaction-input/demo/main.js
+++ b/toolkits/global/packages/global-customer-satisfaction-input/demo/main.js
@@ -1,0 +1,3 @@
+import {customerSatisfactionInput} from '../js';
+
+customerSatisfactionInput();

--- a/toolkits/global/packages/global-customer-satisfaction-input/demo/main.scss
+++ b/toolkits/global/packages/global-customer-satisfaction-input/demo/main.scss
@@ -1,0 +1,18 @@
+@charset "UTF-8";
+
+@import '../node_modules/@springernature/brand-context/springer/scss/core.scss';
+@import '../node_modules/@springernature/brand-context/springer/scss/enhanced.scss';
+
+// Global Forms SCSS
+@import '../node_modules/@springernature/global-forms/scss/00-tokens/default.tokens.scss';
+@import '../node_modules/@springernature/global-forms/scss/50-components/forms';
+
+// Component SCSS
+@import '../scss/00-tokens/default.tokens.scss';
+@import '../scss/30-mixins/customer-satisfaction-input-button';
+@import './scss/demo-page-layout';
+@import '../scss/50-components/customer-satisfaction-input';
+
+// Global Utility SCSS
+@import '../node_modules/@springernature/brand-context/default/scss/60-utilities/hiding.scss';
+@import '../node_modules/@springernature/brand-context/default/scss/60-utilities/spacing.scss';

--- a/toolkits/global/packages/global-customer-satisfaction-input/demo/scss/_demo-page-layout.scss
+++ b/toolkits/global/packages/global-customer-satisfaction-input/demo/scss/_demo-page-layout.scss
@@ -1,0 +1,48 @@
+html {
+	box-sizing: border-box;
+}
+
+* {
+	box-sizing: inherit;
+}
+
+.c-page-layout {
+	display: grid;
+	grid-template-rows: auto 1fr auto;
+	min-height: 100vh;
+	grid-template-columns: 1fr;
+	background-color: #fff;
+	border: 1px solid #ccc;
+	max-width: 1280px;
+}
+
+.c-page-layout__header,
+.c-page-layout__main,
+.c-page-layout__sidebar,
+.c-page-layout__footer {
+	border: 1px dashed #ccc;
+	min-height: 100px;
+	width: 100%;
+}
+
+.c-page-layout__container {
+	margin: 0 auto;
+	padding: 0 16px;
+}
+
+.c-page-layout__main {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 64px;
+}
+
+.c-page-layout__sidebar {
+	flex-grow: 1;
+	flex-basis: 454px;
+}
+
+.c-page-layout__main > :not(.c-page-layout__sidebar) {
+	flex-basis: 0;
+	flex-grow: 999;
+	min-width: 53%;
+}

--- a/toolkits/global/packages/global-customer-satisfaction-input/js/customer-satisfaction-input.js
+++ b/toolkits/global/packages/global-customer-satisfaction-input/js/customer-satisfaction-input.js
@@ -1,0 +1,99 @@
+class CustomerSatisfactionInput {
+	constructor(aside) {
+		this._aside = aside;
+		this._form = this._aside.querySelector('form');
+		this._formRadioFieldset = this._form.querySelector('fieldset');
+		this._formRadios = Array.from(this._form.querySelectorAll('[data-customer-satisfaction-input="radio"]'));
+		this._surveyLink = this._form.querySelector('[data-customer-satisfaction-input="survey-link"]');
+		this._surveyLink.href = this._getSurveyLinkHref();
+		this._submitButton = this._form.querySelector('button[type="submit"]');
+		this._submitMessage = this._form.querySelector('[data-customer-satisfaction-input="submit-message"]');
+		this._permissibleUserJourneys = ['get prepared to publish', 'get published', 'discover relevant scholarly content', 'manage my editorial work', 'manage my peer reviews', 'promote my work', 'evaluate the performance of scholarly work', 'manage an apc', 'buy something', 'access what i am entitled to', 'librarian get the information i need', 'librarian assess the performance and use of my portfolio', 'librarian buy something'];
+		this._bindEvents();
+	}
+
+	_getCheckedRadioValue() {
+		return this._formRadios.find(element => element.checked).value;
+	}
+
+	_getSurveyLinkHref() {
+		return this._surveyLink.href + '?location=' + window.location.href.split('?')[0];
+	}
+
+	_getUserJourneys() {
+		if (!this._aside.dataset.customerSatisfactionInputUserJourneys) {
+			console.error('Attempt to send Global Customer Satisfaction Input event failed. Value not found for User Journeys.');
+			return;
+		}
+		const userJourneyStrings = this._aside.dataset.customerSatisfactionInputUserJourneys.split(',');
+		const sanitisedUserJourneyStrings = userJourneyStrings.map(string => string.trim().toLowerCase());
+		const containsPermissibleUserJourneys = sanitisedUserJourneyStrings.every(string => {
+			return this._permissibleUserJourneys.includes(string);
+		});
+		if (containsPermissibleUserJourneys) {
+			return sanitisedUserJourneyStrings.join(',');
+		}
+		console.error('Attempt to send Global Customer Satisfaction Input event failed. One or more of the user journeys provided are not permissible values.');
+		return false;
+	}
+
+	_dispatchDataLayerEvent(radioValue) {
+		if (!window.dataLayer) {
+			console.error('Attempt to send Global Customer Satisfaction Input event failed. window.dataLayer does not exist.');
+			return;
+		}
+		const userJourneys = this._getUserJourneys();
+		if (userJourneys && radioValue) {
+			window.dataLayer.push({
+				// this event name corresponds to the GTM trigger setup for this solution
+				event: 'survey.track',
+				userJourneys: userJourneys,
+				radioValue: radioValue,
+				additionalInfo: this._aside.dataset.customerSatisfactionInputAdditionalInfo || null
+			});
+		}
+	}
+
+	_displayMessage() {
+		this._submitButton.classList.add('u-hide');
+		this._formRadioFieldset.classList.add('u-hide');
+		this._submitMessage.classList.remove('u-hide');
+	}
+
+	_bindEvents() {
+		this._form.addEventListener('submit', event => {
+			event.preventDefault();
+			event.stopPropagation();
+		});
+		['click', 'keydown'].forEach(eventType => {
+			this._submitButton.addEventListener(eventType, event => {
+				if (/Enter|Space/.test(event.key) || event.type === 'click') {
+					event.preventDefault();
+					event.stopPropagation();
+					const validForm = this._validateForm();
+					if (validForm) {
+						this._dispatchDataLayerEvent(this._getCheckedRadioValue());
+						this._displayMessage();
+						return;
+					}
+					this._displayError();
+				}
+			});
+		});
+	}
+
+	_validateForm() {
+		return this._formRadios.some(element => {
+			return element.checked;
+		});
+	}
+
+	_displayError() {
+		if (this._form.classList.contains('c-customer-satisfaction-input--show-error')) {
+			return;
+		}
+		this._form.classList.add('c-customer-satisfaction-input--show-error');
+	}
+}
+
+export {CustomerSatisfactionInput};

--- a/toolkits/global/packages/global-customer-satisfaction-input/js/index.js
+++ b/toolkits/global/packages/global-customer-satisfaction-input/js/index.js
@@ -1,0 +1,14 @@
+import {CustomerSatisfactionInput} from './customer-satisfaction-input';
+
+const init = () => {
+	const asides = document.querySelectorAll('aside[data-customer-satisfaction-input]');
+
+	asides.forEach(aside => {
+		/* eslint-disable no-new */
+		new CustomerSatisfactionInput(aside);
+		/* eslint-enable no-new */
+	});
+};
+
+export {init as customerSatisfactionInput};
+

--- a/toolkits/global/packages/global-customer-satisfaction-input/package.json
+++ b/toolkits/global/packages/global-customer-satisfaction-input/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@springernature/global-customer-satisfaction-input",
+  "version": "0.0.1",
+  "license": "MIT",
+  "description": "HTML form based component for gathering customer satisfaction data",
+  "keywords": [],
+  "author": "Springer Nature",
+  "brandContext": "^30.0.4",
+  "dependencies": {
+    "@springernature/global-forms": "^5.0.0"
+  }
+}

--- a/toolkits/global/packages/global-customer-satisfaction-input/package.json
+++ b/toolkits/global/packages/global-customer-satisfaction-input/package.json
@@ -5,7 +5,7 @@
   "description": "HTML form based component for gathering customer satisfaction data",
   "keywords": [],
   "author": "Springer Nature",
-  "brandContext": "^30.0.4",
+  "brandContext": "^29.0.3",
   "dependencies": {
     "@springernature/global-forms": "^5.0.0"
   }

--- a/toolkits/global/packages/global-customer-satisfaction-input/scss/00-tokens/_default.tokens.scss
+++ b/toolkits/global/packages/global-customer-satisfaction-input/scss/00-tokens/_default.tokens.scss
@@ -1,26 +1,26 @@
-// Generated on 10/31/2022, 12:54:00 PM
-// Source: design-tokens/componenets/global/global-ratings-survey/default.json
+// Generated on 12/01/2022, 16:04:00 PM
+// Source: design-tokens/components/global/global-customer-satisfaction-input/default.json
 // DO NOT edit directly
 
-$global-ratings-survey-container-background-color: #f3f3f3;
-$global-ratings-survey-container-padding: 16px;
-$global-ratings-survey-error-margin: 8px;
-$global-ratings-survey-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
-$global-ratings-survey-heading-font-size: 16px;
-$global-ratings-survey-heading-font-weight: 700;
-$global-ratings-survey-heading-margin: 8px;
-$global-ratings-survey-line-height: 1.4;
-$global-ratings-survey-link-font-size: 16px;
-$global-ratings-survey-link-margin: 8px;
-$global-ratings-survey-message-font-size: 16px;
-$global-ratings-survey-message-icon-margin: 8px;
-$global-ratings-survey-message-icon-size: 24px;
-$global-ratings-survey-radio-icon-border-radius: 2px;
-$global-ratings-survey-radio-icon-size-desktop: 24px;
-$global-ratings-survey-radio-icon-size-narrow: 21px;
-$global-ratings-survey-radio-icon-spacing-desktop: 8px;
-$global-ratings-survey-radio-icon-spacing-narrow: 6px;
-$global-ratings-survey-radio-label-font-size-desktop: 14px;
-$global-ratings-survey-radio-label-font-size-narrow: 12px;
-$global-ratings-survey-radio-spacing-desktop: 16px;
-$global-ratings-survey-radio-spacing-narrow: 5px;
+$global-customer-satisfaction-input-container-background-color: #f3f3f3;
+$global-customer-satisfaction-input-container-padding: 16px;
+$global-customer-satisfaction-input-error-margin: 8px;
+$global-customer-satisfaction-input-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+$global-customer-satisfaction-input-heading-font-size: 16px;
+$global-customer-satisfaction-input-heading-font-weight: 700;
+$global-customer-satisfaction-input-heading-margin: 8px;
+$global-customer-satisfaction-input-line-height: 1.4;
+$global-customer-satisfaction-input-link-font-size: 16px;
+$global-customer-satisfaction-input-link-margin: 8px;
+$global-customer-satisfaction-input-message-font-size: 16px;
+$global-customer-satisfaction-input-message-icon-margin: 8px;
+$global-customer-satisfaction-input-message-icon-size: 24px;
+$global-customer-satisfaction-input-radio-icon-border-radius: 2px;
+$global-customer-satisfaction-input-radio-icon-size-desktop: 24px;
+$global-customer-satisfaction-input-radio-icon-size-narrow: 21px;
+$global-customer-satisfaction-input-radio-icon-spacing-desktop: 8px;
+$global-customer-satisfaction-input-radio-icon-spacing-narrow: 6px;
+$global-customer-satisfaction-input-radio-label-font-size-desktop: 14px;
+$global-customer-satisfaction-input-radio-label-font-size-narrow: 12px;
+$global-customer-satisfaction-input-radio-spacing-desktop: 16px;
+$global-customer-satisfaction-input-radio-spacing-narrow: 5px;

--- a/toolkits/global/packages/global-customer-satisfaction-input/scss/00-tokens/_default.tokens.scss
+++ b/toolkits/global/packages/global-customer-satisfaction-input/scss/00-tokens/_default.tokens.scss
@@ -1,0 +1,26 @@
+// Generated on 10/31/2022, 12:54:00 PM
+// Source: design-tokens/componenets/global/global-ratings-survey/default.json
+// DO NOT edit directly
+
+$global-ratings-survey-container-background-color: #f3f3f3;
+$global-ratings-survey-container-padding: 16px;
+$global-ratings-survey-error-margin: 8px;
+$global-ratings-survey-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+$global-ratings-survey-heading-font-size: 16px;
+$global-ratings-survey-heading-font-weight: 700;
+$global-ratings-survey-heading-margin: 8px;
+$global-ratings-survey-line-height: 1.4;
+$global-ratings-survey-link-font-size: 16px;
+$global-ratings-survey-link-margin: 8px;
+$global-ratings-survey-message-font-size: 16px;
+$global-ratings-survey-message-icon-margin: 8px;
+$global-ratings-survey-message-icon-size: 24px;
+$global-ratings-survey-radio-icon-border-radius: 2px;
+$global-ratings-survey-radio-icon-size-desktop: 24px;
+$global-ratings-survey-radio-icon-size-narrow: 21px;
+$global-ratings-survey-radio-icon-spacing-desktop: 8px;
+$global-ratings-survey-radio-icon-spacing-narrow: 6px;
+$global-ratings-survey-radio-label-font-size-desktop: 14px;
+$global-ratings-survey-radio-label-font-size-narrow: 12px;
+$global-ratings-survey-radio-spacing-desktop: 16px;
+$global-ratings-survey-radio-spacing-narrow: 5px;

--- a/toolkits/global/packages/global-customer-satisfaction-input/scss/30-mixins/_customer-satisfaction-input-button.scss
+++ b/toolkits/global/packages/global-customer-satisfaction-input/scss/30-mixins/_customer-satisfaction-input-button.scss
@@ -1,0 +1,35 @@
+// October 2022: Temporary mixin, to be removed once button styles in Elements have been refactored. Unable to use existing button styles in Elements because there is not one type of button that is satisfactory across all imprints for this component.
+
+@mixin global-customer-satisfaction-input-button {
+	position: relative;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	background-color: white;
+	border-radius: 32px;
+	border: 4px solid white;
+	box-shadow: 0 0 0 1px #01324b;
+	color: #01324b;
+	cursor: pointer;
+	font-size: 14px;
+	font-weight: 700;
+	line-height: 1.3;
+	margin: 8px 0 0 0;
+	padding: 8px 16px;
+	text-decoration: none;
+	transition: all 0.2s;
+	width: 100%;
+
+	&:hover {
+		color: white;
+		background-color: #01324b;
+		border: 4px solid #01324b;
+		box-shadow: none;
+	}
+
+	&:focus {
+		border: 4px solid #ffcc00;
+		box-shadow: none;
+		outline: none;
+	}
+}

--- a/toolkits/global/packages/global-customer-satisfaction-input/scss/50-components/_customer-satisfaction-input.scss
+++ b/toolkits/global/packages/global-customer-satisfaction-input/scss/50-components/_customer-satisfaction-input.scss
@@ -1,8 +1,8 @@
 .c-customer-satisfaction-input {
-	padding: $global-ratings-survey-container-padding;
-	background-color: $global-ratings-survey-container-background-color;
+	padding: $global-customer-satisfaction-input-container-padding;
+	background-color: $global-customer-satisfaction-input-container-background-color;
 	overflow: hidden;
-	font-family: $global-ratings-survey-font-family;
+	font-family: $global-customer-satisfaction-input-font-family;
 }
 
 .c-customer-satisfaction-input__container {
@@ -12,11 +12,11 @@
 
 // !important used to ensure overrides heading styles on all of our imprint sites
 .c-customer-satisfaction-input__heading {
-	margin: 0 0 $global-ratings-survey-heading-margin !important;
+	margin: 0 0 $global-customer-satisfaction-input-heading-margin !important;
 	font-family: inherit !important;
-	font-size: $global-ratings-survey-heading-font-size !important;
-	line-height: $global-ratings-survey-line-height !important;
-	font-weight: $global-ratings-survey-heading-font-weight !important;
+	font-size: $global-customer-satisfaction-input-heading-font-size !important;
+	line-height: $global-customer-satisfaction-input-line-height !important;
+	font-weight: $global-customer-satisfaction-input-heading-font-weight !important;
 }
 
 .c-customer-satisfaction-input__submit-message div {
@@ -26,16 +26,16 @@
 }
 
 .c-customer-satisfaction-input__submit-message svg {
-	width: $global-ratings-survey-message-icon-size;
-	height: $global-ratings-survey-message-icon-size;
-	margin-right: $global-ratings-survey-message-icon-margin;
+	width: $global-customer-satisfaction-input-message-icon-size;
+	height: $global-customer-satisfaction-input-message-icon-size;
+	margin-right: $global-customer-satisfaction-input-message-icon-margin;
 }
 
 .c-customer-satisfaction-input__submit-message p {
 	margin: 0;
-	line-height: $global-ratings-survey-line-height;
+	line-height: $global-customer-satisfaction-input-line-height;
 	font-family: inherit;
-	font-size: $global-ratings-survey-message-font-size;
+	font-size: $global-customer-satisfaction-input-message-font-size;
 }
 
 .c-customer-satisfaction-input__button {
@@ -45,9 +45,9 @@
 
 .c-customer-satisfaction-input a {
 	display: inline-block;
-	margin-top: $global-ratings-survey-link-margin;
+	margin-top: $global-customer-satisfaction-input-link-margin;
 	font-family: inherit;
-	font-size: $global-ratings-survey-message-font-size;
+	font-size: $global-customer-satisfaction-input-message-font-size;
 }
 
 .c-customer-satisfaction-input__visually-hidden,
@@ -63,35 +63,35 @@
 
 /* Override Global Forms Styles */
 .c-customer-satisfaction-input .c-forms__label--pictographic-radio svg {
-	width: $global-ratings-survey-radio-icon-size-narrow;
-	height: $global-ratings-survey-radio-icon-size-narrow;
-	padding: $global-ratings-survey-radio-icon-spacing-narrow;
-	border-radius: $global-ratings-survey-radio-icon-border-radius;
+	width: $global-customer-satisfaction-input-radio-icon-size-narrow;
+	height: $global-customer-satisfaction-input-radio-icon-size-narrow;
+	padding: $global-customer-satisfaction-input-radio-icon-spacing-narrow;
+	border-radius: $global-customer-satisfaction-input-radio-icon-border-radius;
 }
 
 .c-customer-satisfaction-input .c-forms__pictographic-radios {
-	gap: $global-ratings-survey-radio-spacing-narrow;
+	gap: $global-customer-satisfaction-input-radio-spacing-narrow;
 	justify-content: center;
 }
 
 .c-customer-satisfaction-input .c-forms__label {
 	font-family: inherit;
-	font-size: $global-ratings-survey-radio-label-font-size-narrow;
+	font-size: $global-customer-satisfaction-input-radio-label-font-size-narrow;
 }
 
 @include media-query('sm') {
 	.c-customer-satisfaction-input .c-forms__label--pictographic-radio svg {
-		width: $global-ratings-survey-radio-icon-size-desktop;
-		height: $global-ratings-survey-radio-icon-size-desktop;
-		padding: $global-ratings-survey-radio-icon-spacing-desktop;
+		width: $global-customer-satisfaction-input-radio-icon-size-desktop;
+		height: $global-customer-satisfaction-input-radio-icon-size-desktop;
+		padding: $global-customer-satisfaction-input-radio-icon-spacing-desktop;
 	}
 
 	.c-customer-satisfaction-input .c-forms__pictographic-radios {
-		gap: $global-ratings-survey-radio-spacing-desktop;
+		gap: $global-customer-satisfaction-input-radio-spacing-desktop;
 	}
 
 	.c-customer-satisfaction-input .c-forms__label {
-		font-size: $global-ratings-survey-radio-label-font-size-desktop;
+		font-size: $global-customer-satisfaction-input-radio-label-font-size-desktop;
 	}
 }
 
@@ -109,7 +109,7 @@
 
 .c-customer-satisfaction-input .c-forms__error {
 	display: none;
-	margin-bottom: $global-ratings-survey-error-margin;
+	margin-bottom: $global-customer-satisfaction-input-error-margin;
 }
 
 .c-customer-satisfaction-input--show-error .c-forms__error {

--- a/toolkits/global/packages/global-customer-satisfaction-input/scss/50-components/_customer-satisfaction-input.scss
+++ b/toolkits/global/packages/global-customer-satisfaction-input/scss/50-components/_customer-satisfaction-input.scss
@@ -1,0 +1,117 @@
+.c-customer-satisfaction-input {
+	padding: $global-ratings-survey-container-padding;
+	background-color: $global-ratings-survey-container-background-color;
+	overflow: hidden;
+	font-family: $global-ratings-survey-font-family;
+}
+
+.c-customer-satisfaction-input__container {
+	display: flex;
+	justify-content: center;
+}
+
+// !important used to ensure overrides heading styles on all of our imprint sites
+.c-customer-satisfaction-input__heading {
+	margin: 0 0 $global-ratings-survey-heading-margin !important;
+	font-family: inherit !important;
+	font-size: $global-ratings-survey-heading-font-size !important;
+	line-height: $global-ratings-survey-line-height !important;
+	font-weight: $global-ratings-survey-heading-font-weight !important;
+}
+
+.c-customer-satisfaction-input__submit-message div {
+	display: flex;
+	justify-content: flex-start;
+	align-items: center;
+}
+
+.c-customer-satisfaction-input__submit-message svg {
+	width: $global-ratings-survey-message-icon-size;
+	height: $global-ratings-survey-message-icon-size;
+	margin-right: $global-ratings-survey-message-icon-margin;
+}
+
+.c-customer-satisfaction-input__submit-message p {
+	margin: 0;
+	line-height: $global-ratings-survey-line-height;
+	font-family: inherit;
+	font-size: $global-ratings-survey-message-font-size;
+}
+
+.c-customer-satisfaction-input__button {
+	// TODO: Remove this mixin and replace with Brand Context button styles once work to improve them has been carried out
+	@include global-customer-satisfaction-input-button;
+}
+
+.c-customer-satisfaction-input a {
+	display: inline-block;
+	margin-top: $global-ratings-survey-link-margin;
+	font-family: inherit;
+	font-size: $global-ratings-survey-message-font-size;
+}
+
+.c-customer-satisfaction-input__visually-hidden,
+.c-customer-satisfaction-input legend.c-forms__label {
+	/* hide visually, not to assistive tech */
+	clip-path: inset(50%);
+	height: 1px;
+	overflow: hidden;
+	position: absolute;
+	white-space: nowrap;
+	width: 1px;
+}
+
+/* Override Global Forms Styles */
+.c-customer-satisfaction-input .c-forms__label--pictographic-radio svg {
+	width: $global-ratings-survey-radio-icon-size-narrow;
+	height: $global-ratings-survey-radio-icon-size-narrow;
+	padding: $global-ratings-survey-radio-icon-spacing-narrow;
+	border-radius: $global-ratings-survey-radio-icon-border-radius;
+}
+
+.c-customer-satisfaction-input .c-forms__pictographic-radios {
+	gap: $global-ratings-survey-radio-spacing-narrow;
+	justify-content: center;
+}
+
+.c-customer-satisfaction-input .c-forms__label {
+	font-family: inherit;
+	font-size: $global-ratings-survey-radio-label-font-size-narrow;
+}
+
+@include media-query('sm') {
+	.c-customer-satisfaction-input .c-forms__label--pictographic-radio svg {
+		width: $global-ratings-survey-radio-icon-size-desktop;
+		height: $global-ratings-survey-radio-icon-size-desktop;
+		padding: $global-ratings-survey-radio-icon-spacing-desktop;
+	}
+
+	.c-customer-satisfaction-input .c-forms__pictographic-radios {
+		gap: $global-ratings-survey-radio-spacing-desktop;
+	}
+
+	.c-customer-satisfaction-input .c-forms__label {
+		font-size: $global-ratings-survey-radio-label-font-size-desktop;
+	}
+}
+
+.c-customer-satisfaction-input .c-forms__fieldset--pictographic-radios {
+	justify-content: center;
+}
+
+.c-customer-satisfaction-input .c-forms__label + .c-forms__label {
+	margin-top: 0;
+}
+
+.c-customer-satisfaction-input .c-forms__fieldset {
+	margin: 0;
+}
+
+.c-customer-satisfaction-input .c-forms__error {
+	display: none;
+	margin-bottom: $global-ratings-survey-error-margin;
+}
+
+.c-customer-satisfaction-input--show-error .c-forms__error {
+	display: flex;
+}

--- a/toolkits/global/packages/global-customer-satisfaction-input/view/customerSatisfactionInput.hbs
+++ b/toolkits/global/packages/global-customer-satisfaction-input/view/customerSatisfactionInput.hbs
@@ -1,0 +1,24 @@
+<aside class="u-hide u-js-show c-customer-satisfaction-input" data-customer-satisfaction-input=""
+	   data-customer-satisfaction-input-user-journeys="{{userJourneys}}"
+	   {{#if additionalInfo}}data-customer-satisfaction-input-additional-info="{{additionalInfo}}"{{/if}}>
+	<div class="c-customer-satisfaction-input__container">
+		<form class="c-customer-satisfaction-input__form">
+			<h{{headingLevel}} class="c-customer-satisfaction-input__heading">How was your experience today?</h{{headingLevel}}>
+			{{#with globalFormData}}
+				{{> globalFormFieldset }}
+			{{/with}}
+			<button class="c-customer-satisfaction-input__button" type="submit">Send feedback</button>
+			<div class="u-hide c-customer-satisfaction-input__submit-message" data-customer-satisfaction-input="submit-message">
+				<div>
+					<svg xmlns="http://www.w3.org/2000/svg" id="i-circle-tick" viewBox="0 0 20 20" aria-hidden="true" focusable="false" fill="#00a79d"><path d="M10 0a10 10 0 1 0 0 20 10 10 0 0 0 0-20Z"/><path d="M15 5.5a1 1 0 0 0-.8.4l-5.4 6-3.1-2.6a1 1 0 0 0-1.5.1 1 1 0 0 0 .2 1.5l3.9 3.4c.4.3 1 .3 1.4-.1l6-7c.4-.4.4-1 0-1.5a1 1 0 0 0-.8-.2Z" fill="#fff"/></svg>
+					<p>Thank you for your feedback.</p>
+				</div>
+				{{#if questionUrl}}
+					{{#if questionText}}
+						<a href="{{questionUrl}}" data-customer-satisfaction-input="survey-link" target="_blank" rel="noopener">{{questionText}} (opens in a new tab)</a>
+					{{/if}}
+				{{/if}}
+			</div>
+		</form>
+	</div>
+</aside>


### PR DESCRIPTION
This replaces the Global Ratings Survey component which we decided to rename. Global Ratings Survey will be deprecated in a [subsequent PR](https://github.com/springernature/frontend-toolkits/pull/851).

The code committed here is the same as Global Ratings Survey albeit with different naming applied throughout. This component also remains dependent on the same version of Brand Context as Global Ratings Survey, version 29.0.3. Adopting a new version of BC is on hold pending some changes that need to happen in Elements and as such this will be done in a subsequent PR.

At this time I am the only consumer of this component. But soon other teams will start consuming it so it is good to do this rename now.

**Why are we renaming the component?**

I have worked closely with the Elements team on this renaming. Our reasoning for a rename:

- To better align it with the naming and terminology used for the overall solution it is part of, as documented here: https://customer-satisfaction-survey.public.springernature.app
- To provide a name that does a better job of describing what this component does i.e. user "input" relating to "customer satisfaction" data



