### PR TITLE
Remove user details from sn header

### DIFF
--- a/toolkits/springernature/packages/springernature-header/HISTORY.md
+++ b/toolkits/springernature/packages/springernature-header/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 3.1.0 (2022-12-06)
+    * Remove references to user-details component, and move some core styles to enhanced (media queries)
+
 ## 3.0.2 (2022-02-18)
     * Remove post install step that was causing issues with CI
 

--- a/toolkits/springernature/packages/springernature-header/README.md
+++ b/toolkits/springernature/packages/springernature-header/README.md
@@ -1,10 +1,10 @@
 # Springer Nature User Details
 
-Springer nature branded header component, with Springer Nature Editorial logo, optional journal logo, and the user-details component.
+Springer nature branded header component, with Springer Nature Editorial logo, optional journal logo.
 
 ## Requirements
 
-A class name of `.js` on the document root element will be required to enable visual styles for the user info drop down. The class should be added via a micro (but blocking) script, placed as far up in the <head> of the document as possible.
+A class name of `.js` on the document root element will be required to enable enhanced visual styles. The class should be added via a micro (but blocking) script, placed as far up in the <head> of the document as possible.
 
 ```javascript
 <script>
@@ -22,26 +22,14 @@ The component assumes you have the following data available to your template:
 logoutUri
 showJournalLogo - boolean to indicate whether or not there is a journal logo
 backUrl - the href for the anchor wrapping the header logos (usually to the home page)
-user-details {
-    first_name
-    last_name
-    email_address
-}
 submission {
     journalId
     journalName
 }
 
-The springernature header optionally includes the user-details component [springernature-user-details component](https://github.com/springernature/frontend-toolkits/tree/master/toolkits/springernature/packages/springernature-user-details). You will also need to import the [springernature context](https://github.com/springernature/frontend-toolkits/tree/master/context/brand-context/springernature).
+You will need to import the [springernature context](https://github.com/springernature/frontend-toolkits/tree/master/context/brand-context/springernature).
 
 The template assumes you are using handlebars and there is minimal use of built-in helpers - if you are using a different templating language then the tags will need to be modified.
-
-### Javascript
-
-```javascript
-import userDetails from '@springernature/user-details/js';
-userDetails();
-```
 
 ### CSS
 
@@ -52,8 +40,6 @@ Import the core styles into your main stylesheet
 @import '@springernature/brand-context/springernature/scss/core';
 
 @import '@springernature/springernature-header/scss/10-settings/layout';
-@import '@springernature/springernature-user-details/scss/10-settings/typography'; // if including user-details data
-@import '@springernature/springernature-user-details/scss/50-components/core'; // if including user-details data
 @import '@springernature/springernature-header/scss/50-components/core';
 ```
 
@@ -63,7 +49,6 @@ Import the enhanced settings and styles into your main stylesheet
 // enhanced.scss
 @import '@springernature/brand-context/springernature/scss/enhanced';
 
-@import '@springernature/springernature-user-details/scss/10-settings/colours'; // if including user-details data
-@import '@springernature/springernature-user-details/scss/50-components/enhanced'; // if including user-details data
+@import '@springernature/springernature-header/scss/10-settings/layout';
 @import '@springernature/springernature-header/scss/50-components/enhanced';
 ```

--- a/toolkits/springernature/packages/springernature-header/package.json
+++ b/toolkits/springernature/packages/springernature-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/springernature-header",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "license": "MIT",
   "description": "Springer Nature branded header component",
   "keywords": [],

--- a/toolkits/springernature/packages/springernature-header/scss/10-settings/layout.scss
+++ b/toolkits/springernature/packages/springernature-header/scss/10-settings/layout.scss
@@ -1,2 +1,6 @@
 $header--header-height: 40px;
 $header--content-width: 1184px;
+$header__site-logo-height-small: 35px;
+$header__site-logo-width-small: 123px;
+$header__site-logo-height: 45px;
+$header__site-logo-width: 158px;

--- a/toolkits/springernature/packages/springernature-header/scss/50-components/core.scss
+++ b/toolkits/springernature/packages/springernature-header/scss/50-components/core.scss
@@ -5,7 +5,7 @@
 	color: #7d7d7d;
 	min-height: $header--header-height;
 	border-bottom: 5px solid #3c9cd7;
-	padding: 20px 0;
+	padding: 0 0 20px;
 	width: 100%;
 	top: 0;
 }
@@ -13,8 +13,7 @@
 .c-header__inner {
 	max-width: $header--content-width;
 	margin: 0 auto;
-	padding-left: 20px;
-	padding-right: 20px;
+	padding: 20px 20px 0;
 }
 
 .c-header__logo-link {
@@ -23,7 +22,8 @@
 }
 
 .c-header__site-logo {
-	max-height: 50px;
+	width: 123px;
+	height: 35px;
 	margin: 0 30px 10px 0;
 }
 
@@ -33,15 +33,6 @@
 }
 
 .c-header__journal-title {
-	@include media-query('md') {
-		font-size: 1.375rem;
-	}
-
-	@include media-query('lg') {
-		font-size: 1.6875rem;
-	}
-
-	font-family: $context--font-family-serif;
 	line-height: 2.875rem;
 	font-size: .9375rem;
 	color: color('black');

--- a/toolkits/springernature/packages/springernature-header/scss/50-components/core.scss
+++ b/toolkits/springernature/packages/springernature-header/scss/50-components/core.scss
@@ -22,8 +22,8 @@
 }
 
 .c-header__site-logo {
-	width: 123px;
-	height: 35px;
+	width: $header__site-logo-width-small;
+	height: $header__site-logo-height-small;
 	margin: 0 30px 10px 0;
 }
 

--- a/toolkits/springernature/packages/springernature-header/scss/50-components/enhanced.scss
+++ b/toolkits/springernature/packages/springernature-header/scss/50-components/enhanced.scss
@@ -12,19 +12,19 @@
 	}
 }
 
-.c-header__site-logo,
-.c-header__journal-logo {
-	width: auto;
-	height: auto;
-	min-width: 130px;
-	max-width: 209px;
-}
-
 .c-header__site-logo {
+	@include media-query('md') {
+		width: 158px;
+		height: 45px;
+	}
+	
 	padding-right: 20px;
 }
 
 .c-header__journal-logo {
+	width: auto;
+	height: auto;
+	min-width: 130px;
 	max-width: 100%;
 	height: 24px;
 
@@ -60,4 +60,16 @@
 			flex-basis: 75%;
 		}
 	}
+}
+
+.c-header__journal-title {
+	@include media-query('md') {
+		font-size: 1.375rem;
+	}
+	
+	@include media-query('lg') {
+		font-size: 1.6875rem;
+	}
+	
+	font-family: $context--font-family-serif;
 }

--- a/toolkits/springernature/packages/springernature-header/scss/50-components/enhanced.scss
+++ b/toolkits/springernature/packages/springernature-header/scss/50-components/enhanced.scss
@@ -14,8 +14,8 @@
 
 .c-header__site-logo {
 	@include media-query('md') {
-		width: 158px;
-		height: 45px;
+		width: $header__site-logo-width;
+		height: $header__site-logo-height;
 	}
 	
 	padding-right: 20px;

--- a/toolkits/springernature/packages/springernature-header/view/header.hbs
+++ b/toolkits/springernature/packages/springernature-header/view/header.hbs
@@ -11,9 +11,6 @@
                     {{/if}}
                 {{/if}}
             </a>
-
-            {{!-- If you are using the user-details component, insert here --}}
-            
         </div>
     </div>
 </header>


### PR DESCRIPTION
I have removed references to the user-details component, as this has been replaced with the Identity component.
I moved some styles from core.scss to enhanced.scss.
I moved top padding from .c-header to .c-header__inner.
I tidied some of the rules around sizing for the logos.