### PR TITLE
fix: updates compiled design tokens Sass variable names

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,5 +1,7 @@
 # History
 
+## 31.0.1 (2023-01-10)
+    * FIX: updates the block spacing variable naming to use the correct token variable.
 ## 31.0.0 (2023-01-04)
     * Reduce scope of block spacing
 	* NOTE: This version replaces all versions >= 28.0.0

--- a/context/brand-context/default/scss/40-base/block-spacing.scss
+++ b/context/brand-context/default/scss/40-base/block-spacing.scss
@@ -10,14 +10,14 @@ h1, h2, h3, h4, h5 {
 // The specificity is that of one element selector.
 :is(p, ol, ul, dl, figure, blockquote, form, pre, table, img, video, aside, section, article) +
 :is(p, ol, ul, dl, figure, blockquote, form, pre, table, img, video, aside, section, article) {
-	margin-block-start: $$t-typography-block-spacing-medium;
+	margin-block-start: $t-typography-block-spacing-medium;
 }
 
 // <div> elements found among basic semantic content likely need similar margin applied.
 // The specificity is that of two element selectors; a utility class can override it
 :is(p, ol, ul, dl, figure, blockquote, pre, table, img, video) + div,
 div + :is(p, ol, ul, dl, figure, blockquote, pre, table, img, video) {
-	margin-block-start: $$t-typography-block-spacing-medium;
+	margin-block-start: $t-typography-block-spacing-medium;
 }
 
 // Headings have differing margins to other flow elements.

--- a/context/brand-context/default/scss/40-base/block-spacing.scss
+++ b/context/brand-context/default/scss/40-base/block-spacing.scss
@@ -10,14 +10,14 @@ h1, h2, h3, h4, h5 {
 // The specificity is that of one element selector.
 :is(p, ol, ul, dl, figure, blockquote, form, pre, table, img, video, aside, section, article) +
 :is(p, ol, ul, dl, figure, blockquote, form, pre, table, img, video, aside, section, article) {
-	margin-block-start: $tokens--typography-block-spacing-medium;
+	margin-block-start: $$t-typography-block-spacing-medium;
 }
 
 // <div> elements found among basic semantic content likely need similar margin applied.
 // The specificity is that of two element selectors; a utility class can override it
 :is(p, ol, ul, dl, figure, blockquote, pre, table, img, video) + div,
 div + :is(p, ol, ul, dl, figure, blockquote, pre, table, img, video) {
-	margin-block-start: $tokens--typography-block-spacing-medium;
+	margin-block-start: $$t-typography-block-spacing-medium;
 }
 
 // Headings have differing margins to other flow elements.

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "31.0.0",
+  "version": "31.0.1",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],


### PR DESCRIPTION
There are two outliers from a recent name spacing change for design tokens where we went from tokens-- to t- to align with how we namespace components.