### PR TITLE
fix: spelling srrors

### DIFF
--- a/toolkits/global/packages/global-layout-grid/HISTORY.md
+++ b/toolkits/global/packages/global-layout-grid/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 0.3.1 (2023-01-11)
+    * fix: corrects spelling errors in documentation where there was a missing -
+
 ## 0.3.0 (2022-07-28)
     * Upgrade to brand-context v25.0.0
 

--- a/toolkits/global/packages/global-layout-grid/HISTORY.md
+++ b/toolkits/global/packages/global-layout-grid/HISTORY.md
@@ -1,7 +1,7 @@
 # History
 
 ## 0.3.1 (2023-01-11)
-    * fix: corrects spelling errors in documentation where there was a missing -
+    * Fix: corrects spelling errors in documentation where there was a missing -
 
 ## 0.3.0 (2022-07-28)
     * Upgrade to brand-context v25.0.0

--- a/toolkits/global/packages/global-layout-grid/README.md
+++ b/toolkits/global/packages/global-layout-grid/README.md
@@ -43,10 +43,10 @@ Note the use of list semantics. Collections of teasers/products should ordinaril
 
 ### Custom settings
 
-The component maps `$grid--basis` and `$grid--gap` to CSS custom properties, allowing you to adjust the values inline. In the following example, `--grid--gap` is set to `2em` and `--grid-basis` to `20ch`.
+The component maps `$grid--basis` and `$grid--gap` to CSS custom properties, allowing you to adjust the values inline. In the following example, `--grid--gap` is set to `2em` and `--grid--basis` to `20ch`.
 
 ```html
-<ul class="l-grid" style="--grid-gap: 2em; --grid-basis: min(20ch, 100%)">
+<ul class="l-grid" style="--grid--gap: 2em; --grid--basis: min(20ch, 100%)">
     <li>
         Item 1
     </li>

--- a/toolkits/global/packages/global-layout-grid/package.json
+++ b/toolkits/global/packages/global-layout-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-layout-grid",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "MIT",
   "description": "A versatile responsive grid using CSS Grid (no media queries necessary)",
   "keywords": [],


### PR DESCRIPTION
This updates a couple of cases in the readme.md where some CSS custom properties have a missing `-` in them.

This closes #805 