### PR TITLE
Updates the breadcrumb visibility on mobile

### DIFF
--- a/toolkits/global/packages/global-breadcrumbs/HISTORY.md
+++ b/toolkits/global/packages/global-breadcrumbs/HISTORY.md
@@ -1,7 +1,7 @@
 # History
 
-## 5.1.0 (2023-06-29)
-    * Add new styles for small screen devices to only show last two levels
+## 6.0.0 (2023-06-29)
+    * BREAKING: Add new styles for small screen devices to only show last two levels
 ## 5.0.0 (2023-01-18)
     * BREAKING: Upgrade to brand-context v31.0.1
 

--- a/toolkits/global/packages/global-breadcrumbs/HISTORY.md
+++ b/toolkits/global/packages/global-breadcrumbs/HISTORY.md
@@ -1,5 +1,7 @@
 # History
 
+## 5.1.0 (2023-06-29)
+    * Add new styles for small screen devices to only show last two levels
 ## 5.0.0 (2023-01-18)
     * BREAKING: Upgrade to brand-context v31.0.1
 

--- a/toolkits/global/packages/global-breadcrumbs/package.json
+++ b/toolkits/global/packages/global-breadcrumbs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-breadcrumbs",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "license": "MIT",
   "description": "breadcrumbs",
   "keywords": [],

--- a/toolkits/global/packages/global-breadcrumbs/package.json
+++ b/toolkits/global/packages/global-breadcrumbs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-breadcrumbs",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "license": "MIT",
   "description": "breadcrumbs",
   "keywords": [],

--- a/toolkits/global/packages/global-breadcrumbs/scss/50-components/breadcrumbs.scss
+++ b/toolkits/global/packages/global-breadcrumbs/scss/50-components/breadcrumbs.scss
@@ -22,3 +22,16 @@ svg.c-breadcrumbs__chevron {
 	width: 10px;
 	height: 10px;
 }
+
+.c-breadcrumbs .c-breadcrumbs__item {
+	@include media-query('sm', 'max') {
+		display: none;
+	}
+}
+
+.c-breadcrumbs .c-breadcrumbs__item:nth-last-child(1),
+.c-breadcrumbs .c-breadcrumbs__item:nth-last-child(2) {
+	@include media-query('sm', 'max') {
+		display: inline;
+	}
+}


### PR DESCRIPTION
To bring both the elements and frontend toolkit breadcrumbs in line, I created this PR to hide all but the last two levels of breadcrumb on small screen devices.