### PR TITLE
CSAT input element adds responseRating to survey url query string

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Ensure you have [`nvm` installed](https://github.com/creationix/nvm/blob/master/
 
 The components found within the toolkits are validated using the [`sass` package on NPM](https://www.npmjs.com/package/sass). You should use the same version within your application (currently `1.47.0`) build process.
 
+### Get bootstrapped for local development
+
+Lerna needs a little help beyond the usual `npm` install - run `npm run bootstrap:local` before you try anything else.
+
 ### Installing dependencies
 
 To install dependencies:

--- a/toolkits/global/packages/global-customer-satisfaction-input/__tests__/customer-satisfaction-input.spec.js
+++ b/toolkits/global/packages/global-customer-satisfaction-input/__tests__/customer-satisfaction-input.spec.js
@@ -205,9 +205,19 @@ describe('Global Customer Satisfaction Input', () => {
 	test('Should get the selected and add it as a query parameter to the survey link', () => {
 		expect(surveyLink.href === 'https://www.surveymonkey.com/1').toBe(true);
 		window.location.href = 'http://localhost/?shafkjsahfh'
-		customerSatisfactionInput();
-		label.click();
-		button.click();
-		expect(surveyLink.href).toEqual('https://www.surveymonkey.com/1?location=http://localhost/&responseRating=1');
+		customerSatisfactionInput()
+		expect(surveyLink.href).toEqual(`https://www.surveymonkey.com/1?location=http://localhost/`);
 	})
+
+	test('Should get the selected and add it as a query parameter to the survey link', () => {
+		const rating = 3
+		customerSatisfactionInput();
+		clickRating(rating)
+		button.click();
+		expect(surveyLink.href).toContain(`responseRating=${rating}`);
+	})
+
+	function clickRating(rating) {
+		document.querySelectorAll('label')[rating - 1].click();
+	}
 });

--- a/toolkits/global/packages/global-customer-satisfaction-input/__tests__/customer-satisfaction-input.spec.js
+++ b/toolkits/global/packages/global-customer-satisfaction-input/__tests__/customer-satisfaction-input.spec.js
@@ -195,16 +195,19 @@ describe('Global Customer Satisfaction Input', () => {
 		expect(message.classList.contains('u-hide')).toBe(false);
 	});
 
-	test('Should get the current location and join survey link', () => {
-		expect(surveyLink.href === 'https://www.surveymonkey.com/1').toBe(true);
-		customerSatisfactionInput();
-		expect(surveyLink.href === 'https://www.surveymonkey.com/1?location=http://localhost/').toBe(true);
-	})
-
-	test('Should generate URL parameters and append them to the survey link', () => {
+	test('Should get the current location and add it as a query parameter to the survey link', () => {
 		expect(surveyLink.href === 'https://www.surveymonkey.com/1').toBe(true);
 		window.location.href = 'http://localhost/?shafkjsahfh'
 		customerSatisfactionInput();
-		expect(surveyLink.href === 'https://www.surveymonkey.com/1?location=http://localhost/').toBe(true);
+		expect(surveyLink.href).toEqual('https://www.surveymonkey.com/1?location=http://localhost/');
+	})
+
+	test('Should get the selected and add it as a query parameter to the survey link', () => {
+		expect(surveyLink.href === 'https://www.surveymonkey.com/1').toBe(true);
+		window.location.href = 'http://localhost/?shafkjsahfh'
+		customerSatisfactionInput();
+		label.click();
+		button.click();
+		expect(surveyLink.href).toEqual('https://www.surveymonkey.com/1?location=http://localhost/&responseRating=1');
 	})
 });

--- a/toolkits/global/packages/global-customer-satisfaction-input/__tests__/customer-satisfaction-input.spec.js
+++ b/toolkits/global/packages/global-customer-satisfaction-input/__tests__/customer-satisfaction-input.spec.js
@@ -1,5 +1,6 @@
 'use strict';
 import {customerSatisfactionInput} from '../js/index.js';
+import * as qs from 'querystring';
 
 const fixture = `
 <aside class="u-hide u-js-show" data-customer-satisfaction-input="" data-customer-satisfaction-input-user-journeys="get prepared to publish">
@@ -203,21 +204,15 @@ describe('Global Customer Satisfaction Input', () => {
 	})
 
 	test('Should get the selected and add it as a query parameter to the survey link', () => {
-		expect(surveyLink.href === 'https://www.surveymonkey.com/1').toBe(true);
-		window.location.href = 'http://localhost/?shafkjsahfh'
-		customerSatisfactionInput()
-		expect(surveyLink.href).toEqual(`https://www.surveymonkey.com/1?location=http://localhost/`);
-	})
-
-	test('Should get the selected and add it as a query parameter to the survey link', () => {
 		const rating = 3
 		customerSatisfactionInput();
-		clickRating(rating)
+
+		clickOnRating(rating)
 		button.click();
 		expect(surveyLink.href).toContain(`responseRating=${rating}`);
 	})
 
-	function clickRating(rating) {
+	function clickOnRating(rating) {
 		document.querySelectorAll('label')[rating - 1].click();
 	}
 });

--- a/toolkits/global/packages/global-customer-satisfaction-input/js/customer-satisfaction-input.js
+++ b/toolkits/global/packages/global-customer-satisfaction-input/js/customer-satisfaction-input.js
@@ -16,6 +16,16 @@ class CustomerSatisfactionInput {
 		return this._formRadios.find(element => element.checked).value;
 	}
 
+	_updateSurveyLinkQueryString(parameterName, value) {
+		if (this._surveyLink) {
+			const url = new URL(this._surveyLink.href);
+			const parameters = url.searchParams;
+			parameters.set(parameterName, value);
+			url.search = parameters.toString();
+			this._surveyLink.href = url.toString();
+		}
+	}
+
 	_setSurveyLinkHref() {
 		if (this._surveyLink) {
 			this._surveyLink.href = this._surveyLink.href + '?location=' + window.location.href.split('?')[0];
@@ -23,9 +33,7 @@ class CustomerSatisfactionInput {
 	}
 
 	_setSurveyLinkResponseRating(rating) {
-		if (this._surveyLink) {
-			this._surveyLink.href = this._surveyLink.href + '&responseRating=' + rating;
-		}
+		this._updateSurveyLinkQueryString('responseRating', rating);
 	}
 
 	_getUserJourneys() {

--- a/toolkits/global/packages/global-customer-satisfaction-input/js/customer-satisfaction-input.js
+++ b/toolkits/global/packages/global-customer-satisfaction-input/js/customer-satisfaction-input.js
@@ -22,6 +22,12 @@ class CustomerSatisfactionInput {
 		}
 	}
 
+	_setSurveyLinkResponseRating(rating) {
+		if (this._surveyLink) {
+			this._surveyLink.href = this._surveyLink.href + '&responseRating=' + rating;
+		}
+	}
+
 	_getUserJourneys() {
 		if (!this._aside.dataset.customerSatisfactionInputUserJourneys) {
 			console.error('Attempt to send Global Customer Satisfaction Input event failed. Value not found for User Journeys.');
@@ -74,6 +80,7 @@ class CustomerSatisfactionInput {
 					event.stopPropagation();
 					const validForm = this._validateForm();
 					if (validForm) {
+						this._setSurveyLinkResponseRating((this._getCheckedRadioValue()));
 						this._dispatchDataLayerEvent(this._getCheckedRadioValue());
 						this._displayMessage();
 						return;


### PR DESCRIPTION
adds the responseRating to the query string of the survey url.

uses `responseRating` which is what Jon used, but I guess it could be made configurable if anyone ever wanted something different (or to turn it off?).