### PR TITLE
[AK] Add spellcheck attribute so it can be used as input parameter

### DIFF
--- a/toolkits/global/packages/global-forms/HISTORY.md
+++ b/toolkits/global/packages/global-forms/HISTORY.md
@@ -1,4 +1,6 @@
 # History
+## 6.0.1 (2023-07-31)
+    * Adds support for spellcheck attribute
 
 
 ## 6.0.0 (2023-01-18)

--- a/toolkits/global/packages/global-forms/package.json
+++ b/toolkits/global/packages/global-forms/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@springernature/global-forms",
-	"version": "6.0.0",
+	"version": "6.0.1",
 	"license": "MIT",
 	"description": "form component",
 	"keywords": [

--- a/toolkits/global/packages/global-forms/view/globalFormAttributes.hbs
+++ b/toolkits/global/packages/global-forms/view/globalFormAttributes.hbs
@@ -11,6 +11,7 @@
 {{#if minlength}} minlength="{{minlength}}"{{/if}}
 {{#unless autocomplete}} autocomplete="off"{{/unless}}
 {{#if autocomplete}} autocomplete="{{autocomplete}}"{{/if}}
+{{#if spellcheck}} spellcheck="{{spellcheck}}"{{/if}}
 {{#if novalidate}} novalidate{{/if}}
 {{#if datalist.id}} list="{{datalist.id}}"{{/if}}
 {{#if accept}} accept="{{accept}}"{{/if}}


### PR DESCRIPTION
To prevent word suggestions from the system/keyboard **spellcheck="false"** can be added to the input field. Due to the fact spellcheck isn't listed in the globalFormAttributes it couldn't be added when using global forms. 

![image](https://github.com/springernature/frontend-toolkits/assets/28729610/d45a1ba8-e8e8-4b0d-913f-e331147c5eaf)


This shows the issue, when searching for UCL and hitting enter, results for ICL where listed.

To reproduce this, check https://staging-wayf.springernature.com/?redirect_uri=https%3A%2F%2Frd.springer.com%2Farticle%2F10.1007%2Fs10488-015-0664-7 on Safari.