### PR TITLE
Version 1.0.1 of Global Customer Satisfaction Input component

### DIFF
--- a/toolkits/global/packages/global-customer-satisfaction-input/HISTORY.md
+++ b/toolkits/global/packages/global-customer-satisfaction-input/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 1.0.1 (2023-08-14)
+    * Removes aria-required and aria-invalid as were redundant. This will fix accessibility test warnings/errors about the same.
+
 ## 1.0.0 (2023-07-26)
     * BREAKING
         * Brings component up to date with v32.0.0 of Brand Context

--- a/toolkits/global/packages/global-customer-satisfaction-input/package.json
+++ b/toolkits/global/packages/global-customer-satisfaction-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-customer-satisfaction-input",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "description": "HTML form based component for gathering customer satisfaction data",
   "keywords": [],

--- a/toolkits/global/packages/global-customer-satisfaction-input/view/customerSatisfactionInput.hbs
+++ b/toolkits/global/packages/global-customer-satisfaction-input/view/customerSatisfactionInput.hbs
@@ -8,9 +8,7 @@
 				<div class="c-customer-satisfaction-input__field c-customer-satisfaction-input__field--globalFormRadios">
 					<fieldset class="c-customer-satisfaction-input__fieldset c-customer-satisfaction-input__field c-forms__radios"
 							  id="customer-satisfaction-input-radios{{#if id}}-{{id}}{{/if}}" name="customer-satisfaction-input-radios"
-							  invalid="" aria-invalid="true"
-							  aria-describedby="error-customer-satisfaction-input-radios1" required=""
-							  aria-required="true" autocomplete="off">
+							  invalid="" aria-describedby="error-customer-satisfaction-input-radios1" required="" autocomplete="off">
 						<legend class="c-customer-satisfaction-input__visually-hidden">Rating. A scale of 5 feelings conveyed using images that range from awful to great. The feelings represent how you feel about your experience today.</legend>
 						<small class="c-customer-satisfaction-input__error" id="error-customer-satisfaction-input-radios{{#if id}}-{{id}}{{/if}}">
 							<span class="c-customer-satisfaction-input__error-icon">
@@ -25,8 +23,7 @@
 						<div class="c-customer-satisfaction-input__pictographic-radios">
 							<div class="c-customer-satisfaction-input__label c-customer-satisfaction-input__label--wrapper">
 								<input class="c-customer-satisfaction-input__input c-customer-satisfaction-input__visually-hidden" type="radio" id="radio-awful{{#if id}}-{{id}}{{/if}}"
-									   name="customer-satisfaction-input-radios" value="1" required=""
-									   aria-required="true" autocomplete="off" data-customer-satisfaction-input="radio">
+									   name="customer-satisfaction-input-radios" value="1" required="" autocomplete="off" data-customer-satisfaction-input="radio">
 								<label for="radio-awful{{#if id}}-{{id}}{{/if}}" class="c-customer-satisfaction-input__label c-customer-satisfaction-input__label--pictographic-radio">
 									<svg viewBox="0 0 24 24" fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false">
 										<clipPath id="a{{#if id}}-{{id}}{{/if}}">
@@ -46,8 +43,7 @@
 							</div>
 							<div class="c-customer-satisfaction-input__label c-customer-satisfaction-input__label--wrapper">
 								<input class="c-customer-satisfaction-input__input c-customer-satisfaction-input__visually-hidden" type="radio" id="radio-bad{{#if id}}-{{id}}{{/if}}"
-									   name="customer-satisfaction-input-radios" value="2" required=""
-									   aria-required="true" autocomplete="off" data-customer-satisfaction-input="radio">
+									   name="customer-satisfaction-input-radios" value="2" required="" autocomplete="off" data-customer-satisfaction-input="radio">
 								<label for="radio-bad{{#if id}}-{{id}}{{/if}}" class="c-customer-satisfaction-input__label c-customer-satisfaction-input__label--pictographic-radio">
 									<svg fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
 										<defs>
@@ -75,8 +71,7 @@
 							</div>
 							<div class="c-customer-satisfaction-input__label c-customer-satisfaction-input__label--wrapper">
 								<input class="c-customer-satisfaction-input__input c-customer-satisfaction-input__visually-hidden" type="radio" id="radio-ok{{#if id}}-{{id}}{{/if}}"
-									   name="customer-satisfaction-input-radios" value="3" required=""
-									   aria-required="true" autocomplete="off" data-customer-satisfaction-input="radio">
+									   name="customer-satisfaction-input-radios" value="3" required="" autocomplete="off" data-customer-satisfaction-input="radio">
 								<label for="radio-ok{{#if id}}-{{id}}{{/if}}" class="c-customer-satisfaction-input__label c-customer-satisfaction-input__label--pictographic-radio">
 									<svg fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
 										<defs>
@@ -104,8 +99,7 @@
 							</div>
 							<div class="c-customer-satisfaction-input__label c-customer-satisfaction-input__label--wrapper">
 								<input class="c-customer-satisfaction-input__input c-customer-satisfaction-input__visually-hidden" type="radio" id="radio-good{{#if id}}-{{id}}{{/if}}"
-									   name="customer-satisfaction-input-radios" value="4" required=""
-									   aria-required="true" autocomplete="off" data-customer-satisfaction-input="radio">
+									   name="customer-satisfaction-input-radios" value="4" required="" autocomplete="off" data-customer-satisfaction-input="radio">
 								<label for="radio-good{{#if id}}-{{id}}{{/if}}" class="c-customer-satisfaction-input__label c-customer-satisfaction-input__label--pictographic-radio">
 									<svg fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
 										<defs>
@@ -133,8 +127,7 @@
 							</div>
 							<div class="c-customer-satisfaction-input__label c-customer-satisfaction-input__label--wrapper">
 								<input class="c-customer-satisfaction-input__input c-customer-satisfaction-input__visually-hidden" type="radio" id="radio-great{{#if id}}-{{id}}{{/if}}"
-									   name="customer-satisfaction-input-radios" value="5" required=""
-									   aria-required="true" autocomplete="off" data-customer-satisfaction-input="radio">
+									   name="customer-satisfaction-input-radios" value="5" required="" autocomplete="off" data-customer-satisfaction-input="radio">
 								<label for="radio-great{{#if id}}-{{id}}{{/if}}" class="c-customer-satisfaction-input__label c-customer-satisfaction-input__label--pictographic-radio">
 									<svg fill="transparent" stroke="currentColor" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
 										<defs>


### PR DESCRIPTION
Removes aria-required and aria-invalid from CSAT html as not needed

The HTML elements in question already have `required` and/or `invalid` attributes on them and are the correct semantic elements