### PR TITLE
Fix `global-customer-satisfaction-input` overflow bug

### DIFF
--- a/toolkits/global/packages/global-customer-satisfaction-input/HISTORY.md
+++ b/toolkits/global/packages/global-customer-satisfaction-input/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 1.0.3 (2023-09-18)
+    * Fixes issue with visually hidden elements causing an overflow due to absolute positioning.
+
 ## 1.0.2 (2023-08-24)
     * Fixes issue with SVG not rendering correctly in Firefox. Ids used in HTML have been refactored and properly namespaced.
     * Fixes issue with aria-described-by value related to error messaging not corresponding to the error html ID

--- a/toolkits/global/packages/global-customer-satisfaction-input/demo/dist/index.html
+++ b/toolkits/global/packages/global-customer-satisfaction-input/demo/dist/index.html
@@ -1067,6 +1067,7 @@ html {
 }
 
 .c-customer-satisfaction-input {
+  position: relative;
   padding: 16px;
   background-color: #f3f3f3;
   overflow: hidden;

--- a/toolkits/global/packages/global-customer-satisfaction-input/package.json
+++ b/toolkits/global/packages/global-customer-satisfaction-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-customer-satisfaction-input",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "MIT",
   "description": "HTML form based component for gathering customer satisfaction data",
   "keywords": [],

--- a/toolkits/global/packages/global-customer-satisfaction-input/scss/50-components/_customer-satisfaction-input.scss
+++ b/toolkits/global/packages/global-customer-satisfaction-input/scss/50-components/_customer-satisfaction-input.scss
@@ -1,4 +1,5 @@
 .c-customer-satisfaction-input {
+	position: relative;
 	padding: $global-customer-satisfaction-input-container-padding;
 	background-color: $global-customer-satisfaction-input-container-background-color;
 	overflow: hidden;


### PR DESCRIPTION
Issue: springernature/frontend-toolkits/issues/889

- Add `position: relative` rule to `.c-customer-satisfaction-input`