### PR TITLE
Use a span rather than div inside Summary, as div not allowed

### DIFF
--- a/toolkits/global/packages/global-details/HISTORY.md
+++ b/toolkits/global/packages/global-details/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 2.0.1 (2024-09-10)
+    * Use a span inside the summary rather than div
+
 ## 2.0.0 (2023-05-17)
     * BREAKING: Removes use of $tokens--typography-block-spacing-medium in springer settings and replaces with 1.5em
     * BREAKING: Upgrade to brand-context v32.0.0 - the version that removes block-spacing styling

--- a/toolkits/global/packages/global-details/package.json
+++ b/toolkits/global/packages/global-details/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-details",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "description": "A JS-independent, accessible disclosure component",
   "keywords": [],

--- a/toolkits/global/packages/global-details/scss/50-components/details.scss
+++ b/toolkits/global/packages/global-details/scss/50-components/details.scss
@@ -59,7 +59,7 @@
 
 /* ↓ Complex selector necessary to ensure
 nested icons are not rotated */
-.c-details > [open] > summary > div > .u-icon {
+.c-details > [open] > summary > .u-icon {
 	transform: rotate(90deg);
 }
 

--- a/toolkits/global/packages/global-details/view/details.hbs
+++ b/toolkits/global/packages/global-details/view/details.hbs
@@ -1,12 +1,12 @@
 <{{#if listItem}}li{{else}}div{{/if}} class="c-details">
 	<details {{#if open}}open{{/if}} class="c-details__details">
 		<summary class="c-details__summary">
-			<div class="c-details__header" {{#if headingLevel}}role="heading" aria-level="{{headingLevel}}"{{/if}}>
+			<span class="c-details__header" {{#if headingLevel}}role="heading" aria-level="{{headingLevel}}"{{/if}}>
 				<svg class="u-icon" width="22" height="22" aria-hidden="true" focusable="false">
 					<use xlink:href="{{iconURL}}"></use>
 				</svg>
 				<span class="c-details__title">{{title}}</span>
-			</div>
+			</span>
 		</summary>
 		<div class="c-details__content">
 			{{{content}}}


### PR DESCRIPTION
Recommend using span rather than div inside the Summary. 
Make the selector for the icon slightly less specific so it works either way. 