### PR TITLE
Add type=module to package file

### DIFF
--- a/toolkits/global/packages/global-loader-animation/package.json
+++ b/toolkits/global/packages/global-loader-animation/package.json
@@ -5,5 +5,6 @@
   "description": "Loader animation to show when making requests",
   "keywords": [],
   "author": "Springernature",
-  "brandContext": "^31.0.1"
+  "brandContext": "^31.0.1",
+  "type": "module"
 }


### PR DESCRIPTION
Updating here as this package doesn't seem to be in Elements.
I am using the node test runner and it is complaining that this package is using ES imports but missing "type"="module" in the package.json.

