### PR TITLE
Nature: Update Focus Outline Colour

### DIFF
--- a/context/brand-context/HISTORY.md
+++ b/context/brand-context/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 32.0.1 (2025-09-10)
+    * FIX: Use WCAG compliant focus color for Nature brand.
+
 ## 32.0.0 (2023-05-16)
     * BREAKING: Removes block-spacing styles from frontend-toolkits.
 

--- a/context/brand-context/nature/scss/10-settings/colors/default.scss
+++ b/context/brand-context/nature/scss/10-settings/colors/default.scss
@@ -37,7 +37,8 @@ $context--colors: (
 	'nature-secondary': #a12a3f,
 	'nature-tertiary': #d7c8c8,
 	'action-base': #004b83,
-	'action-light': scale-color(#004b83, $lightness: 10%)
+	'action-light': scale-color(#004b83, $lightness: 10%),
+	'focus-color': #0088cc // accessible focus color from elements single package
 );
 
 // nature sub-brands
@@ -175,4 +176,4 @@ $subject-areas-colors: (
 	'scientific-community-society-secondary': #fcf0f7
 );
 
-$context--focus-color: color(lemon);
+$context--focus-color: map-get($context--colors, focus-color);

--- a/context/brand-context/package.json
+++ b/context/brand-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/brand-context",
-  "version": "32.0.0",
+  "version": "32.0.1",
   "license": "MIT",
   "description": "Bootstrapping for all components and products",
   "keywords": [],


### PR DESCRIPTION
The current focus ring on Nature fails the [contrast requirement for WCAG 2.2 AA](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html#:~:text=Ensure%20meaningful%20visual%20cues%20achieve%203%3A1%20against%20the%20background.). In order to fix this, the PR updates the colour to match the [Springer Nature focus ring colour](https://eds.springernature.com/design-tokens/springernature/state/#:~:text=Table%20view-,%24t%2Da%2Dstate%2Dfocus,-%230088cc), which is compliant with the contrast requirement.