### PR TITLE
Release version 3.1.0 with nature setting for pagination background color of active link

### DIFF
--- a/toolkits/global/packages/global-pagination/HISTORY.md
+++ b/toolkits/global/packages/global-pagination/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 3.1.0 (2025-09-22)
+    * Add nature setting for pagination to override selected background color
+
 ## 3.0.0 (2023-01-18)
     * BREAKING: Upgrade to brand-context v31.0.1
 

--- a/toolkits/global/packages/global-pagination/package.json
+++ b/toolkits/global/packages/global-pagination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-pagination",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "license": "MIT",
   "description": "A component for the controls of pagination",
   "keywords": [],

--- a/toolkits/global/packages/global-pagination/scss/10-settings/nature.scss
+++ b/toolkits/global/packages/global-pagination/scss/10-settings/nature.scss
@@ -1,0 +1,10 @@
+/**
+ * @springernature/global-pagination
+ * Nature skin settings
+ */
+
+// Default setting
+@import 'default';
+
+$pagination--link-active-border-color: color('blue');
+$pagination--link-active-background-color: color('blue');


### PR DESCRIPTION
On the search results page at https://www.nature.com/search?q=brain&journal=, the pagination link [Page 1 link have  foreground - #fff and background - #888 ] does not meet the required colour contrast ratio between text and background, making it difficult for some users to read.

Decided to changes the active link background color and border color to match link color on hover.

Ticket - https://springernature.atlassian.net/browse/DIS-101

Co-authored-by: Ricky Lau <ricky.lau@springernature.com>