### PR TITLE
Fix mangeled text for Navigation item "Explore content/Content" in Sa…

### DIFF
--- a/toolkits/nature/packages/nature-header/HISTORY.md
+++ b/toolkits/nature/packages/nature-header/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 11.0.1 (2025-10-06)
+    * Fix mangeled text for Navigation item "Explore content/Content" in Safari. Toggle between two text spans and no longer using :first-letter.
+
 ## 11.0.0 (2023-01-18)
     * BREAKING: Upgrade to brand-context v31.0.1
 

--- a/toolkits/nature/packages/nature-header/package.json
+++ b/toolkits/nature/packages/nature-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/nature-header",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "license": "MIT",
   "description": "Publisher level header",
   "keywords": [],

--- a/toolkits/nature/packages/nature-header/scss/50-components/header.scss
+++ b/toolkits/nature/packages/nature-header/scss/50-components/header.scss
@@ -132,10 +132,6 @@
 	gap: spacing(4);
 	white-space: nowrap;
 
-	::first-letter {
-		text-transform: capitalize;
-	}
-
 	svg {
 		transition-duration: 0.2s;
 	}
@@ -147,6 +143,15 @@
 	@include media-query('sm') {
 		display: inline;
 		visibility: visible;
+	}
+}
+
+.c-header__show-text-sm {
+	display: inline;
+	visibility: visible;
+
+	@include media-query('sm') {
+		@include u-hide;
 	}
 }
 

--- a/toolkits/nature/packages/nature-header/view/header.hbs
+++ b/toolkits/nature/packages/nature-header/view/header.hbs
@@ -41,9 +41,10 @@
 				<ul class="c-header__menu c-header__menu--journal">
 					<li class="c-header__item c-header__item--dropdown-menu">
 						<a href="#explore" class="c-header__link" data-header-expander>
-							<span><span class="c-header__show-text">Explore</span> content</span><svg role="img" aria-hidden="true" focusable="false" height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg">
-								<path d="m5.58578644 3-3.29289322-3.29289322c-.39052429-.39052429-.39052429-1.02368927 0-1.41421356s1.02368927-.39052429 1.41421356 0l4 4c.39052429.39052429.39052429 1.02368927 0 1.41421356l-4 4c-.39052429.39052429-1.02368927.39052429-1.41421356 0s-.39052429-1.02368927 0-1.41421356z" transform="matrix(0 1 -1 0 11 3)"></path>
-							</svg>
+							<span>
+								<span class="c-header__show-text">Content</span>
+								<span class="c-header__show-text">Explore content</span><svg role="img" aria-hidden="true" focusable="false" height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m5.58578644 3-3.29289322-3.29289322c-.39052429-.39052429-.39052429-1.02368927 0-1.41421356s1.02368927-.39052429 1.41421356 0l4 4c.39052429.39052429.39052429 1.02368927 0 1.41421356l-4 4c-.39052429.39052429-1.02368927.39052429-1.41421356 0s-.39052429-1.02368927 0-1.41421356z" transform="matrix(0 1 -1 0 11 3)"></path></svg>
+							</span>
 						</a>
 					</li>
 					<li class="c-header__item c-header__item--dropdown-menu">

--- a/toolkits/nature/packages/nature-header/view/header.hbs
+++ b/toolkits/nature/packages/nature-header/view/header.hbs
@@ -42,7 +42,7 @@
 					<li class="c-header__item c-header__item--dropdown-menu">
 						<a href="#explore" class="c-header__link" data-header-expander>
 							<span>
-								<span class="c-header__show-text">Content</span>
+								<span class="c-header__show-text-sm">Content</span>
 								<span class="c-header__show-text">Explore content</span><svg role="img" aria-hidden="true" focusable="false" height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m5.58578644 3-3.29289322-3.29289322c-.39052429-.39052429-.39052429-1.02368927 0-1.41421356s1.02368927-.39052429 1.41421356 0l4 4c.39052429.39052429.39052429 1.02368927 0 1.41421356l-4 4c-.39052429.39052429-1.02368927.39052429-1.41421356 0s-.39052429-1.02368927 0-1.41421356z" transform="matrix(0 1 -1 0 11 3)"></path></svg>
 							</span>
 						</a>


### PR DESCRIPTION
…fari. Toggle between two text spans and no longer using :first-letter.

<img width="2532" height="1170" alt="image" src="https://github.com/user-attachments/assets/0434b560-cece-4c12-9cd1-758b21a61897" />
