### PR TITLE
Fix horizontal scroll on nature pages

### DIFF
--- a/toolkits/global/packages/global-footer/HISTORY.md
+++ b/toolkits/global/packages/global-footer/HISTORY.md
@@ -1,5 +1,10 @@
 # History
 
+## 2.0.3 (2025-10-15)
+    * prevent horizontal scroll
+        * allow manage cookie button to wrap
+        * overflow hidden on container 
+
 ## 2.0.2 (2025-09-30)
     * removes focus on component to inherit focus from page
 

--- a/toolkits/global/packages/global-footer/package.json
+++ b/toolkits/global/packages/global-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/global-footer",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "MIT",
   "description": "Global footer component",
   "keywords": [],

--- a/toolkits/global/packages/global-footer/scss/50-components/footer.scss
+++ b/toolkits/global/packages/global-footer/scss/50-components/footer.scss
@@ -5,6 +5,7 @@
 	padding-bottom: $footer--padding-bottom;
 	color: $footer--text-color;
 	line-height: $footer--line-height;
+	overflow: hidden;
 }
 
 .c-footer__container {
@@ -44,6 +45,8 @@ button.c-footer__link {
 	padding: 0;
 	background: none;
 	font-family: $footer--font-family;
+	text-align: left;
+	white-space: normal;
 }
 
 .c-footer__list {

--- a/toolkits/nature/packages/nature-header/HISTORY.md
+++ b/toolkits/nature/packages/nature-header/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 11.0.2 (2025-10-15)
+    * Adjust margin on element to avoid horizontal scroll
+
 ## 11.0.1 (2025-10-06)
     * Fix mangeled text for Navigation item "Explore content/Content" in Safari. Toggle between two text spans and no longer using :first-letter.
 

--- a/toolkits/nature/packages/nature-header/package.json
+++ b/toolkits/nature/packages/nature-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/nature-header",
-  "version": "11.0.1",
+  "version": "11.0.2",
   "license": "MIT",
   "description": "Publisher level header",
   "keywords": [],

--- a/toolkits/nature/packages/nature-header/scss/50-components/header.scss
+++ b/toolkits/nature/packages/nature-header/scss/50-components/header.scss
@@ -49,7 +49,7 @@
 	flex: 0 1 auto;
 	font-weight: $context--font-weight-bold;
 	line-height: 1.4;
-	margin: 0 (0 - spacing(8)); // Make flush with edge
+	margin: 0 (0 - spacing(4)); // Make flush with edge
 }
 
 .c-header__menu--hide-lg-max {


### PR DESCRIPTION
This fixes the horizontal scroll noticed on nature pages when viewport is less than 540px.

`nature-header` had negative margin that was breaking out of layout (deleted the footer to show header issue):
<img width="326" height="258" alt="image" src="https://github.com/user-attachments/assets/99b2e5b8-aead-4f9a-be83-3f88051a35f5" />

`global-footer` has button with text `Your privacy choices/Manage cookies` that was not wrapping:
<img width="329" height="324" alt="image" src="https://github.com/user-attachments/assets/f135705a-72eb-44b5-96d1-c98c44f96a28" />
